### PR TITLE
Allow the bot to start without a Github API token

### DIFF
--- a/lib/cog/services/github.ex
+++ b/lib/cog/services/github.ex
@@ -7,7 +7,7 @@ defmodule Cog.Services.GitHub do
       nil ->
         Logger.error("GitHub API token [config entry :cog/:github_service/:api_token] is missing or empty.")
         Logger.error("Aborting GitHub service startup.")
-        {:stop, {:shutdown, :missing_api_token}}
+        :ignore
       token ->
         Logger.info("Using API token #{inspect token}")
         client = Tentacat.Client.new(%{access_token: token})


### PR DESCRIPTION
If a Github API token is not found, we simply ignore the Github
service instead of killing the whole bot.

Partially addresses #17
