### PR TITLE
Use Probe to log events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ erl_crash.dump
 /creds
 Mnesia.*
 /bundles
+/audit_logs

--- a/mix.exs
+++ b/mix.exs
@@ -17,6 +17,7 @@ defmodule Cog.Mixfile do
 
   def application do
     [applications: [:logger,
+                    :probe,
                     :ibrowse,
                     :httpotion,
                     :gproc,
@@ -65,6 +66,7 @@ defmodule Cog.Mixfile do
      {:gproc, "~> 0.5.0", override: true},
      {:html_entities, "~> 0.2"},
      {:spanner, git: "git@github.com:operable/spanner", ref: "b633eadba692fd6d8c26d79d74c8649f9a3b0175"},
+     {:probe, git: "git@github.com:operable/probe", ref: "02c3df4beb0332c4cab47646cfbcdf1cace1da36"},
      {:exml, github: "paulgray/exml", tag: "2.2.1"},
      {:erlcloud, github: "gleber/erlcloud", branch: "master"},
      {:fumanchu, github: "operable/fumanchu", ref: "210bd6294d7fce3e9b651cc481496bf6d0cd4f1f"},

--- a/mix.lock
+++ b/mix.lock
@@ -44,6 +44,7 @@
   "poolboy": {:hex, :poolboy, "1.5.1"},
   "porcelain": {:hex, :porcelain, "2.0.0"},
   "postgrex": {:hex, :postgrex, "0.9.1"},
+  "probe": {:git, "git@github.com:operable/probe", "02c3df4beb0332c4cab47646cfbcdf1cace1da36", [ref: "02c3df4beb0332c4cab47646cfbcdf1cace1da36"]},
   "ranch": {:hex, :ranch, "1.1.0"},
   "slack": {:git, "https://github.com/BlakeWilliams/Elixir-Slack.git", "e348e12551e8f6361d9c666ed52c83eeccce86b8", [ref: "e348e12551e8f6361d9c666ed52c83eeccce86b8"]},
   "spanner": {:git, "git@github.com:operable/spanner", "b633eadba692fd6d8c26d79d74c8649f9a3b0175", [ref: "b633eadba692fd6d8c26d79d74c8649f9a3b0175"]},


### PR DESCRIPTION
Instead of routing executor lifecycle events through Logger to the
console, we now use Probe to write them to a file.
- Adds a dependency on Probe
- Adds the Probe event manager to the main supervision tree.
- Renames the event-generating functions in `executor.ex` to reflect
  their "event-ness" rather than emphasizing logging.
