### PR TITLE
Instrument REST API with lifecycle events

### DIFF
--- a/lib/cog/events/api_event.ex
+++ b/lib/cog/events/api_event.ex
@@ -1,0 +1,113 @@
+defmodule Cog.Events.ApiEvent do
+  @moduledoc """
+  Provides functions for generating REST API request processing
+  events.
+
+  The functions in this module generate API events from `Plug.Conn`
+  instances, and depend on various metadata having been added to the
+  `Conn` beforehand; see `Cog.Plug.Util` and `Cog.Plug.Event`
+  """
+
+  alias Plug.Conn
+
+  import Cog.Events.Util, only: [elapsed: 1,
+                                 now_iso8601_utc: 0]
+  import Cog.Plug.Util, only: [get_request_id: 1,
+                               get_start_time: 1,
+                               get_user: 1]
+
+  @type event_label :: :api_request_started |
+                       :api_request_authenticated |
+                       :api_request_finished
+  @typedoc """
+  Encapsulates information about REST API request processing events.
+
+  # Fields
+
+  * `request_id`: The unique identifier assigned to the request. All
+    events emitted in the processing of the request will share the
+    same ID.
+
+  * `event`: label indicating which API request lifecycle event is
+    being recorded.
+
+  * `timestamp`: When the event was created, in UTC, as an ISO-8601
+    extended-format string (e.g. `"2016-01-07T15:08:00Z"`). For
+    pipelines that execute in sub-second time, also see
+    `elapsed_microseconds`.
+
+  * `elapsed_microseconds`: Number of microseconds elapsed since
+    beginning of request processing to the creation of this event. Can
+    be used to order events from a single request.
+
+  * `http_method`: the HTTP method of the request being processed as
+    an uppercase string.
+
+  * `path`: the path portion of the request URL
+
+  * `data`: Map of arbitrary event-specific data. See below for
+    details.
+
+  # Event-specific Data
+
+  Depending on the type of event, the `data` map will contain
+  different keys. These are detailed here for each event.
+
+  ## `api_request_started`
+
+  No extra data
+
+  ## `api_request_authenticated`
+
+  * `user`: (String) the Cog username of the authenticated
+    requestor. Note that this is not a chat handle.
+
+  ## `api_request_finished`
+
+  * `status`: (Integer) the HTTP status code of the response.
+
+  """
+  @type t :: %__MODULE__{request_id: Cog.Events.Util.correlation_id(),
+                         event: event_label(),
+                         timestamp: String.t,
+                         elapsed_microseconds: non_neg_integer(),
+                         http_method: String.t,
+                         path: String.t,
+                         data: map()}
+  defstruct [request_id: nil,
+             event: nil,
+             timestamp: nil,
+             elapsed_microseconds: 0,
+             http_method: nil,
+             path: nil,
+             data: %{}]
+
+  @doc "Create an `api_request_started` event."
+  def started(%Conn{}=conn),
+    do: new(conn, :api_request_started)
+
+  @doc "Create an `api_request_started` event."
+  def authenticated(%Conn{}=conn) do
+    # Should never be called if there's no user set
+    new(conn, :api_request_authenticated, %{user: get_user(conn).username})
+  end
+
+  @doc "Create an `api_request_started` event."
+  def finished(%Conn{}=conn),
+    do: new(conn, :api_request_finished, %{status: conn.status})
+
+  # Centralize common event creation logic
+  defp new(conn, event, data \\ %{}) do
+    %__MODULE__{request_id: get_request_id(conn),
+                http_method: conn.method,
+                path: conn.request_path,
+                event: event,
+                timestamp: now_iso8601_utc,
+                elapsed_microseconds: case event do
+                                        :api_request_started -> 0
+                                        _ -> elapsed(get_start_time(conn))
+                                      end,
+                data: data}
+  end
+
+end

--- a/lib/cog/events/pipeline_event.ex
+++ b/lib/cog/events/pipeline_event.ex
@@ -3,8 +3,7 @@ defmodule Cog.Events.PipelineEvent do
   Provides functions for generating command pipeline execution events.
   """
 
-  # ISO-8601 UTC
-  @date_format "~.4.0w-~.2.0w-~.2.0wT~.2.0w:~.2.0w:~.2.0wZ"
+  import Cog.Events.Util
 
   @typedoc """
   One of the valid kinds of events that can be emitted by a pipeline
@@ -125,13 +124,6 @@ defmodule Cog.Events.PipelineEvent do
                 elapsed_microseconds: elapsed,
                 timestamp: now_iso8601_utc,
                 data: data}
-  end
-
-  # Current time, as an ISO-8601 formatted string
-  defp now_iso8601_utc do
-    {{year, month, day}, {hour, min, sec}} = :calendar.universal_time
-    :io_lib.format(@date_format, [year, month, day, hour, min, sec])
-    |> IO.iodata_to_binary
   end
 
 end

--- a/lib/cog/events/util.ex
+++ b/lib/cog/events/util.ex
@@ -1,0 +1,47 @@
+defmodule Cog.Events.Util do
+  @moduledoc """
+  Various utility functions used for generating event data.
+  """
+
+  # ISO-8601 UTC
+  @date_format "~.4.0w-~.2.0w-~.2.0wT~.2.0w:~.2.0w:~.2.0wZ"
+
+  @typedoc "Unique correlation ID"
+  @type correlation_id :: String.t
+
+  @doc """
+  Current time, as an ISO-8601 formatted string.
+
+  Example:
+
+      iex> Cog.Events.Util.now_iso8691_utc
+      "2016-01-15T01:48:20Z"
+
+  """
+  @spec now_iso8601_utc() :: binary()
+  def now_iso8601_utc do
+    {{year, month, day}, {hour, min, sec}} = :calendar.universal_time
+    :io_lib.format(@date_format, [year, month, day, hour, min, sec])
+    |> IO.iodata_to_binary
+  end
+
+  @doc "Current time as an Erlang timestamp."
+  @spec now() :: :erlang.timestamp()
+  def now,
+    do: :os.timestamp
+
+  @doc "Microseconds between `start_time` and now."
+  @spec elapsed(:erlang.timestamp()) :: integer()
+  def elapsed(start_time),
+    do: :timer.now_diff(now, start_time)
+
+  @doc """
+  Generate a unique identifier for use as a correlation ID for events
+  from the same source (e.g., from the same HTTP request, the same
+  chat command pipeline execution, etc.)
+  """
+  @spec unique_id() :: identifier()
+  def unique_id,
+    do: UUID.uuid4(:hex)
+
+end

--- a/web/plugs/authorization.ex
+++ b/web/plugs/authorization.ex
@@ -3,6 +3,8 @@ defmodule Cog.Plug.Authorization do
 
   import Plug.Conn
   import Phoenix.Controller, only: [json: 2]
+  import Cog.Plug.Util, only: [get_user: 1]
+
   alias Cog.Models.User
   alias Cog.Models.Permission
   alias Cog.Repo
@@ -22,7 +24,7 @@ defmodule Cog.Plug.Authorization do
 
   # Expects to be called after the `Cog.Plug.Authentication` plug
   def call(conn, permission_name) do
-    authenticated_user = conn.assigns[:user]
+    authenticated_user = get_user(conn)
     permission = name_to_permission(permission_name)
     case User.has_permission(authenticated_user, permission) do
       true ->

--- a/web/plugs/event.ex
+++ b/web/plugs/event.ex
@@ -1,0 +1,53 @@
+defmodule Cog.Plug.Event do
+  @moduledoc """
+  Core functionality of the REST API event instrumentation.
+
+  This plug should be placed at the beginning of a Phoenix processing
+  pipeline, as it sets some data in the request that is used
+  throughout API processing for sending events.
+
+  First, it stamps the request with a timestamp, from which all other
+  events emitted in the course of processing will report the amount of
+  time elapsed.
+
+  Second, it adds a unique request ID. This is distinct from the one
+  added by `Plug.RequestId`; we chose not to use that plug and instead
+  rolled our own in order to ensure that all correlation IDs used
+  across all our events (not just those from the API) had the same
+  structure.
+
+  The plug will emit an `api_request_started` event, and will ensure
+  that an `api_request_finished` event will be emitted at the end of
+  processing (via a callback function).
+
+  Other events may be emitted through the course of request
+  processing, but they require the data added by this plug.
+  """
+
+  @behaviour Plug
+
+  alias Plug.Conn
+  alias Cog.Events.ApiEvent
+
+  import Cog.Plug.Util, only: [stamp_start_time: 1,
+                               stamp_request_id: 1]
+
+  # Nothing to configure
+  def init(_opts),
+    do: :ok
+
+  def call(conn, :ok) do
+    # Set key data for the request that all events will use
+    conn = conn |> stamp_start_time |> stamp_request_id
+
+    # Emit started event
+    conn |> ApiEvent.started |> Probe.notify
+
+    # Ensure finished event will be emitted
+    Conn.register_before_send(conn, fn(conn) ->
+      conn |> ApiEvent.finished |> Probe.notify
+      conn
+    end)
+  end
+
+end

--- a/web/plugs/util.ex
+++ b/web/plugs/util.ex
@@ -1,0 +1,54 @@
+defmodule Cog.Plug.Util do
+  @moduledoc """
+  Utility functions for storing and retrieving various custom pieces
+  of data in a `Plug.Conn` struct.
+  """
+
+  import Plug.Conn, only: [assign: 3]
+
+  alias Plug.Conn
+  alias Cog.Models.User
+
+  @doc """
+  Store the current authenticated user in the `conn`.
+  """
+  @spec set_user(%Conn{}, %User{}) :: %Conn{}
+  def set_user(%Conn{}=conn, %User{}=user),
+    do: assign(conn, :user, user)
+
+  @doc """
+  Retrieve the authenticated user for the request (if any).
+  """
+  @spec get_user(%Conn{}) :: %User{} | nil
+  def get_user(%Conn{}=conn),
+    do: conn.assigns[:user]
+
+  @doc """
+  Records the current time in the `conn`
+  """
+  @spec stamp_start_time(%Conn{}) :: %Conn{}
+  def stamp_start_time(%Conn{}=conn),
+    do: assign(conn, :start_time, Cog.Events.Util.now)
+
+  @doc """
+  Retrieve the timestamp when processing of the request began.
+  """
+  @spec get_start_time(%Conn{}) :: :erlang.timestamp() | nil
+  def get_start_time(%Conn{}=conn),
+    do: conn.assigns[:start_time]
+
+  @doc """
+  Records a new unique identifier in the `conn`.
+  """
+  @spec stamp_request_id(%Conn{}) :: %Conn{}
+  def stamp_request_id(%Conn{}=conn),
+    do: assign(conn, :request_id, Cog.Events.Util.unique_id)
+
+  @doc """
+  Retrieve the stored request identifier from the `conn`
+  """
+  @spec get_request_id(%Conn{}) :: binary() | nil
+  def get_request_id(%Conn{}=conn),
+    do: conn.assigns[:request_id]
+
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -10,6 +10,7 @@ defmodule Cog.Router do
   end
 
   pipeline :api do
+    plug Cog.Plug.Event
     plug :accepts, ["json"]
   end
 


### PR DESCRIPTION
Emits `api_request_started`, `api_request_authenticated`, and
`api_request_finished` events for all REST API requests.

This is done by adding a new `Cog.Plug.Event` plug to the head of our
request processing pipeline. It sets some metadata in the `Plug.Conn`
struct for use in generating events. It is also responsible for emitting
the `api_request_started` and `api_request_finished` events.

The `Cog.Plug.Authentication` plug has also been instrumented to emit
the `api_request_authenticated` event (when authentication is
successful).

In the course of this work, several utility functions were extracted to
`Cog.Plug.Util` and `Cog.Events.Util` and imported into the modules that
need them.
