### PR TITLE
Move user resolution to head of executor flow

### DIFF
--- a/lib/cog/command/permission_interpreter.ex
+++ b/lib/cog/command/permission_interpreter.ex
@@ -7,16 +7,7 @@ defmodule Cog.Command.PermissionInterpreter do
   alias Cog.Command
   alias Cog.Permissions
 
-  def check(handle, adapter, %Ast.Invocation{}=invocation) do
-    case Command.UserPermissionsCache.fetch(username: handle, adapter: adapter) do
-      :not_found ->
-        :ignore
-      {:ok, {user, perms}} ->
-        check_permissions(invocation, user, perms)
-    end
-  end
-
-  defp check_permissions(invoke, user, perms) do
+  def check(%Ast.Invocation{}=invoke, user, perms) do
     context = Permissions.Context.new(user: user, permissions: perms, command: invoke.command,
                                       options: invoke.options, args: invoke.args)
     {:ok, rules} = Command.RuleCache.fetch(invoke.command)

--- a/lib/cog/events/pipeline_event.ex
+++ b/lib/cog/events/pipeline_event.ex
@@ -49,6 +49,8 @@ defmodule Cog.Events.PipelineEvent do
   * `adapter`: (String) the chat adapter being used
   * `handle`: (String) the adapter-specific chat handle of the user issuing the
     command.
+  * `cog_user`: The Cog-specific username of the invoker of issuer of
+    the command. May be different than the adapter-specific handle.
 
   ## `command_dispatched`
 
@@ -89,8 +91,9 @@ defmodule Cog.Events.PipelineEvent do
   @doc """
   Create a `pipeline_initialized` event
   """
-  def initialized(pipeline_id, text, adapter, handle) do
+  def initialized(pipeline_id, text, adapter, cog_user, handle) do
     new(pipeline_id, :pipeline_initialized, 0, %{command_text: text,
+                                                 cog_user: cog_user,
                                                  adapter: adapter,
                                                  chat_handle: handle})
   end


### PR DESCRIPTION
When emitting event logs for execution pipelines, it's better to include
the Cog user name as well as their adapter-specific chat handle (which
may be different!) in order to facilitate making system-wide
correlations. In order to do that, however, we need to move user
resolution to the very beginning of pipeline processing.

This ends up being nice, because if we determine that the invoking user
doesn't even have a Cog account, we can immediately abort all
processing; before, we did a fair amount of work before checking this.

Note: this change actually alters the behavior of the bot. Before, we
only resolved a Cog user if we needed to check permissions for the
command being run; if the command bypassed permission checks, we would
allow anybody to execute a command, even if they didn't have a Cog
account. This commit (by moving user resolution to the first processing
step, before a command has been parsed to see if it needs permission
checking) changes that, effectively requiring any user of the bot to
have a Cog account first.

The `PermissionInterpreter` no longer does the `UserPermissionsCache`
lookup, as this is now done by the executor directly. Additionally,
function heads, variable names, and pattern matches in
`UserPermissionsCache` were reworked to reflect the current state of the
cache (many reflected the time before it cached both users and
permissions).

Finishes work for #7
