### PR TITLE
Options in list for Once execution

### DIFF
--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -508,7 +508,7 @@ defmodule Cog.Command.Pipeline.Executor do
           Map.put_new(acc, k, List.wrap(v))
         end)
         args = List.flatten(current.args)
-        %{current | options: options, args: args}
+        %{current | args: args}
       "multiple" ->
         current
     end


### PR DESCRIPTION
The options should not be in a list, but should stay the same format regardless of execution type.

Partially addresses #23 
