### PR TITLE
Bundle enabled/disabled: Toward saner delete!

### DIFF
--- a/lib/cog/models/bundle.ex
+++ b/lib/cog/models/bundle.ex
@@ -6,6 +6,7 @@ defmodule Cog.Models.Bundle do
     field :name, :string
     field :config_file, :map
     field :manifest_file, :map
+    field :enabled, :boolean, default: true
 
     has_many :commands, Command
     has_many :templates, Template
@@ -15,16 +16,23 @@ defmodule Cog.Models.Bundle do
   end
 
   @required_fields ~w(name config_file manifest_file)
+  @optional_fields ~w(enabled)
 
-  summary_fields [:id, :name, :namespace, :inserted_at]
-  detail_fields [:id, :name, :namespace, :commands, :inserted_at]
+  summary_fields [:id, :name, :namespace, :inserted_at, :enabled]
+  detail_fields [:id, :name, :namespace, :commands, :inserted_at, :enabled]
 
   def changeset(model, params \\ :empty) do
     model
-    |> cast(params, @required_fields)
+    |> cast(params, @required_fields, @optional_fields)
     |> validate_format(:name, ~r/\A[A-Za-z0-9\_\-\.]+\z/)
     |> unique_constraint(:name)
   end
+
+  def enable(%__MODULE__{}=bundle),
+    do: changeset(bundle, %{enabled: true})
+
+  def disable(%__MODULE__{}=bundle),
+    do: changeset(bundle, %{enabled: false})
 
   def embedded?(%__MODULE__{name: name}),
     do: name == Cog.embedded_bundle

--- a/lib/cog/relay/tracker.ex
+++ b/lib/cog/relay/tracker.ex
@@ -1,0 +1,158 @@
+defmodule Cog.Relay.Tracker do
+  require Logger
+
+  alias Cog.Models.Bundle
+
+  @moduledoc """
+  Represents the internal state of `Cog.Relay.Relays` and functions to
+  operate on it.
+
+  Tracks all the relays that have checked in with the bot, recording
+  which bundles they each serve. Additionally, we track a bundle's
+  current activation status (enabled or disabled) in order to help
+  determine which relays we can dispatch to.
+  """
+
+  @type bundle_status :: :enabled | :disabled
+  @type t :: %__MODULE__{map: %{String.t => %{relays: MapSet.t,
+                                              status: bundle_status()}}}
+  defstruct [map: %{}]
+
+  @doc """
+  Create a new, empty Tracker
+  """
+  @spec new() :: t
+  def new(),
+    do: %__MODULE__{}
+
+  @doc """
+  Removes all record of `relay` from the tracker. If `relay` is the
+  last one serving a given bundle, that bundle is removed from the
+  tracker as well.
+  """
+  @spec remove_relay(t, String.t) :: t
+  def remove_relay(tracker, relay) do
+    map = tracker.map
+    tracker_bundles = Map.keys(map)
+
+    map = Enum.reduce(tracker_bundles, map, fn(bundle, acc) ->
+      acc = Map.update!(acc, bundle, &delete_relay(&1, relay))
+      relays_remaining = get_in(acc, [bundle, :relays])
+      if Enum.empty?(relays_remaining) do
+        Map.delete(acc, bundle)
+      else
+        acc
+      end
+    end)
+
+    %{tracker | map: map}
+  end
+
+  @doc """
+  Records `relay` as serving each of `bundles`. If `relay` has
+  previously been recorded as serving other bundles, those bundles are
+  retained; this is an incremental, cumulative operation.
+
+  If `relay` is the first to serve a bundle, the current status of the
+  bundle is recorded in the tracker.
+  """
+  @spec add_bundles_for_relay(t, String.t, [%Bundle{}]) :: t
+  def add_bundles_for_relay(tracker, relay, bundles) do
+    map = Enum.reduce(bundles, tracker.map, fn(bundle, acc) ->
+      initial_status = if bundle.enabled, do: :enabled, else: :disabled
+      Map.update(acc, bundle.name, entry(relay, initial_status), &append_relay(&1, relay))
+    end)
+    %{tracker | map: map}
+  end
+
+  @doc """
+  Like `add_bundles_for_relay/3` but overwrites any existing bundle
+  information for `relay`. From this point, `relay` is known to only
+  serve `bundles`, and no others.
+  """
+  @spec set_bundles_for_relay(t, String.t, [%Bundle{}]) :: t
+  def set_bundles_for_relay(tracker, relay, bundles) do
+    tracker
+    |> remove_relay(relay)
+    |> add_bundles_for_relay(relay, bundles)
+  end
+
+  @doc """
+  Removes the given bundle from the tracker.
+  """
+  @spec drop_bundle(t, String.t) :: t
+  def drop_bundle(tracker, bundle_name) do
+    map = Map.delete(tracker.map, bundle_name)
+    %{tracker | map: map}
+  end
+
+  @doc """
+  Returns the current information for `bundle_name` in the tracker, or
+  an error if the tracker does not know about `bundle_name`.
+
+  Example:
+
+      %{status: :enabled,
+        relays: ["44a92066-b1ae-4456-8e6a-4f212ded3180",
+                 "85da0992-cfcf-49b5-bc5b-d9bd53fb23cd"]}
+  """
+  @spec bundle_status(t, String.t) :: {:ok, map()} | {:error, :no_relays_serving_bundle}
+  def bundle_status(%__MODULE__{map: map}, bundle_name) do
+    case Map.get(map, bundle_name) do
+      nil ->
+        {:error, :no_relays_serving_bundle}
+      entry ->
+        {:ok, Map.update!(entry, :relays, &MapSet.to_list(&1))}
+    end
+  end
+
+  @doc """
+  Return a list of relays serving `bundle_name`. If the bundle is
+  disabled, return an empty list.
+  """
+  @spec active_relays(t, String.t) :: [String.t]
+  def active_relays(tracker, bundle_name) do
+    case tracker do
+      %__MODULE__{map: %{^bundle_name => %{status: :enabled, relays: relays}}} ->
+        MapSet.to_list(relays)
+      _ ->
+        []
+    end
+  end
+
+  @doc """
+  Mark `bundle_name` as being enabled.
+  """
+  @spec enable_bundle(t, String.t) :: t
+  def enable_bundle(tracker, bundle_name),
+    do: set_status(tracker, bundle_name, :enabled)
+
+  @doc """
+  Mark `bundle_name` as being disabled.
+  """
+  @spec disable_bundle(t, String.t) :: t
+  def disable_bundle(tracker, bundle),
+    do: set_status(tracker, bundle, :disabled)
+
+  ########################################################################
+
+  defp entry(relay, initial_status),
+    do: %{status: initial_status, relays: MapSet.new([relay])}
+
+  defp append_relay(entry, relay),
+    do: Map.update!(entry, :relays, &MapSet.put(&1, relay))
+
+  defp delete_relay(entry, relay),
+    do: Map.update!(entry, :relays, &MapSet.delete(&1, relay))
+
+  defp set_status(tracker, bundle, status) do
+    map = case Map.get(tracker.map, bundle) do
+            nil ->
+              tracker.map
+            _ ->
+              put_in(tracker.map, [bundle, :status], status)
+          end
+    %{tracker | map: map}
+  end
+
+end

--- a/priv/repo/migrations/20160122152844_bundle_status.exs
+++ b/priv/repo/migrations/20160122152844_bundle_status.exs
@@ -1,0 +1,9 @@
+defmodule Cog.Repo.Migrations.BundleStatus do
+  use Ecto.Migration
+
+  def change do
+    alter table(:bundles) do
+      add :enabled, :boolean, default: true
+    end
+  end
+end

--- a/test/cog/relay/tracker_test.exs
+++ b/test/cog/relay/tracker_test.exs
@@ -1,0 +1,156 @@
+defmodule Cog.Relay.Tracker.Test do
+  use ExUnit.Case
+  require Logger
+  alias Cog.Relay.Tracker
+  alias Cog.Models.Bundle
+
+  @relay_one "relay_one"
+  @relay_two "relay_two"
+  @relay_three "relay_three"
+
+  test "adding a single bundle works" do
+    bundle = enabled_bundle("one")
+    tracker = Tracker.add_bundles_for_relay(Tracker.new, @relay_one, [bundle])
+    assert_enabled(bundle, [@relay_one], tracker)
+  end
+
+  test "adding a new disabled bundle works" do
+    bundle = disabled_bundle("one")
+    tracker = Tracker.add_bundles_for_relay(Tracker.new, @relay_one, [bundle])
+    assert_disabled(bundle, [@relay_one], tracker)
+  end
+
+  test "adding multiple bundles works" do
+    bundles = ["bundle_one", "bundle_two", "bundle_three"] |> Enum.map(&enabled_bundle/1)
+    tracker = Tracker.add_bundles_for_relay(Tracker.new, @relay_one, bundles)
+    for bundle <- bundles do
+      assert_enabled(bundle, [@relay_one], tracker)
+    end
+  end
+
+  test "multiple relays can provide a bundle" do
+    bundle = enabled_bundle("bundle_one")
+
+    relays = [@relay_one, @relay_two, @relay_three]
+
+    tracker = Tracker.new
+    |> Tracker.add_bundles_for_relay(@relay_one, [bundle])
+    |> Tracker.add_bundles_for_relay(@relay_two, [bundle])
+    |> Tracker.add_bundles_for_relay(@relay_three, [bundle])
+
+    assert_enabled(bundle, relays, tracker)
+  end
+
+  test "adding bundles is an appending operation" do
+    batch_1 = Enum.map(["a", "b", "c"], &enabled_bundle/1)
+    batch_2 = Enum.map(["d", "e"], &enabled_bundle/1)
+
+    tracker = Tracker.new
+    |> Tracker.add_bundles_for_relay(@relay_one, batch_1)
+    |> Tracker.add_bundles_for_relay(@relay_one, batch_2)
+
+    for bundle <- Enum.concat(batch_1, batch_2) do
+      assert_enabled(bundle, [@relay_one], tracker)
+    end
+  end
+
+  test "setting bundles is an overwriting operation" do
+    batch_1 = Enum.map(["a", "b", "c"], &enabled_bundle/1)
+    batch_2 = Enum.map(["d", "e"], &enabled_bundle/1)
+
+    tracker = Tracker.new
+    |> Tracker.add_bundles_for_relay(@relay_one, batch_1)
+    |> Tracker.set_bundles_for_relay(@relay_one, batch_2)
+
+    for bundle <- batch_2 do
+      assert_enabled(bundle, [@relay_one], tracker)
+    end
+
+    for bundle <- batch_1 do
+      assert_missing(bundle, tracker)
+    end
+  end
+
+  test "dropping relays for bundle works" do
+    # Arrange
+    bundle = enabled_bundle("a")
+
+    tracker = Tracker.new
+    |> Tracker.add_bundles_for_relay(@relay_one, [bundle])
+    |> Tracker.set_bundles_for_relay(@relay_two, [bundle])
+
+    # Act
+    tracker = Tracker.drop_bundle(tracker, bundle)
+
+    # Assert
+    assert_missing(bundle, tracker)
+  end
+
+  test "dropping relays for a non-existent returns tracker unchanged" do
+    tracker_before = Tracker.new
+    tracker_after = Tracker.drop_bundle(tracker_before, "non_existent_bundle")
+    assert tracker_before == tracker_after
+  end
+
+  test "deactivating an existing bundle" do
+    bundle = enabled_bundle("a")
+
+    tracker = Tracker.new
+    |> Tracker.add_bundles_for_relay(@relay_one, [bundle])
+
+    tracker = Tracker.disable_bundle(tracker, bundle.name)
+    assert_disabled(bundle, [@relay_one], tracker)
+  end
+
+  test "deactivating a non-existent bundle leaves tracker unchanged" do
+    tracker = Tracker.new
+    tracker_after = Tracker.disable_bundle(tracker, "non_existent_bundle")
+    assert tracker == tracker_after
+  end
+
+  test "activating an existing bundle" do
+    bundle = enabled_bundle("a")
+
+    tracker = Tracker.new
+    |> Tracker.add_bundles_for_relay(@relay_one, [bundle])
+    |> Tracker.disable_bundle(bundle.name)
+
+    assert_disabled(bundle, [@relay_one], tracker)
+
+    tracker = Tracker.enable_bundle(tracker, bundle.name)
+
+    Logger.warn(">>>>>>> tracker = #{inspect tracker}")
+
+    assert_enabled(bundle, [@relay_one], tracker)
+  end
+
+  test "activating a non-existent bundle leaves tracker unchanged" do
+    tracker = Tracker.new
+    tracker_after = Tracker.enable_bundle(tracker, "non_existent_bundle")
+    assert tracker == tracker_after
+  end
+
+  ########################################################################
+
+  defp enabled_bundle(name),
+    do: %Bundle{name: name, enabled: true}
+
+  defp disabled_bundle(name),
+    do: %Bundle{name: name, enabled: false}
+
+  defp assert_enabled(bundle, expected_relays, tracker),
+    do: assert_bundle_status(tracker, bundle, :enabled, expected_relays)
+
+  defp assert_disabled(bundle, expected_relays, tracker),
+    do: assert_bundle_status(tracker, bundle, :disabled, expected_relays)
+
+  defp assert_missing(bundle, tracker),
+    do: assert {:error, :no_relays_serving_bundle} = Tracker.bundle_status(tracker, bundle)
+
+  defp assert_bundle_status(tracker, bundle, expected_status, expected_relays) do
+    {:ok, %{relays: actual_relays, status: status}} = Tracker.bundle_status(tracker, bundle.name)
+    assert status == expected_status
+    assert Enum.sort(expected_relays) == Enum.sort(actual_relays)
+  end
+
+end

--- a/web/controllers/v1/bundle_status_controller.ex
+++ b/web/controllers/v1/bundle_status_controller.ex
@@ -1,0 +1,106 @@
+defmodule Cog.V1.BundleStatusController do
+  @moduledoc """
+  Allows for reading and modifying the "status" of a bundle.
+
+  Bundles may either be "enabled" or "disabled". If "enabled", commands
+  within the bundle may be dispatched to any relays serving them. If
+  "disabled", relays may continue to run the bundles, but no commands
+  will be dispatched.
+
+  The active state of a bundle is independent of whether there are any
+  relays currently serving the bundle. If you, say, deactivate a
+  bundle that the bot knows about, but no relays are running it, relays
+  that may come online in the future serving the bundle will still not
+  have commands dispatched to them.
+
+  This provides a means of centrally, persistently, and quickly
+  disabling the use of a given bundle in a Cog system.
+
+  An example status object might look like this:
+
+      %{bundle: "github",
+        status: "enabled",
+        relays: ["44a92066-b1ae-4456-8e6a-4f212bed3180"]}
+
+  `relays` is an array of IDs of relays currently serving the given
+  bundle.
+  """
+
+  use Cog.Web, :controller
+
+  require Logger
+  alias Cog.Repo
+  alias Cog.Models.Bundle
+  alias Cog.Queries.Bundles
+
+  plug Cog.Plug.Authentication
+  plug Cog.Plug.Authorization, permission: "#{Cog.embedded_bundle}:manage_commands"
+
+  def show(conn, %{"id" => id}) do
+    case Repo.one(Bundles.bundle_details(id)) do
+      nil ->
+        send_resp(conn, 404, Poison.encode!(%{error: "Bundle #{id} not found"}))
+      bundle ->
+        json(conn, status(bundle))
+    end
+  end
+  def manage_status(conn, %{"id" => id, "status" => desired_status}) when desired_status in ["enabled", "disabled"] do
+    case Repo.one(Bundles.bundle_details(id)) do
+      nil ->
+        send_resp(conn, 404, Poison.encode!(%{error: "Bundle #{id} not found"}))
+      bundle ->
+        if Bundle.embedded?(bundle) do
+          send_resp(conn, 400, Poison.encode!(%{error: "Cannot modify the status of the embedded bundle!"}))
+        else
+          return = bundle
+          |> make_status(desired_status)
+          |> status
+          json(conn, return)
+        end
+    end
+  end
+  def manage_status(conn, %{"status" => bad_status}),
+    do: send_resp(conn, 400, Poison.encode!(%{error: "Unrecognized status: #{inspect bad_status}"}))
+  def manage_status(conn, _params),
+    do: send_resp(conn, 400, Poison.encode!(%{error: "Bad request"}))
+
+  # Generate the response body from a bundle.
+  #
+  # Gives the name of the bundle, it's current activation status, and
+  # a list of relays currently running the bundle (if any).
+  #
+  # Note that it is possible to get (and change!) the activation
+  # status of a bundle known to the bot, even if no relays are
+  # currently running it.
+  #
+  # Example:
+  #
+  #     %{bundle: "github",
+  #       status: "enabled",
+  #       relays: ["44a92066-b1ae-4456-8e6a-4f212bed3180"]}
+  #
+  defp status(bundle) do
+    case Cog.Relay.Relays.bundle_status(bundle.name) do
+      {:ok, map} ->
+        %{bundle: bundle.name,
+          relays: map.relays,
+          status: map.status}
+      {:error, :no_relays_serving_bundle} ->
+        %{bundle: bundle.name,
+          relays: [],
+          status: (if bundle.enabled, do: "enabled", else: "disabled")}
+    end
+  end
+
+  # Set the status of `bundle`, both in the database, and for any
+  # currently-running relays.
+  defp make_status(bundle, "enabled") do
+    :ok = Cog.Relay.Relays.enable(bundle.name)
+    bundle |> Bundle.enable |> Repo.update!
+  end
+  defp make_status(bundle, "disabled") do
+    :ok = Cog.Relay.Relays.disable(bundle.name)
+    bundle |> Bundle.disable |> Repo.update!
+  end
+
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -41,6 +41,10 @@ defmodule Cog.Router do
 
     resources "/v1/bootstrap", V1.BootstrapController, only: [:index, :create]
     resources "/v1/bundles", V1.BundlesController, only: [:index, :show, :delete]
+
+    get "/v1/bundles/:id/status", V1.BundleStatusController, :show
+    post "/v1/bundles/:id/status", V1.BundleStatusController, :manage_status
+
   end
 
   scope "/", Cog do


### PR DESCRIPTION
Bundles now have an `enabled` field. In a nutshell, this determines
whether or not the bot will respond to commands from that bundle. This
can be used to quickly shut off command functionality, but (more broadly
speaking) is the first step toward a reliable bot-mediated command
uninstaller procedure; you'll shut off a bundle before you delete it.
# REST API

Users may toggle a bundle between enabled and disabled with a REST API;
an example user flow might look like this:

```
GET /v1/bundles/ID/status
{"status":"enabled","relays":["44a92066-b1ae-4456-8e6a-4f212ded3180"],"bundle":"github"}

POST /v1/bundles/ID/status {"status": "disabled"}
{"status":"disabled","relays":["44a92066-b1ae-4456-8e6a-4f212ded3180"],"bundle":"github"}

GET /v1/bundles/ID/status
{"status":"disabled","relays":["44a92066-b1ae-4456-8e6a-4f212ded3180"],"bundle":"github"}

POST /v1/bundles/ID/status {"status": "enabled"}
{"status":"enabled","relays":["44a92066-b1ae-4456-8e6a-4f212ded3180"],"bundle":"github"}

GET /v1/bundles/ID/status
{"status":"enabled","relays":["44a92066-b1ae-4456-8e6a-4f212ded3180"],"bundle":"github"}
```

`POST` the desired state of the bundle to the endpoint and the API
handles the rest.

Changing the state of a bundle currently involves two operations: 1)
updating the database record for the bundle, and 2) notifying the
`Cog.Relay.Relays` server to update its bundle state appropriately. The
server uses this information to determine whether or not to return
relays for command dispatch.

Bundles may be enabled or disabled independently of whether any relays
happen to be serving them.
# Refactorings

As part of the refactoring that took place here, a `Cog.Relay.Tracker`
module was extracted. This essentially abstracts the internal state of
the `Cog.Relay.Relays` server and encapsulates it with functions that
manipulate it.

Though it will only be used inside the `Relays` GenServer, splitting it
out has a few benefits:
- The internals of the GenServer are not cluttered with lots of data
  manipulation functions. You can focus solely on the "server-ness" of
  it now.
- It is easier to focus on the data manipulation. This makes it easier`
  to understand the data and the ins-and-outs of how it is
  processed. This should make any bugs easier to find.
# Future Directions

I went through several iterations on the way to the code in this
commit. At the end, I realized that a better way would be to have
`Cog.Relay.Relays` remain ignorant of bundle status, and instead make
the executor aware of it. The executor already needs to perform bundle
lookups as part of command disambiguation, so we could take advantage of
that and determine directly whether or not we should dispatch to a
relay.

However, this will require some surgery on the executor and command
disambiguation code, the former of which is already slated for some
refactorings soon. Given the nearness to launch, this change can wait
for later.
