### PR TITLE
Don't crash the executor if a chat user doesn't have an account

### DIFF
--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -138,7 +138,7 @@ defmodule Cog.Command.Pipeline.Executor do
                                 started: :os.timestamp()}
         initialization_event(loop_data)
         {:ok, :parse, loop_data, 0}
-      :ignore ->
+      {:error, :not_found} ->
         Logger.warn("Ignoring message from unknown user #{adapter}/#{handle}")
         :ignore
     end

--- a/lib/cog/command/user_permissions_cache.ex
+++ b/lib/cog/command/user_permissions_cache.ex
@@ -46,8 +46,8 @@ defmodule Cog.Command.UserPermissionsCache do
                 fetch_and_cache(key, state)
               [{_, _, expiry}] when expiry < expires_before ->
                 fetch_and_cache(key, state)
-              [{^key, perms, _}] ->
-                {:ok, perms}
+              [{^key, {user, perms}, _}] ->
+                {:ok, {user, perms}}
             end
     {:reply, reply, state}
   end
@@ -85,7 +85,7 @@ defmodule Cog.Command.UserPermissionsCache do
     Logger.info("Cache miss for #{inspect key}")
     case Repo.one(Queries.User.for_handle(username, adapter)) do
       nil ->
-        :not_found
+        {:error, :not_found}
       user ->
         perms = Cog.Models.User.all_permissions(user)
         value = {user, Map.keys(perms)}


### PR DESCRIPTION
We were matching the wrong return value!
