### PR TITLE
Use the proper supervisor when terminating embedded bundle

### DIFF
--- a/lib/cog/support/model_utilities.ex
+++ b/lib/cog/support/model_utilities.ex
@@ -192,7 +192,7 @@ defmodule Cog.Support.ModelUtilities do
     [Bundle, User, Group, Role, Namespace]
     |> Enum.each(&Repo.delete_all/1)
 
-    Supervisor.terminate_child(Cog.Supervisor, Cog.Bundle.Embedded)
+    Supervisor.terminate_child(Cog.Relay.RelaySup, Cog.Bundle.Embedded)
   end
 
 end


### PR DESCRIPTION
Just keepin' up with all the ch-ch-ch-changes.
