### PR TITLE
echo everything passed as arguments

### DIFF
--- a/lib/cog/commands/echo.ex
+++ b/lib/cog/commands/echo.ex
@@ -11,10 +11,7 @@ defmodule Cog.Commands.Echo do
 
   """
 
-  def handle_message(req, state) do
-    {:reply, req.reply_to, echo_string(req.args), state}
-  end
+  def handle_message(req, state),
+    do: {:reply, req.reply_to, Enum.join(req.args, " "), state}
 
-  defp echo_string([]), do: ""
-  defp echo_string(args) when is_list(args), do: hd(args)
 end


### PR DESCRIPTION
Previously, passing multiple arguments to `echo` would only return the
first one. Now, we simply join all arguments with a space.

This matches the behavior of the `echo` CLI executable, FWIW.
