### PR TITLE
Add a `seed` command

### DIFF
--- a/lib/cog/commands/seed.ex
+++ b/lib/cog/commands/seed.ex
@@ -1,0 +1,50 @@
+defmodule Cog.Command.Seed do
+  use Spanner.GenCommand.Base, bundle: Cog.embedded_bundle,
+                               enforcing: false
+
+  alias Spanner.Command.Request
+  require Logger
+
+  @moduledoc """
+  Seed a pipeline with arbitrary data.
+
+  Accepts a single string argument, which must be valid JSON for
+  either a map or a list of maps.
+
+  Though some values may be able to be typed without enclosing quotes,
+  it is highly recommended to single-quote your entire string.
+
+  Best used for debugging and experimentation.
+
+  Examples:
+
+      !seed '{"thing":"stuff"}' | echo $thing
+      > stuff
+
+      !seed '[{"thing":"stuff"},{"thing":"more stuff"}]' | echo $thing
+      > stuff
+      > more stuff
+
+  """
+  def handle_message(%Request{args: [input]}=req, state) when not(is_binary(input)),
+    do: {:reply, req.reply_to, "Argument must be a string", state}
+  def handle_message(%Request{args: [input]}=req, state) do
+    case Poison.decode(input) do
+      {:ok, value} when is_map(value) ->
+        {:reply, req.reply_to, value, state}
+      {:ok, value} when is_list(value) ->
+        if Enum.all?(value, &is_map/1) do
+          {:reply, req.reply_to, value, state}
+        else
+          {:reply, req.reply_to, "All values in a JSON list must be maps", state}
+        end
+      {:ok, _} ->
+        {:reply, req.reply_to, "JSON must be a map or a list of maps", state}
+      {:error, _} ->
+        {:reply, req.reply_to, "Bad input! Please supply valid JSON", state}
+    end
+  end
+  def handle_message(req, state),
+    do: {:reply, req.reply_to, "Please supply a single argument", state}
+
+end


### PR DESCRIPTION
Handy command for seeding a pipeline with arbitrary data. Useful for
investigating variable binding and pipeline execution semantics.
