### PR TITLE
Improve Makefile for initial setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ endif
 # you're actively using. If this is your first time, run `make
 # reset-db` before executing this recipe.
 run: check-for-dirty-schedulers
-	iex --sname cog_dev@localhost -S mix phoenix.server
+	iex -S mix phoenix.server
 
 reset-db:
 	mix ecto.reset


### PR DESCRIPTION
This PR does two things to improve first time install:
1. `make` and `make setup` error out if erlang wasn't compiled with dirty schedulers
2. `make setup` combines a few mix commands that need to be run before things work
