### PR TITLE
Add ability to create permissions via chat

### DIFF
--- a/lib/cog/bundle/embedded.ex
+++ b/lib/cog/bundle/embedded.ex
@@ -57,16 +57,8 @@ defmodule Cog.Bundle.Embedded do
     :ok = GenServer.call(Cog.Relay.Relays, {:announce_embedded_relay, message})
   end
 
-  # These permissions aren't yet being used by any embedded commands,
-  # so we need to add them manually.
-  @remaining_embedded_bundle_permissions ["#{Cog.embedded_bundle}:manage_permissions"]
-
-  defp embedded_bundle do
-    Cog.embedded_bundle
-    |> Config.gen_config(cog_modules, @embedded_bundle_root)
-    |> update_in(["permissions"],
-                 &(&1 ++ @remaining_embedded_bundle_permissions))
-  end
+  defp embedded_bundle,
+    do: Config.gen_config(Cog.embedded_bundle, cog_modules, @embedded_bundle_root)
 
   defp cog_modules,
     do: Keyword.fetch!(cog_app, :modules)

--- a/lib/cog/commands/permissions.ex
+++ b/lib/cog/commands/permissions.ex
@@ -1,21 +1,27 @@
 defmodule Cog.Commands.Permissions do
   @moduledoc """
-  Grant and revoke permissions on users, roles, and groups.
+  Manipulate authorization permissions.
+
+  * Create permissions in the `site` namespace
+  * Grant and revoke permissions on users, roles, and groups.
 
   Format:
 
+      --create --permission=site:<name>
       --grant --permission=<namespace>:<permission> --[user|group|role]=<name>"
       --revoke --permission=<namespace>:<permission> --[user|group|role]=<name>"
 
   Examples:
 
-  > @bot operable:permissions --grant --user=bob --permission=operable:manage_users
-  > @bot operable:permissions --grant --role=dev --permission=site:write
-  > @bot operable:permissions --revoke --group=engineering --permission=operable:giphy
+  > !#{Cog.embedded_bundle}:permissions --create --permission=site:admin
+  > !#{Cog.embedded_bundle}:permissions --grant --user=bob --permission=#{Cog.embedded_bundle}:manage_users
+  > !#{Cog.embedded_bundle}:permissions --grant --role=dev --permission=site:write
+  > !#{Cog.embedded_bundle}:permissions --revoke --group=engineering --permission=giphy:giphy
 
   """
   use Spanner.GenCommand.Base, bundle: Cog.embedded_bundle
 
+  option "create", type: "bool"
   option "grant", type: "bool"
   option "revoke", type: "bool"
   option "user", type: "string"
@@ -23,10 +29,12 @@ defmodule Cog.Commands.Permissions do
   option "role", type: "string"
   option "permission", type: "string"
 
+  permission "manage_permissions"
   permission "manage_users"
   permission "manage_roles"
   permission "manage_groups"
 
+  rule "when command is #{Cog.embedded_bundle}:permissions with option[create] == true must have #{Cog.embedded_bundle}:manage_permissions"
   rule "when command is #{Cog.embedded_bundle}:permissions with option[user] == /.*/ must have #{Cog.embedded_bundle}:manage_users"
   rule "when command is #{Cog.embedded_bundle}:permissions with option[role] == /.*/ must have #{Cog.embedded_bundle}:manage_roles"
   rule "when command is #{Cog.embedded_bundle}:permissions with option[group] == /.*/ must have #{Cog.embedded_bundle}:manage_groups"
@@ -41,6 +49,16 @@ defmodule Cog.Commands.Permissions do
       case validate(req) do
         %__MODULE__{errors: []}=result ->
           case result.action do
+            :create ->
+              {ns,name} = Permission.split_name (result.permission)
+              namespace = Repo.get_by(Namespace, name: ns)
+              permission = Permission.build_new(namespace, %{name: name})
+              case Repo.insert(permission) do
+                {:ok, _} ->
+                  {:create, result.permission}
+                {:error, changeset} ->
+                  Repo.rollback(changeset.errors)
+              end
             :grant ->
               Permittable.grant_to(result.permittable, result.permission)
               Cog.Command.UserPermissionsCache.reset_cache
@@ -81,12 +99,15 @@ defmodule Cog.Commands.Permissions do
 
   defp validate_action(%__MODULE__{req: req, errors: errors}=input) do
     case req.options do
+      %{"create" => true} -> %{input | action: :create}
       %{"grant" => true} -> %{input | action: :grant}
       %{"revoke" => true} -> %{input | action: :revoke}
       _ -> %{input | errors: errors ++ [:missing_action]}
     end
   end
 
+  defp validate_permittable(%__MODULE__{action: :create}=input),
+    do: input # nothing to validate in this case
   defp validate_permittable(%__MODULE__{req: req, errors: errors}=input) do
     case req.options do
       %{"user" => username} ->
@@ -109,6 +130,27 @@ defmodule Cog.Commands.Permissions do
     end
   end
 
+  defp validate_permission(%__MODULE__{req: req, errors: errors, action: :create}=input) do
+    case req.options do
+      %{"permission" => name} when is_binary(name) ->
+        case String.split(name, ":") do
+          ["site", _permission] ->
+            case Cog.Queries.Permission.from_full_name(name) |> Repo.one do
+              nil ->
+                # Permission must not already exist
+                %{input | permission: name}
+              %Permission{} ->
+                %{input | errors: errors ++ [{:permission_exists, name}]}
+            end
+          _ ->
+            %{input | errors: errors ++ [:invalid_creation_permission]}
+        end
+      %{"permission" => wrong_type} ->
+        %{input | errors: errors ++ [{:wrong_type, {:option, :permission}, :string, wrong_type}]}
+      _ ->
+        %{input | errors: errors ++ [:missing_permission]}
+    end
+  end
   defp validate_permission(%__MODULE__{req: req, errors: errors}=input) do
     case req.options do
       %{"permission" => full_name} ->
@@ -127,6 +169,8 @@ defmodule Cog.Commands.Permissions do
 
   # TODO: Really should template these
 
+  defp translate_success({:create, permission_full_name}),
+    do: "Create permission `#{permission_full_name}`"
   defp translate_success({:grant, permittable, permission_full_name}),
     do: "Granted permission `#{permission_full_name}` to #{type(permittable)} `#{name(permittable)}`"
   defp translate_success({:revoke, permittable, permission_full_name}),
@@ -153,6 +197,13 @@ defmodule Cog.Commands.Permissions do
   defp translate_error({:unrecognized_permission, name}),
     do: "Could not find permission `#{name}`"
   defp translate_error(:missing_permission),
-    do: "Must specify a permission to grant or revoke using `--permission`"
-
+    do: "Must specify a permission to operate on using `--permission`"
+  defp translate_error({:permission_exists, name}),
+    do: "The permission `#{name}` already exists"
+  defp translate_error(:invalid_creation_permission),
+    do: "Only permissions in the `site` namespace can be created; please specify permission as `site:<NAME>`"
+  defp translate_error({:wrong_type, {opt_or_arg, opt_or_arg_name}, desired_type, given_value}),
+    do: "The #{opt_or_arg} `#{opt_or_arg_name}` must be a #{desired_type}; you gave `#{inspect given_value}`"
+  defp translate_error(other),
+    do: "Error: `#{inspect other}`"
 end


### PR DESCRIPTION
Users can now create permissions in the `site` namespace via chat, just
as they are able to via the API and `cogctl`

```
!operable:permissions --create --permission="site:foo"
```

With this, we finally use all the core permissions in chat commands, so
we can remove the workaround for the embedded bundle which added the
`operable:manage_permissions` permission out-of-band.

Fixes #165
