### PR TITLE
Allow listing of permissions from chat

### DIFF
--- a/lib/cog/queries/permission.ex
+++ b/lib/cog/queries/permission.ex
@@ -1,6 +1,14 @@
 defmodule Cog.Queries.Permission do
   use Cog.Queries
 
+
+  def names do
+    from p in Cog.Models.Permission,
+    join: n in assoc(p, :namespace),
+    order_by: [n.name, p.name],
+    select: [n.name, p.name]
+  end
+
   def from_full_name(full_name) do
     {namespace, name} = Permission.split_name(full_name)
 


### PR DESCRIPTION
```
!operable:permissions --list
```

```
The following permissions exist:

* operable:manage_commands
* operable:manage_groups
* operable:manage_permissions
* operable:manage_roles
* operable:manage_users
```

I'm a bit sad that the output is a string and not templated, but I'm
going to be taking a pass through all the embedded commands next to
ensure they _all_ do the right thing soon, so that'll be fixed up; the
current behavior is neither worse nor better than what's already there.
