### PR TITLE
return json when an invalid provider is passed to chat-handle

### DIFF
--- a/web/controllers/v1/chat_handle_controller.ex
+++ b/web/controllers/v1/chat_handle_controller.ex
@@ -38,7 +38,9 @@ defmodule Cog.V1.ChatHandleController do
             |> render(Cog.ChangesetView, "error.json", changeset: changeset)
         end
       {:error, :invalid_provider} ->
-        send_resp(conn, :unprocessable_entity, Poison.encode!(%{error: "Provider '#{chat_handle_params["chat_provider"]}' not found"}))
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(Cog.ErrorView, "422.json", %{error: "Provider '#{chat_handle_params["chat_provider"]}' not found"})
     end
   end
 
@@ -64,7 +66,9 @@ defmodule Cog.V1.ChatHandleController do
             |> render(Cog.ChangesetView, "error.json", changeset: changeset)
         end
       {:error, :invalid_provider} ->
-        send_resp(conn, :unprocessable_entity, Poison.encode!(%{error: "Provider '#{chat_handle_params["chat_provider"]}' not found"}))
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(Cog.ErrorView, "422.json", %{error: "Provider '#{chat_handle_params["chat_provider"]}' not found"})
     end
   end
 

--- a/web/views/error_view.ex
+++ b/web/views/error_view.ex
@@ -13,6 +13,10 @@ defmodule Cog.ErrorView do
     "Server internal error"
   end
 
+  def render("422.json", %{error: msg}) do
+    %{error: msg}
+  end
+
   # In case no render clause matches or no
   # template is found, let's render it as 500
   def template_not_found(_template, assigns) do


### PR DESCRIPTION
When trying to create a chat-handle with an invalid provider the api would crash and send a non json response back to cogctl. This catches that error and provides a suitable response to the user.

I think this should resolve #184 
