### PR TITLE
Swap out :string for :text in migrations

### DIFF
--- a/priv/repo/migrations/20160209185334_varchar_to_text.exs
+++ b/priv/repo/migrations/20160209185334_varchar_to_text.exs
@@ -1,0 +1,17 @@
+defmodule Cog.Repo.Migrations.VarcharToText do
+  use Ecto.Migration
+
+  def change do
+    alter table(:tokens) do
+      modify :value, :text, null: false
+    end
+    alter table(:commands) do
+      modify :execution, :text, default: "multiple"
+      modify :calling_convention, :text, default: "bound"
+    end
+    alter table(:templates) do
+      modify :name, :text, null: false
+      modify :adapter, :text, null: false
+    end
+  end
+end


### PR DESCRIPTION
Use text fields over varchar to avoid dealing with arbitrary field lengths and also makes these migrations consistent with the rest.
