### PR TITLE
Register names unique processes

### DIFF
--- a/lib/cog/adapters/slack/supervisor.ex
+++ b/lib/cog/adapters/slack/supervisor.ex
@@ -4,7 +4,7 @@ defmodule Cog.Adapters.Slack.Sup do
   import Cog.Helpers, only: [ensure_integer: 1]
 
   def start_link do
-    Supervisor.start_link(__MODULE__, [])
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
   end
 
   def init(_) do

--- a/lib/cog/command/command_sup.ex
+++ b/lib/cog/command/command_sup.ex
@@ -4,7 +4,7 @@ defmodule Cog.Command.CommandSup do
   alias Cog.Command
 
   def start_link do
-    Supervisor.start_link(__MODULE__, [])
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
   end
 
   def init(_) do

--- a/lib/cog/command/pipeline/initializer.ex
+++ b/lib/cog/command/pipeline/initializer.ex
@@ -6,7 +6,7 @@ defmodule Cog.Command.Pipeline.Initializer do
   use GenServer
 
   def start_link() do
-    GenServer.start_link(__MODULE__, [])
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
   def init(_) do


### PR DESCRIPTION
Added some names for a handful of singleton processes. Among other
things, this makes it much easier to add debug tracing; you don't need
to find out the PID first.
