### PR TITLE
Switch Slack library back to upstream

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -42,6 +42,7 @@ defmodule Cog.Mixfile do
   defp deps do
     [
      {:slack, "~> 0.4.2"},
+     {:websocket_client, github: "jeremyong/websocket_client", ref: "f6892c8b55004008ce2d52be7d98b156f3e34569"},
      {:poison, "1.5.0"},
      {:ibrowse, github: "cmullaparthi/ibrowse", tag: "v4.1.2"},
      {:uuid, "1.0.1"},

--- a/mix.lock
+++ b/mix.lock
@@ -50,4 +50,4 @@
   "spanner": {:git, "git@github.com:operable/spanner", "204558d5d3cbab4f45403688ee92e6c6ef18bcc9", [ref: "204558d5d3cbab4f45403688ee92e6c6ef18bcc9"]},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
   "uuid": {:hex, :uuid, "1.0.1"},
-  "websocket_client": {:git, "https://github.com/jeremyong/websocket_client.git", "f6892c8b55004008ce2d52be7d98b156f3e34569", []}}
+  "websocket_client": {:git, "https://github.com/jeremyong/websocket_client.git", "f6892c8b55004008ce2d52be7d98b156f3e34569", [ref: "f6892c8b55004008ce2d52be7d98b156f3e34569"]}}


### PR DESCRIPTION
The change we were using from Chris' fork has been merged.
