### PR TITLE
Fix JSON formatting for existing adapters

### DIFF
--- a/lib/cog/template_cache.ex
+++ b/lib/cog/template_cache.ex
@@ -44,14 +44,14 @@ defmodule Cog.TemplateCache do
     end
   end
 
-  def lookup(_bundle, "Slack", "json") do
+  def lookup(_bundle, "slack", "json") do
     fn context ->
       text = Poison.encode!(context, pretty: true)
       "```#{text}```"
     end
   end
 
-  def lookup(_bundle, "HipChat", "json") do
+  def lookup(_bundle, "hipchat", "json") do
     fn context ->
       text = Poison.encode!(context, pretty: true)
       "/code #{text}"


### PR DESCRIPTION
Back when the adapter names were lower-cased, these two instances got
missed. As a result, JSON-templated output was displayed as "plain
text", instead of being formatted in a code block.

See a comparison here; the first message does not have this fix applied, while the second one does.

<img width="167" alt="slack" src="https://cloud.githubusercontent.com/assets/207178/13033572/a1ae205a-d2e9-11e5-9c4a-ba3b9d980623.png">
