### PR TITLE
Render multiple outputs from executor

### DIFF
--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -491,10 +491,10 @@ defmodule Cog.Command.Pipeline.Executor do
     # This is *NOT* a long-term solution.
     case TemplateCache.lookup(bundle_id, adapter, template) do
       fun when is_function(fun) ->
-        if length(context) < 2 do
-          fun.(context)
-        else
+        if is_list(context) do
           Enum.join(Enum.map(context, fun))
+        else
+          fun.(context)
         end
       nil ->
         # Unfortunately, we don't have the bundle name or the command


### PR DESCRIPTION
This PR contains a short-term fix for rendering multiple outputs from a pipeline. I believe this does what we need it to do but would like independent verification with more pipelines (cc @imbriaco).

We really need to give the executor a thorough spring cleaning.

See #236 for details on the actual bug.
