### PR TITLE
Infinite error when installing bundles

### DIFF
--- a/lib/cog/bundle/install.ex
+++ b/lib/cog/bundle/install.ex
@@ -45,7 +45,7 @@ defmodule Cog.Bundle.Install do
   def install_bundle(bundle_params) do
     # TODO: Validate bundle (e.g., check manifest, etc)
 
-    {:ok, bundle} = Repo.transaction(fn ->
+    Repo.transaction(fn ->
       bundle = %Bundle{}
       |> Bundle.changeset(bundle_params)
       |> Repo.insert!
@@ -67,10 +67,9 @@ defmodule Cog.Bundle.Install do
 
       Map.get(bundle.config_file, "templates", [])
       |> Enum.each(&create_template(bundle, &1))
+
       bundle
     end)
-
-    bundle
   end
 
   # Given the parent `bundle` and the bundle configuration schema for a

--- a/lib/cog/relay/util.ex
+++ b/lib/cog/relay/util.ex
@@ -7,4 +7,18 @@ defmodule Cog.Relay.Util do
     String.to_integer(istr, to_base)
   end
 
+  @doc "Return true if tuple has an :ok status"
+  def is_ok?({:ok, _}), do: true
+  def is_ok?({_,_}), do: false
+
+  @doc "Returns the data that is wrapped in a tuple"
+  def unwrap_tuple({_status, bundle_data}), do: bundle_data
+
+  @doc "Given a tuple containing tuples with both :ok and :error statuses,
+  return a tuple containing lists of the separated items"
+  def unwrap_partition_results({oks, errors}) do
+    {Enum.map(oks, &unwrap_tuple/1),
+     Enum.map(errors, &unwrap_tuple/1)}
+  end
+
 end


### PR DESCRIPTION
This is a partial fix for https://github.com/operable/cog/issues/127.

We display an error when the transaction fails for any reason in the log when installing a bundle. The next step will be to send an error to relay to move the bundle to the failed state.
