### PR TITLE
Bundles are disabled by default

### DIFF
--- a/lib/cog/models/bundle.ex
+++ b/lib/cog/models/bundle.ex
@@ -6,7 +6,7 @@ defmodule Cog.Models.Bundle do
     field :name, :string
     field :config_file, :map
     field :manifest_file, :map
-    field :enabled, :boolean, default: true
+    field :enabled, :boolean, default: false
 
     has_many :commands, Command
     has_many :templates, Template
@@ -26,12 +26,28 @@ defmodule Cog.Models.Bundle do
     |> cast(params, @required_fields, @optional_fields)
     |> validate_format(:name, ~r/\A[A-Za-z0-9\_\-\.]+\z/)
     |> unique_constraint(:name)
+    |> enable_if_embedded
   end
 
   def embedded?(%__MODULE__{name: name}),
     do: name == Cog.embedded_bundle
   def embedded?(_),
     do: false
+
+  # When the embedded bundle is installed, it should always be
+  # enabled. Though we prevent disabling it elsewhere, this code also
+  # happens to block that, as well.
+  #
+  # Nothing is changed if it is not the embedded bundle.
+  defp enable_if_embedded(changeset) do
+    embedded = Cog.embedded_bundle
+    case fetch_field(changeset, :name) do
+      {_, ^embedded} ->
+        put_change(changeset, :enabled, true)
+      _ ->
+        changeset
+    end
+  end
 
   def bundle_path(%__MODULE__{name: name}) do
     Path.join(bundle_root!, name)

--- a/priv/repo/migrations/20160216200959_bundles_are_disabled_by_default.exs
+++ b/priv/repo/migrations/20160216200959_bundles_are_disabled_by_default.exs
@@ -1,0 +1,9 @@
+defmodule Cog.Repo.Migrations.BundlesAreDisabledByDefault do
+  use Ecto.Migration
+
+  def change do
+    alter table(:bundles) do
+      modify :enabled, :boolean, default: false
+    end
+  end
+end


### PR DESCRIPTION
When installing a bundle, it should always be disabled until explicitly
enabled by an administrator.

Here, we add a migration that changes the database default, as well as
the bundle model default.

Additionally, the embedded bundle is the only one that should be
installed as enabled (rather hard to do anything without _that_). A
changeset function has been added to the bundel model to ensure that the
embedded bundle is always enabled.

Fixes #124
