### PR TITLE
Provide feedback to unregistered bot users

### DIFF
--- a/lib/cog/adapters/hipchat/api.ex
+++ b/lib/cog/adapters/hipchat/api.ex
@@ -8,6 +8,20 @@ defmodule Cog.Adapters.HipChat.API do
   @api_base "https://api.hipchat.com/v2"
   @timeout 15000 # 15 seconds
 
+  # TODO: This should be part of a future adapter behavior
+  @doc """
+  Format a chat handle to correspond to a "mention" in this chat
+  provider.
+  """
+  def mention_name(handle), do: "@" <> handle
+
+  # TODO: This should be part of a future adapter behavior
+  @doc """
+  The "name" of the chat service, properly formatted, capitalized,
+  etc. to correspond with colloquial usage.
+  """
+  def service_name, do: "HipChat"
+
   def message(room, message), do: send_message(room, message)
   def send_message(room, message) do
     url = "/room/" <> to_string(room) <> "/message"

--- a/lib/cog/adapters/slack/api.ex
+++ b/lib/cog/adapters/slack/api.ex
@@ -15,6 +15,20 @@ defmodule Cog.Adapters.Slack.API do
     GenServer.start_link(__MODULE__, [token, ttl], name: @server_name)
   end
 
+  # TODO: This should be part of a future adapter behavior
+  @doc """
+  Format a chat handle to correspond to a "mention" in this chat
+  provider.
+  """
+  def mention_name(handle), do: "@" <> handle
+
+  # TODO: This should be part of a future adapter behavior
+  @doc """
+  The "name" of the chat service, properly formatted, capitalized,
+  etc. to correspond with colloquial usage.
+  """
+  def service_name, do: "Slack"
+
   def send_message(channel_id, message) when is_binary(message) do
     GenServer.call(@server_name, {:send_message, channel_id, message}, :infinity)
   end

--- a/priv/repo/migrations/20160219160541_groups_with_permission.exs
+++ b/priv/repo/migrations/20160219160541_groups_with_permission.exs
@@ -1,0 +1,46 @@
+defmodule Cog.Repo.Migrations.GroupsWithPermission do
+  use Ecto.Migration
+
+  def up do
+    execute """
+    CREATE FUNCTION groups_with_permission(
+      p_permission permissions.id%TYPE)
+    RETURNS SETOF groups.id%TYPE
+    LANGUAGE SQL STABLE STRICT
+    AS $$
+      WITH RECURSIVE
+      direct_grants AS (
+        SELECT group_id
+        FROM group_permissions
+        WHERE permission_id = p_permission
+      ),
+      role_grants AS (
+        SELECT gr.group_id
+        FROM group_roles AS gr
+        JOIN role_permissions AS rp
+          USING (role_id)
+        WHERE rp.permission_id = p_permission
+      ),
+      in_groups AS (
+        SELECT group_id FROM direct_grants
+        UNION
+        SELECT group_id FROM role_grants
+        UNION
+        -- find all groups that are members of that group, etc.
+        SELECT ggm.member_id
+        FROM group_group_membership AS ggm
+        JOIN in_groups AS ig
+          USING (group_id)
+      )
+      SELECT group_id
+       FROM in_groups;
+    $$;
+    """
+  end
+
+  def down do
+    execute """
+    DROP FUNCTION groups_with_permission(p_permission permissions.id%TYPE);
+    """
+  end
+end

--- a/priv/repo/migrations/20160219161248_users_with_permission.exs
+++ b/priv/repo/migrations/20160219161248_users_with_permission.exs
@@ -1,0 +1,46 @@
+defmodule Cog.Repo.Migrations.UsersWithPermission do
+  use Ecto.Migration
+
+  def up do
+    execute """
+    CREATE FUNCTION users_with_permission(
+      p_permission permissions.id%TYPE)
+    RETURNS SETOF users.id%TYPE
+    LANGUAGE SQL STABLE STRICT
+    AS $$
+      WITH direct_grants AS (
+        SELECT up.user_id
+        FROM user_permissions AS up
+        WHERE up.permission_id = p_permission
+      ),
+      role_grants AS (
+        SELECT ur.user_id
+        FROM user_roles AS ur
+        JOIN role_permissions AS rp
+          USING(role_id)
+        WHERE rp.permission_id = p_permission
+      ),
+      all_groups AS (
+        SELECT group_id
+        FROM groups_with_permission(p_permission) AS g(group_id)
+      ),
+      group_grants AS (
+        SELECT ugm.member_id AS user_id
+        FROM user_group_membership AS ugm
+        JOIN all_groups AS ag
+          USING(group_id)
+      )
+      SELECT user_id FROM direct_grants
+      UNION
+      SELECT user_id FROM role_grants
+      UNION
+      SELECT user_id FROM group_grants
+      ;
+    $$;
+    """
+  end
+
+  def down do
+    execute "DROP FUNCTION users_with_permission(p_perm permissions.id%TYPE);"
+  end
+end

--- a/test/cog/queries/user_test.exs
+++ b/test/cog/queries/user_test.exs
@@ -1,0 +1,127 @@
+defmodule Cog.Queries.User.Test do
+  use Cog.ModelCase
+
+  alias Cog.Models.User
+
+  setup do
+    # add a few extra users we won't grant anything to, just to ensure
+    # we're being selective
+    user("somebody")
+    user("somebody-else")
+    user("that-puppy-over-there")
+
+    :ok
+  end
+
+  test "user with direct permission is found" do
+    user = user("test")
+    permission = permission("site:test")
+    Permittable.grant_to(user, permission)
+
+    assert_has_permission(user, permission)
+  end
+
+  test "user with granted role permission is found" do
+    user = user("test")
+    role = role("test_role")
+    permission = permission("site:test")
+    Permittable.grant_to(role, permission)
+    Permittable.grant_to(user, role)
+
+    assert_has_permission(user, permission)
+  end
+
+  test "user in group with directly-granted permission is found" do
+    user = user("test")
+    group = group("group")
+    permission = permission("site:test")
+    Permittable.grant_to(group, permission)
+    Groupable.add_to(user, group)
+
+    assert_has_permission(user, permission)
+  end
+
+  test "user in group with directly-granted role permission is found" do
+    user = user("test")
+    role = role("role")
+    group = group("group")
+    permission = permission("site:test")
+    Permittable.grant_to(role, permission)
+    Permittable.grant_to(group, role)
+    Groupable.add_to(user, group)
+
+    assert_has_permission(user, permission)
+  end
+
+  test "user in group in a group with a directly-granted permission is found" do
+    user = user("test")
+    inner = group("inner")
+    outer = group("outer")
+    permission = permission("site:test")
+    Permittable.grant_to(outer, permission)
+    Groupable.add_to(user, inner)
+    Groupable.add_to(inner, outer)
+
+    assert_has_permission(user, permission)
+  end
+
+  test "user in group in a group with a role-granted permission is found" do
+    user = user("test")
+    role = role("role")
+    inner = group("inner")
+    outer = group("outer")
+    permission = permission("site:test")
+    Permittable.grant_to(role, permission)
+    Permittable.grant_to(outer, role)
+    Groupable.add_to(user, inner)
+    Groupable.add_to(inner, outer)
+
+    assert_has_permission(user, permission)
+  end
+
+  test "ensure that multiple users can be found (i.e., all the preceding tests in one)" do
+    permission = permission("site:test")
+    role = role("role")
+    Permittable.grant_to(role, permission)
+
+    # Setup groups
+    gp = group("group-with-permission")
+    Permittable.grant_to(gp, permission)
+    gr = group("group-with-role")
+    Permittable.grant_to(gr, role)
+    ggp = group("group-in-group-with-permission")
+    Groupable.add_to(ggp, gp)
+    ggr = group("group-in-group-with-role")
+    Groupable.add_to(ggr, gr)
+
+    # Setup users
+    up = user("user-with-permission")
+    Permittable.grant_to(up, permission)
+    ur = user("user-with-role")
+    Permittable.grant_to(ur, role)
+    ugp = user("user-in-group-with-permission")
+    Groupable.add_to(ugp, gp)
+    ugr = user("user-in-group-with-role")
+    Groupable.add_to(ugr, gr)
+    uggp = user("user-in-group-in-group-with-permission")
+    Groupable.add_to(uggp, ggp)
+    uggr = user("user-in-group-in-group-with-role")
+    Groupable.add_to(uggr, ggr)
+
+    expected_usernames = [up, ur, ugp, ugr, uggp, uggr] |> ordered_usernames
+    actual_usernames = Cog.Queries.User.with_permission(permission) |> Repo.all |> ordered_usernames
+
+    assert expected_usernames == actual_usernames
+  end
+
+  # Ensure that the `Cog.Queries.User.with_permission/2` query returns
+  # the appropriate information, and that it agrees with
+  # `User.has_permission/2` which is its inverse.
+  defp assert_has_permission(user, permission) do
+    assert User.has_permission(user, permission)
+    assert [user.username] == Cog.Queries.User.with_permission(permission) |> Repo.all |> ordered_usernames
+  end
+
+  defp ordered_usernames(users),
+    do: users |> Enum.map(&(&1.username)) |> Enum.sort
+end


### PR DESCRIPTION
Currently, Cog requires a user to have both a Cog account with a
registered chat handle in order to interact with it. Previously, if a
user without one or both of these attempted to use the bot, the request
would be ignored and no feedback was given.

Now, Cog returns a message to the user explaining the
situation. Additionally, if there exist users with the ability to create
users and that have chat handles for the chat provider being used, their
names are mentioned in the message, providing a path for immediate
remedy of the situation.

A demonstration in Slack:

```
@chris: I'm sorry, but either I don't have a Cog account for you, or
your Slack chat handle has not been registered. Currently, only
registered users can interact with me.

You'll need to ask a Cog administrator to fix this situation and to
register your Slack handle; the following users can help you right here
in chat: @imbriaco, @kevsmith, @latitia, @mpeck, @shelton, @vanstee .
```

In order to achieve this, a few pieces were needed:
- Adapters now have the ability to format "mention names", and to give
  their chat service names (as commonly rendered, e.g., "HipChat",
  "Slack"). This was done to make the feedback messages read as
  naturally as possible, and to take advantage of mentions in an
  adapter-appropriate manner. Both of these would need to make it into a
  future "adapter behaviour" in one form or another; the current
  implementation was most expedient.
- Both a `groups_with_permission` and `users_with_permission` (which
  builds on `groups_with_permission`) stored procedure were created to
  encapsulate the involved queries needed to navigate our authorization
  network. Both return only the IDs of the groups / users that have a
  given permission in order to be maximally flexible.
- These procedures are actually embedded into composable Ecto queries
  which can be used to either return complete User models for users with
  a permission, or to return those User models additionally filtered by
  the presence of a handle for a specific chat provider.
- Finally, the executor now creates a message to send back to the
  unregistered user instead of merely logging the situation and silently
  ignoring them. Error templates will ultimately make this
  implementation cleaner.

Fixes #230
