### PR TITLE
Add Brewfile for installing dependencies on Mac OS X with homebrew

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,6 @@
+tap 'operable/operable'
+brew 'erlang', args: ['with-dirty-schedulers']
+brew 'libsodium'
+brew 'postgresql'
+brew 'elixir'
+brew 'goon'


### PR DESCRIPTION
If you are running in development on Mac OS X and use homebrew, this lets you run:

```
brew bundle
```

And it installs all the dependencies for you, including erlang with dirty schedulers. If accepted, this can be added somewhere in https://github.com/operable/cog/wiki/Installation-Guide

_Inspired by that time I read enough of the installation guide to run `make setup` but not enough to have noticed libsodium was a dependencies_
