### PR TITLE
Allow Dockerfile to be built

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,10 +36,11 @@ WORKDIR /
 
 # Setup Cog
 ENV MIX_ENV staging
-RUN mkdir -p /app
+RUN mkdir -p /app/config
 WORKDIR /app
 
 COPY mix.exs mix.lock /app/
+COPY config/helpers.exs /app/config/
 RUN mix deps.get && mix deps.compile
 
 COPY . /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get install -y apt-transport-https build-essential git-core postgresql-c
 # Setup Elixir runtime
 RUN echo "deb https://packages.erlang-solutions.com/debian jessie contrib" >> /etc/apt/sources.list && \
     apt-key adv --fetch-keys http://packages.erlang-solutions.com/debian/erlang_solutions.asc && \
-    apt-get -qq update && apt-get install -y esl-erlang=1:18.1 && \
+    apt-get -qq update && apt-get install -y esl-erlang=1:18.1 libexpat-dev libsodium-dev && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Download and Install Specific Version of Elixir

--- a/mix.exs
+++ b/mix.exs
@@ -61,8 +61,8 @@ defmodule Cog.Mixfile do
      {:hedwig, "~> 0.3.0"},
      {:gproc, "~> 0.5.0", override: true},
      {:html_entities, "~> 0.3.0"},
-     {:spanner, git: "git@github.com:operable/spanner", tag: "0.2"},
-     {:probe, git: "git@github.com:operable/probe", tag: "0.2"},
+     {:spanner, github: "operable/spanner", tag: "0.2"},
+     {:probe, github: "operable/probe", tag: "0.2"},
      {:exml, github: "paulgray/exml", tag: "2.2.1"},
      {:fumanchu, github: "operable/fumanchu", ref: "cog-0.2"},
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,10 @@
+<<<<<<< 766ebd01bf96dd32e6472cd567d9f9b38f574c90
 %{"adz": {:git, "https://github.com/operable/adz.git", "601ceb3a19716ea635a7cd83c05f5593f5cf6c40", [tag: "0.2"]},
   "carrier": {:git, "https://github.com/operable/carrier.git", "addaf0acd9acc3af894ccb396550f8785f277074", [tag: "0.2"]},
+=======
+%{"adz": {:git, "git@github.com:operable/adz", "601ceb3a19716ea635a7cd83c05f5593f5cf6c40", [tag: "0.2"]},
+  "carrier": {:git, "git@github.com:operable/carrier", "107ee3b252cc57c8581cb3f37000139a7bb1a2d0", [tag: "0.2"]},
+>>>>>>> Ensure mix deps are up-to-date
   "certifi": {:hex, :certifi, "0.3.0"},
   "comeonin": {:hex, :comeonin, "2.1.1"},
   "connection": {:hex, :connection, "1.0.2"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,10 +1,5 @@
-<<<<<<< 766ebd01bf96dd32e6472cd567d9f9b38f574c90
 %{"adz": {:git, "https://github.com/operable/adz.git", "601ceb3a19716ea635a7cd83c05f5593f5cf6c40", [tag: "0.2"]},
   "carrier": {:git, "https://github.com/operable/carrier.git", "addaf0acd9acc3af894ccb396550f8785f277074", [tag: "0.2"]},
-=======
-%{"adz": {:git, "git@github.com:operable/adz", "601ceb3a19716ea635a7cd83c05f5593f5cf6c40", [tag: "0.2"]},
-  "carrier": {:git, "git@github.com:operable/carrier", "107ee3b252cc57c8581cb3f37000139a7bb1a2d0", [tag: "0.2"]},
->>>>>>> Ensure mix deps are up-to-date
   "certifi": {:hex, :certifi, "0.3.0"},
   "comeonin": {:hex, :comeonin, "2.1.1"},
   "connection": {:hex, :connection, "1.0.2"},
@@ -54,7 +49,7 @@
   "probe": {:git, "https://github.com/operable/probe.git", "c8ebf0877651b3cc5370e3f6ca7790a277106016", [tag: "0.2"]},
   "ranch": {:hex, :ranch, "1.2.1"},
   "slack": {:hex, :slack, "0.4.2"},
-  "spanner": {:git, "https://github.com/operable/spanner.git", "4dc3bd344bc7cd8e82344b2ec77a6a12a91b16f3", [tag: "0.2"]},
+  "spanner": {:git, "https://github.com/operable/spanner.git", "8992e191f6974d7edd42ab1df405323775d2130f", [tag: "0.2"]},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
   "uuid": {:hex, :uuid, "1.1.3"},
   "websocket_client": {:git, "https://github.com/jeremyong/websocket_client.git", "f6892c8b55004008ce2d52be7d98b156f3e34569", [ref: "f6892c8b55004008ce2d52be7d98b156f3e34569"]}}

--- a/mix.lock
+++ b/mix.lock
@@ -46,10 +46,10 @@
   "poolboy": {:hex, :poolboy, "1.5.1"},
   "porcelain": {:hex, :porcelain, "2.0.1"},
   "postgrex": {:hex, :postgrex, "0.11.1"},
-  "probe": {:git, "git@github.com:operable/probe", "c8ebf0877651b3cc5370e3f6ca7790a277106016", [tag: "0.2"]},
+  "probe": {:git, "https://github.com/operable/probe.git", "c8ebf0877651b3cc5370e3f6ca7790a277106016", [tag: "0.2"]},
   "ranch": {:hex, :ranch, "1.2.1"},
   "slack": {:hex, :slack, "0.4.2"},
-  "spanner": {:git, "git@github.com:operable/spanner", "8992e191f6974d7edd42ab1df405323775d2130f", [tag: "0.2"]},
+  "spanner": {:git, "https://github.com/operable/spanner.git", "4dc3bd344bc7cd8e82344b2ec77a6a12a91b16f3", [tag: "0.2"]},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
   "uuid": {:hex, :uuid, "1.1.3"},
   "websocket_client": {:git, "https://github.com/jeremyong/websocket_client.git", "f6892c8b55004008ce2d52be7d98b156f3e34569", [ref: "f6892c8b55004008ce2d52be7d98b156f3e34569"]}}


### PR DESCRIPTION
:information_desk_person: The current `Dockerfile` fails to build. This is due to two issues:
* `config/helpers.exs` is referenced in `mix.exs`, so this file needs to be copied into the Docker image
* parts of the dependency tree still reference private GitHub URLs, which fail to be pulled during the Docker build process due to missing ssh credentials

These changes attempt fix these issues.

:warning: Dependencies:
* [x] operable/carrier#8
* [x] operable/spanner#40