### PR TITLE
Fix Cog's Dockerfile so the container can be built

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,48 +1,16 @@
-FROM debian:jessie
+FROM operable/docker-base
 
-ENV DEBIAN_FRONTEND noninteractive
-
-# Set locale
-ENV LANG C.UTF-8
-ENV LANGUAGE C.UTF-8
-ENV LC_ALL C.UTF-8
-
-RUN apt-get update -qq && apt-get install -y locales -qq && locale-gen en_US.UTF-8 en_us && dpkg-reconfigure locales && dpkg-reconfigure locales && locale-gen C.UTF-8 && /usr/sbin/update-locale LANG=C.UTF-8
-
-# Add some basic dependencies
-RUN apt-get install -y apt-transport-https build-essential git-core postgresql-client unzip wget
-
-# Setup Elixir runtime
-RUN echo "deb https://packages.erlang-solutions.com/debian jessie contrib" >> /etc/apt/sources.list && \
-    apt-key adv --fetch-keys http://packages.erlang-solutions.com/debian/erlang_solutions.asc && \
-    apt-get -qq update && apt-get install -y esl-erlang=1:18.1 && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# Download and Install Specific Version of Elixir
-WORKDIR /elixir
-RUN wget -q https://github.com/elixir-lang/elixir/releases/download/v1.1.1/Precompiled.zip && \
-    unzip Precompiled.zip && \
-    rm -f Precompiled.zip && \
-    ln -s /elixir/bin/elixirc /usr/local/bin/elixirc && \
-    ln -s /elixir/bin/elixir /usr/local/bin/elixir && \
-    ln -s /elixir/bin/mix /usr/local/bin/mix && \
-    ln -s /elixir/bin/iex /usr/local/bin/iex
-
-# Install local Elixir hex and rebar
-RUN /usr/local/bin/mix local.hex --force && \
-    /usr/local/bin/mix local.rebar --force
-
-WORKDIR /
+# Setup Mix Environment to use. We declare the MIX_ENV at build time
+ARG MIX_ENV
+ENV MIX_ENV ${MIX_ENV:-dev}
 
 # Setup Cog
-ENV MIX_ENV staging
-RUN mkdir -p /app
-WORKDIR /app
-
-COPY mix.exs mix.lock /app/
+COPY mix.exs mix.lock /home/operable/
+RUN mkdir /home/operable/config
+COPY config/helpers.exs /home/operable/config/
 RUN mix deps.get && mix deps.compile
 
-COPY . /app/
+COPY . /home/operable/
 
 RUN mix clean && mix compile
-RUN rm -f /app/.dockerignore
+RUN rm -f /home/operable/.dockerignore

--- a/mix.exs
+++ b/mix.exs
@@ -61,8 +61,8 @@ defmodule Cog.Mixfile do
      {:hedwig, "~> 0.3.0"},
      {:gproc, "~> 0.5.0", override: true},
      {:html_entities, "~> 0.3.0"},
-     {:spanner, git: "git@github.com:operable/spanner", tag: "0.2"},
-     {:probe, git: "git@github.com:operable/probe", tag: "0.2"},
+     {:spanner, github: "operable/spanner", tag: "0.2"},
+     {:probe, github: "operable/probe", tag: "0.2"},
      {:exml, github: "paulgray/exml", tag: "2.2.1"},
      {:fumanchu, github: "operable/fumanchu", ref: "cog-0.2"},
 

--- a/mix.lock
+++ b/mix.lock
@@ -46,10 +46,10 @@
   "poolboy": {:hex, :poolboy, "1.5.1"},
   "porcelain": {:hex, :porcelain, "2.0.1"},
   "postgrex": {:hex, :postgrex, "0.11.1"},
-  "probe": {:git, "git@github.com:operable/probe", "c8ebf0877651b3cc5370e3f6ca7790a277106016", [tag: "0.2"]},
+  "probe": {:git, "https://github.com/operable/probe.git", "c8ebf0877651b3cc5370e3f6ca7790a277106016", [tag: "0.2"]},
   "ranch": {:hex, :ranch, "1.2.1"},
   "slack": {:hex, :slack, "0.4.2"},
-  "spanner": {:git, "git@github.com:operable/spanner", "8992e191f6974d7edd42ab1df405323775d2130f", [tag: "0.2"]},
+  "spanner": {:git, "https://github.com/operable/spanner.git", "8992e191f6974d7edd42ab1df405323775d2130f", [tag: "0.2"]},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
   "uuid": {:hex, :uuid, "1.1.3"},
   "websocket_client": {:git, "https://github.com/jeremyong/websocket_client.git", "f6892c8b55004008ce2d52be7d98b156f3e34569", [ref: "f6892c8b55004008ce2d52be7d98b156f3e34569"]}}


### PR DESCRIPTION
* Updates dependencies in `mix.exs` to make sure they all use HTTPS instead of SSH to fetch.
* Uses operable/docker-base, simplifying the Dockerfile considerably

This solves the same problem as #284, but we'll take this iteration since it uses the operable/docker-base that wasn't publicly available when @sgerrand investigated.