### PR TITLE
Enforce unique bundle names in database

### DIFF
--- a/lib/cog/models/bundle.ex
+++ b/lib/cog/models/bundle.ex
@@ -25,7 +25,7 @@ defmodule Cog.Models.Bundle do
     model
     |> cast(params, @required_fields, @optional_fields)
     |> validate_format(:name, ~r/\A[A-Za-z0-9\_\-\.]+\z/)
-    |> unique_constraint(:name)
+    |> unique_constraint(:name, name: :bundles_name_index)
     |> enable_if_embedded
   end
 

--- a/priv/repo/migrations/20160224180326_unique_bundle_names.exs
+++ b/priv/repo/migrations/20160224180326_unique_bundle_names.exs
@@ -1,0 +1,7 @@
+defmodule Cog.Repo.Migrations.UniqueBundleNames do
+  use Ecto.Migration
+
+  def change do
+    create unique_index(:bundles, [:name])
+  end
+end

--- a/test/cog/rule_test.exs
+++ b/test/cog/rule_test.exs
@@ -5,7 +5,7 @@ defmodule RuleTest do
   alias Cog.Models.Rule
 
   setup do
-    bundle = Repo.insert!(%Bundle{name: "test_bundle", config_file: %{}, manifest_file: %{}})
+    bundle = Bundle.changeset(%Bundle{}, %{name: "test_bundle", config_file: %{}, manifest_file: %{}}) |> Repo.insert!
     {:ok, command} = Command.insert_new(%{name: "pugbomb", version: "1.0.0", bundle_id: bundle.id})
     {:ok, [command: command]}
   end
@@ -27,7 +27,7 @@ defmodule RuleTest do
     use Cog.ModelCase
 
     setup do
-      bundle = Repo.insert!(%Bundle{name: "operable", config_file: %{}, manifest_file: %{}})
+      bundle = Bundle.changeset(%Bundle{}, %{name: "test_bundle", config_file: %{}, manifest_file: %{}}) |> Repo.insert!
       rule_text = "when command is s3:list must have s3:delete"
       {:ok, expr, _} = Piper.Permissions.Parser.parse(rule_text)
       {:ok, command} = Command.insert_new(%{name: "pugbomb", version: "1.0.0", bundle_id: bundle.id})


### PR DESCRIPTION
Not having this was a complete oversight!

Changed some tests to both use the Bundle changeset, and not conflict
with the already-installed `operable` bundle.