### PR TITLE
Commands no longer have versions

### DIFF
--- a/lib/cog/bundle/install.ex
+++ b/lib/cog/bundle/install.ex
@@ -15,7 +15,7 @@ defmodule Cog.Bundle.Install do
 
   require Logger
 
-  @command_attrs ["name", "version", "options", "enforcing",
+  @command_attrs ["name", "options", "enforcing",
                   "calling_convention", "execution",
                   "documentation"]
 
@@ -82,7 +82,6 @@ defmodule Cog.Bundle.Install do
   #                              "enforcing" => true,
   #                              "calling_convention" => "bound",
   #                              "execution" => "multiple",
-  #                              "version" => "0.0.1",
   #                              "options": [%{"name" => "instance-id", "type" => "string", "required" => true}],
   #                              "module" => "Cog.Commands.EC2Tag"})
   defp create_command(%Bundle{}=bundle, command_spec) do

--- a/lib/cog/bundle/install.ex
+++ b/lib/cog/bundle/install.ex
@@ -86,9 +86,7 @@ defmodule Cog.Bundle.Install do
   #                              "options": [%{"name" => "instance-id", "type" => "string", "required" => true}],
   #                              "module" => "Cog.Commands.EC2Tag"})
   defp create_command(%Bundle{}=bundle, command_spec) do
-    command_spec = command_spec
-    |> Enum.filter(fn({key, _}) -> key in @command_attrs end)
-    |> Enum.into(%{})
+    command_spec = Map.take(command_spec, @command_attrs)
 
     command = Command.build_new(bundle, command_spec)
     |> Repo.insert!

--- a/lib/cog/models/command.ex
+++ b/lib/cog/models/command.ex
@@ -6,7 +6,6 @@ defmodule Cog.Models.Command do
 
   schema "commands" do
     field :name, :string
-    field :version, :string
     field :documentation, :string
     field :enforcing, :boolean, default: true
     field :calling_convention, :string, default: "bound"
@@ -18,11 +17,11 @@ defmodule Cog.Models.Command do
     has_many :options, CommandOption
   end
 
-  @required_fields ~w(name version bundle_id)
+  @required_fields ~w(name bundle_id)
   @optional_fields ~w(documentation enforcing calling_convention execution)
 
-  summary_fields [:id, :name, :version]
-  detail_fields [:id, :name, :version, :documentation]
+  summary_fields [:id, :name]
+  detail_fields [:id, :name, :documentation]
 
   @doc """
   Create a new changeset for a command, associating it with its parent

--- a/priv/repo/migrations/20160224184802_drop_command_versions.exs
+++ b/priv/repo/migrations/20160224184802_drop_command_versions.exs
@@ -1,0 +1,9 @@
+defmodule Cog.Repo.Migrations.DropCommandVersions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:commands) do
+      remove :version
+    end
+  end
+end

--- a/test/cog/models/command_test.exs
+++ b/test/cog/models/command_test.exs
@@ -9,7 +9,7 @@ defmodule Cog.Models.CommandTest do
 
   setup do
     {:ok, bundle} = Repo.insert(%Bundle{name: "test_bundle", config_file: %{}, manifest_file: %{}})
-    {:ok, command} = Command.insert_new(%{name: "drop_database", version: "1.0.0", bundle_id: bundle.id})
+    {:ok, command} = Command.insert_new(%{name: "drop_database", bundle_id: bundle.id})
     {:ok, expr, _} = Parser.parse("when command is operable:drop_database must have drop_database:write")
     {:ok, rule} = Rule.insert_new(command, expr)
     {:ok, [bundle: bundle,
@@ -18,13 +18,8 @@ defmodule Cog.Models.CommandTest do
   end
 
   test "command names are unique", %{bundle: bundle} do
-    params = %{name: "pugbomb", version: "1.0.0", bundle_id: bundle.id}
-    {:ok, _} = Command.insert_new(params)
-    assert {:error, %Ecto.Changeset{}} = Command.insert_new(params)
-  end
-
-  test "command versions are required", %{bundle: bundle} do
     params = %{name: "pugbomb", bundle_id: bundle.id}
+    {:ok, _} = Command.insert_new(params)
     assert {:error, %Ecto.Changeset{}} = Command.insert_new(params)
   end
 
@@ -42,12 +37,12 @@ defmodule Cog.Models.CommandTest do
   test "command option names are unique to each command", %{bundle: bundle, command: command} do
     {:ok, _} = CommandOption.insert_new(command, %{name: "term1", type: "bool", required: false})
     assert({:error, %Ecto.Changeset{}=_} = CommandOption.insert_new(command, %{name: "term1", type: "bool", required: false}))
-    {:ok, command} = Command.insert_new(%{name: "wubba", version: "1.0.0", bundle_id: bundle.id})
+    {:ok, command} = Command.insert_new(%{name: "wubba", bundle_id: bundle.id})
     assert({:ok, _} = CommandOption.insert_new(command, %{name: "term1", type: "bool", required: false}))
   end
 
   test "command names must be made up of word characters and dashes", %{bundle: bundle} do
-    params = %{name: "weird:name", version: "1.0.0", bundle_id: bundle.id}
+    params = %{name: "weird:name", bundle_id: bundle.id}
     {:error, command} = Command.insert_new(params)
     assert %{errors: [name: "has invalid format"]} = command
   end

--- a/test/cog/queries/command_test.exs
+++ b/test/cog/queries/command_test.exs
@@ -8,8 +8,8 @@ defmodule Cog.Queries.Command.Test do
 
   setup do
     {:ok, bundle} = Repo.insert(%Bundle{name: "test_bundle", config_file: %{}, manifest_file: %{}})
-    {:ok, qualified_command} = Command.insert_new(%{name: "drop_database", version: "1.0.0", bundle_id: bundle.id})
-    {:ok, shorthand_command} = Command.insert_new(%{name: "test_bundle", version: "1.0.0", bundle_id: bundle.id})
+    {:ok, qualified_command} = Command.insert_new(%{name: "drop_database", bundle_id: bundle.id})
+    {:ok, shorthand_command} = Command.insert_new(%{name: "test_bundle", bundle_id: bundle.id})
     {:ok, [bundle: bundle.name,
            qualified_command: qualified_command.name,
            shorthand_command: shorthand_command.name]}

--- a/test/cog/rule_test.exs
+++ b/test/cog/rule_test.exs
@@ -6,7 +6,7 @@ defmodule RuleTest do
 
   setup do
     bundle = Bundle.changeset(%Bundle{}, %{name: "test_bundle", config_file: %{}, manifest_file: %{}}) |> Repo.insert!
-    {:ok, command} = Command.insert_new(%{name: "pugbomb", version: "1.0.0", bundle_id: bundle.id})
+    {:ok, command} = Command.insert_new(%{name: "pugbomb", bundle_id: bundle.id})
     {:ok, [command: command]}
   end
 
@@ -30,7 +30,7 @@ defmodule RuleTest do
       bundle = Bundle.changeset(%Bundle{}, %{name: "test_bundle", config_file: %{}, manifest_file: %{}}) |> Repo.insert!
       rule_text = "when command is s3:list must have s3:delete"
       {:ok, expr, _} = Piper.Permissions.Parser.parse(rule_text)
-      {:ok, command} = Command.insert_new(%{name: "pugbomb", version: "1.0.0", bundle_id: bundle.id})
+      {:ok, command} = Command.insert_new(%{name: "pugbomb", bundle_id: bundle.id})
       {:ok, rule} = Rule.insert_new(command, expr)
       {:ok, [rule: rule,
              permission: permission("pugbomb:create")]}

--- a/test/support/database_test_setup.ex
+++ b/test/support/database_test_setup.ex
@@ -24,7 +24,7 @@ defmodule DatabaseTestSetup do
   @doc """
   Create a command with the given name
   """
-  def command(name, version \\ "1.0.0") do
+  def command(name) do
     bundle = case Repo.get_by(Bundle, name: "cog") do
       nil ->
         bundle("cog")
@@ -33,7 +33,7 @@ defmodule DatabaseTestSetup do
     end
 
     %Command{}
-    |> Command.changeset(%{name: name, version: version, bundle_id: bundle.id})
+    |> Command.changeset(%{name: name, bundle_id: bundle.id})
     |> Repo.insert!
   end
 


### PR DESCRIPTION
Bundles will have versions soon, but commands are losing them now. There
should be no user-facing effects on this change, as we weren't really
using command versions anyway; they're vestigial from an earlier design.

See also https://github.com/operable/spanner/pull/41, but that is actually independent of this change, and not necessary for this to be merged.