### PR TITLE
Command variable fix

### DIFF
--- a/lib/cog/command/alias_expander.ex
+++ b/lib/cog/command/alias_expander.ex
@@ -68,6 +68,6 @@ defmodule Cog.Command.AliasExpander do
     do: true
   defp is_alias?("user:" <> _),
     do: true
-  defp is_alias?(name) when is_binary(name),
+  defp is_alias?(_),
     do: false
 end

--- a/test/integration/command_test.exs
+++ b/test/integration/command_test.exs
@@ -113,4 +113,9 @@ defmodule Integration.CommandTest do
     response = send_message(user, ~s(@bot: seed '[{"a": "1", "b": "2"}, {"a": "3"}]' | filter --field="b" | echo $a))
     assert response["data"]["response"] == "1"
   end
+
+  test "running a pipeline with a variable that resolves to a command", %{user: user} do
+    response = send_message(user, ~s(@bot: echo "echo" | $body[0] foo))
+    assert response["data"]["response"] == "foo"
+  end
 end


### PR DESCRIPTION
Commands were crashing when a variable was used to reference them.

example: `echo echo | $body[0] foo`

resolves #308 