### PR TITLE
Database is sole source of truth for bundle status 

### DIFF
--- a/lib/cog/command/bundle_cache.ex
+++ b/lib/cog/command/bundle_cache.ex
@@ -1,0 +1,147 @@
+defmodule Cog.Command.BundleCache do
+  @moduledoc """
+  Caches for the current enabled/disabled status for bundles.
+  """
+
+  @ets_table :bundle_cache
+
+  @opaque t :: %__MODULE__{ttl: pos_integer,
+                           tref: :timer.tref,
+                           table: atom}
+  defstruct [ttl: 1,
+             tref: nil,
+             table: @ets_table]
+
+  use GenServer
+  use Adz
+
+  alias Cog.Repo
+  alias Cog.Models.Bundle
+
+  # Expired entries are removed with a period that is some multiple of
+  # the TTL; e.g., if the TTL is 60 seconds, a multiplier of 3 would
+  # result in purges every 3 minutes.
+  @purge_multiplier 3
+
+  @doc """
+  Retrieve the current activation status of the given bundle.
+  """
+  @spec status(String.t) :: {:ok, :enabled | :disabled} | {:error, term}
+  def status(bundle_name) do
+    case lookup(@ets_table, bundle_name) do
+      {:ok, status} ->
+        Logger.debug("Found cached value for key `#{bundle_name}`: #{status}")
+        {:ok, status}
+      :not_found ->
+        Logger.debug("Cache miss for key `#{bundle_name}`")
+        GenServer.call(__MODULE__, {:status, bundle_name})
+    end
+  end
+
+  def init(_) do
+    new_ets_cache_table(@ets_table)
+    ttl = resolve_ttl_in_seconds!(:bundle_cache_ttl)
+    {:ok, tref, purge_period} = purge_timer(ttl, @purge_multiplier)
+    Logger.info("Ready. Bundle cache TTL is #{ttl} seconds, with purges every #{purge_period} seconds")
+    {:ok, %__MODULE__{ttl: ttl, tref: tref, table: @ets_table}}
+  end
+
+  def handle_call({:status, bundle_name}, _caller, state) do
+    reply = case Repo.get_by(Bundle, name: bundle_name) do
+              nil ->
+                {:error, {:no_bundle, bundle_name}}
+              bundle ->
+                cache_item = cache_item(bundle.name, bool_to_status(bundle.enabled), state.ttl)
+                cached_value = cache(cache_item, state.table)
+                {:ok, cached_value}
+            end
+    {:reply, reply, state}
+  end
+
+  defp bool_to_status(true),  do: :enabled
+  defp bool_to_status(false), do: :disabled
+
+  ########################################################################
+  # Generic Functions: Everything from here onward is fair game for a
+  # generic cache behaviour
+
+  def start_link(),
+    do: GenServer.start_link(__MODULE__, [], name: __MODULE__)
+
+  ########################################################################
+  # Configuration
+
+  defp resolve_ttl_in_seconds!(config_key) do
+    ttl = :cog
+    |> Application.get_env(config_key, {60, :sec})
+    |> Cog.Config.convert(:sec)
+
+    if ttl <= 0,
+      do: raise("Must specify a non-zero positive integer for `#{config_key}`")
+    ttl
+  end
+
+  ########################################################################
+  # Cache Structure
+
+  defp new_ets_cache_table(table_name) do
+    :ets.new(table_name, [:ordered_set,
+                          :protected,
+                          :named_table,
+                          {:read_concurrency, true}])
+  end
+
+  defp lookup(table, key) do
+    now = Cog.Time.now
+    case :ets.lookup(table, key) do
+      [{^key, value, expiration}] when expiration > now ->
+        {:ok, value}
+      _ ->
+        :not_found
+    end
+  end
+
+  defp cache({_k, value, _expiration}=cache_item, table) do
+    :ets.insert(table, cache_item)
+    value
+  end
+
+  defp cache_item(key, value, ttl),
+    do: {key, value, expiration(ttl)}
+
+  ########################################################################
+  # Expired Entry Purging
+
+  defp purge_timer(ttl, multiplier) do
+    purge_period = ttl * multiplier
+    {:ok, tref} = :timer.send_interval(purge_period * 1000, :purge_cache) # timers need milliseconds
+    {:ok, tref, purge_period} # humans care about seconds, though
+  end
+
+  def handle_info(:purge_cache, state) do
+    purge_expired(state.table)
+    {:noreply, state}
+  end
+  def handle_info(_, state),
+    do: {:noreply, state}
+
+  defp expiration(ttl),
+    do: Cog.Time.now + ttl
+
+  defp purge_expired(table),
+    do: purge_expired(table, Cog.Time.now, :ets.first(table))
+
+  defp purge_expired(_table, _now, :'$end_of_table'),
+    do: true
+  defp purge_expired(table, now, key) do
+    case :ets.lookup(table, key) do
+      [{^key, _value, expiration}] when expiration < now ->
+        Logger.debug("Purging expired cache entry for `#{key}`")
+        :ets.delete(table, key);
+      _ ->
+        true
+    end
+    purge_expired(table, now, :ets.next(table, key))
+  end
+
+end

--- a/lib/cog/command/command_sup.ex
+++ b/lib/cog/command/command_sup.ex
@@ -11,6 +11,7 @@ defmodule Cog.Command.CommandSup do
     children = [worker(Command.RuleCache, []),
                 worker(Command.CommandCache, []),
                 worker(Command.UserPermissionsCache, []),
+                worker(Command.BundleCache, []),
                 supervisor(Command.Pipeline.ExecutorSup, []),
                 worker(Command.Pipeline.Initializer, [])]
     supervise(children, strategy: :one_for_one)

--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -300,21 +300,28 @@ defmodule Cog.Command.Pipeline.Executor do
   def run_command(:timeout, %__MODULE__{current_bound: current_bound,
                                         request: request}=state) do
     {bundle, name} = Models.Command.split_name(current_bound.command)
-    case Cog.Relay.Relays.pick_one(bundle) do
-      nil ->
-        msg = "No Cog Relays supporting the `#{bundle}` bundle are currently online"
+    case Cog.Command.BundleCache.status(bundle) do
+      {:ok, :enabled} ->
+        case Cog.Relay.Relays.pick_one(bundle) do
+          nil ->
+            msg = "No Cog Relays supporting the `#{bundle}` bundle are currently online"
+            Helpers.send_error(msg, state.request, state.mq_conn)
+            fail_pipeline(state, :no_relays, msg)
+          relay ->
+            topic = "/bot/commands/#{relay}/#{bundle}/#{name}"
+            reply_to_topic = "#{state.topic}/reply"
+            cog_env = maybe_add_env(current_bound, state)
+            req = request_for_invocation(current_bound, request["sender"], request["room"], request["adapter"], reply_to_topic, cog_env)
+
+            dispatch_event(state, relay)
+
+            Connection.publish(state.mq_conn, Spanner.Command.Request.encode!(req), routed_by: topic)
+            {:next_state, :wait_for_command, state, @command_timeout}
+        end
+      {:ok, :disabled} ->
+        msg = "The `#{bundle}` bundle is currently disabled"
         Helpers.send_error(msg, state.request, state.mq_conn)
         fail_pipeline(state, :no_relays, msg)
-      relay ->
-        topic = "/bot/commands/#{relay}/#{bundle}/#{name}"
-        reply_to_topic = "#{state.topic}/reply"
-        cog_env = maybe_add_env(current_bound, state)
-        req = request_for_invocation(current_bound, request["sender"], request["room"], request["adapter"], reply_to_topic, cog_env)
-
-        dispatch_event(state, relay)
-
-        Connection.publish(state.mq_conn, Spanner.Command.Request.encode!(req), routed_by: topic)
-        {:next_state, :wait_for_command, state, @command_timeout}
     end
   end
 

--- a/lib/cog/models/bundle.status.ex
+++ b/lib/cog/models/bundle.status.ex
@@ -19,16 +19,9 @@ defmodule Cog.Models.Bundle.Status do
 
   """
   def current(bundle) do
-    case Cog.Relay.Relays.bundle_status(bundle.name) do
-      {:ok, map} ->
-        %{bundle: bundle.name,
-          relays: map.relays,
-          status: map.status}
-      {:error, :no_relays_serving_bundle} ->
-        %{bundle: bundle.name,
-          relays: [],
-          status: bool_to_status(bundle.enabled)}
-    end
+    %{bundle: bundle.name,
+      relays: Cog.Relay.Relays.relays_running(bundle.name),
+      status: bool_to_status(bundle.enabled)}
   end
 
   @doc """
@@ -42,7 +35,6 @@ defmodule Cog.Models.Bundle.Status do
     if Bundle.embedded?(bundle) do
       {:error, :embedded_bundle}
     else
-      :ok = Cog.Relay.Relays.set_status(bundle.name, status)
       bundle = bundle
       |> Bundle.changeset(%{enabled: status_to_bool(status)})
       |> Repo.update!

--- a/lib/cog/models/bundle.status.ex
+++ b/lib/cog/models/bundle.status.ex
@@ -38,6 +38,10 @@ defmodule Cog.Models.Bundle.Status do
       bundle = bundle
       |> Bundle.changeset(%{enabled: status_to_bool(status)})
       |> Repo.update!
+
+      # TODO: Eventually, do this via event signaling
+      Cog.Command.BundleCache.purge(bundle.name)
+
       {:ok, bundle}
     end
   end

--- a/test/cog/relay/tracker_test.exs
+++ b/test/cog/relay/tracker_test.exs
@@ -9,27 +9,21 @@ defmodule Cog.Relay.Tracker.Test do
   @relay_three "relay_three"
 
   test "adding a single bundle works" do
-    bundle = enabled_bundle("one")
+    bundle = bundle("one")
     tracker = Tracker.add_bundles_for_relay(Tracker.new, @relay_one, [bundle])
-    assert_enabled(bundle, [@relay_one], tracker)
-  end
-
-  test "adding a new disabled bundle works" do
-    bundle = disabled_bundle("one")
-    tracker = Tracker.add_bundles_for_relay(Tracker.new, @relay_one, [bundle])
-    assert_disabled(bundle, [@relay_one], tracker)
+    assert_relays(tracker, bundle, [@relay_one])
   end
 
   test "adding multiple bundles works" do
-    bundles = ["bundle_one", "bundle_two", "bundle_three"] |> Enum.map(&enabled_bundle/1)
+    bundles = ["bundle_one", "bundle_two", "bundle_three"] |> Enum.map(&bundle/1)
     tracker = Tracker.add_bundles_for_relay(Tracker.new, @relay_one, bundles)
     for bundle <- bundles do
-      assert_enabled(bundle, [@relay_one], tracker)
+      assert_relays(tracker, bundle, [@relay_one])
     end
   end
 
   test "multiple relays can provide a bundle" do
-    bundle = enabled_bundle("bundle_one")
+    bundle = bundle("bundle_one")
 
     relays = [@relay_one, @relay_two, @relay_three]
 
@@ -38,32 +32,32 @@ defmodule Cog.Relay.Tracker.Test do
     |> Tracker.add_bundles_for_relay(@relay_two, [bundle])
     |> Tracker.add_bundles_for_relay(@relay_three, [bundle])
 
-    assert_enabled(bundle, relays, tracker)
+    assert_relays(tracker, bundle, relays)
   end
 
   test "adding bundles is an appending operation" do
-    batch_1 = Enum.map(["a", "b", "c"], &enabled_bundle/1)
-    batch_2 = Enum.map(["d", "e"], &enabled_bundle/1)
+    batch_1 = Enum.map(["a", "b", "c"], &bundle/1)
+    batch_2 = Enum.map(["d", "e"], &bundle/1)
 
     tracker = Tracker.new
     |> Tracker.add_bundles_for_relay(@relay_one, batch_1)
     |> Tracker.add_bundles_for_relay(@relay_one, batch_2)
 
     for bundle <- Enum.concat(batch_1, batch_2) do
-      assert_enabled(bundle, [@relay_one], tracker)
+      assert_relays(tracker, bundle, [@relay_one])
     end
   end
 
   test "setting bundles is an overwriting operation" do
-    batch_1 = Enum.map(["a", "b", "c"], &enabled_bundle/1)
-    batch_2 = Enum.map(["d", "e"], &enabled_bundle/1)
+    batch_1 = Enum.map(["a", "b", "c"], &bundle/1)
+    batch_2 = Enum.map(["d", "e"], &bundle/1)
 
     tracker = Tracker.new
     |> Tracker.add_bundles_for_relay(@relay_one, batch_1)
     |> Tracker.set_bundles_for_relay(@relay_one, batch_2)
 
     for bundle <- batch_2 do
-      assert_enabled(bundle, [@relay_one], tracker)
+      assert_relays(tracker, bundle, [@relay_one])
     end
 
     for bundle <- batch_1 do
@@ -73,7 +67,7 @@ defmodule Cog.Relay.Tracker.Test do
 
   test "dropping relays for bundle works" do
     # Arrange
-    bundle = enabled_bundle("a")
+    bundle = bundle("a")
 
     tracker = Tracker.new
     |> Tracker.add_bundles_for_relay(@relay_one, [bundle])
@@ -86,70 +80,22 @@ defmodule Cog.Relay.Tracker.Test do
     assert_missing(bundle, tracker)
   end
 
-  test "dropping relays for a non-existent returns tracker unchanged" do
+  test "dropping relays for a non-existent bundle returns tracker unchanged" do
     tracker_before = Tracker.new
     tracker_after = Tracker.drop_bundle(tracker_before, "non_existent_bundle")
     assert tracker_before == tracker_after
   end
 
-  test "deactivating an existing bundle" do
-    bundle = enabled_bundle("a")
-
-    tracker = Tracker.new
-    |> Tracker.add_bundles_for_relay(@relay_one, [bundle])
-
-    tracker = Tracker.disable_bundle(tracker, bundle.name)
-    assert_disabled(bundle, [@relay_one], tracker)
-  end
-
-  test "deactivating a non-existent bundle leaves tracker unchanged" do
-    tracker = Tracker.new
-    tracker_after = Tracker.disable_bundle(tracker, "non_existent_bundle")
-    assert tracker == tracker_after
-  end
-
-  test "activating an existing bundle" do
-    bundle = enabled_bundle("a")
-
-    tracker = Tracker.new
-    |> Tracker.add_bundles_for_relay(@relay_one, [bundle])
-    |> Tracker.disable_bundle(bundle.name)
-
-    assert_disabled(bundle, [@relay_one], tracker)
-
-    tracker = Tracker.enable_bundle(tracker, bundle.name)
-
-    Logger.warn(">>>>>>> tracker = #{inspect tracker}")
-
-    assert_enabled(bundle, [@relay_one], tracker)
-  end
-
-  test "activating a non-existent bundle leaves tracker unchanged" do
-    tracker = Tracker.new
-    tracker_after = Tracker.enable_bundle(tracker, "non_existent_bundle")
-    assert tracker == tracker_after
-  end
-
   ########################################################################
 
-  defp enabled_bundle(name),
-    do: %Bundle{name: name, enabled: true}
-
-  defp disabled_bundle(name),
-    do: %Bundle{name: name, enabled: false}
-
-  defp assert_enabled(bundle, expected_relays, tracker),
-    do: assert_bundle_status(tracker, bundle, :enabled, expected_relays)
-
-  defp assert_disabled(bundle, expected_relays, tracker),
-    do: assert_bundle_status(tracker, bundle, :disabled, expected_relays)
+  defp bundle(name),
+    do: %Bundle{name: name}
 
   defp assert_missing(bundle, tracker),
-    do: assert {:error, :no_relays_serving_bundle} = Tracker.bundle_status(tracker, bundle)
+    do: assert [] = Tracker.relays(tracker, bundle)
 
-  defp assert_bundle_status(tracker, bundle, expected_status, expected_relays) do
-    {:ok, %{relays: actual_relays, status: status}} = Tracker.bundle_status(tracker, bundle.name)
-    assert status == expected_status
+  defp assert_relays(tracker, bundle, expected_relays) do
+    actual_relays = Tracker.relays(tracker, bundle.name)
     assert Enum.sort(expected_relays) == Enum.sort(actual_relays)
   end
 


### PR DESCRIPTION
Previously, `Cog.Relay.Relays` was tracking not only which relays were
running a given bundle, but also the enabled/disabled status of those
bundles. Now, it tracks only which relays run which bundles, and knows
nothing of the bundles' status.

Instead, the executor now factors in the bundle status when
determining which relay to dispatch to. If the bundle is disabled, we
can now return a more accurate error message to the user (previously,
it was confusing to say that no relays were running a bundle if some
relays actually _were_, but the bundle was just disabled).

To ease the database burden for these status checks, a new bundle
cache is introduced. It is similar to other caches we have, but
implemented to use generic functions as much as possible. Hopefully
this can be the basis of a future generic cache behaviour that we can
use elsewhere.