### PR TITLE
Support Slack emojis as aliases

### DIFF
--- a/lib/cog/command/command_resolver.ex
+++ b/lib/cog/command/command_resolver.ex
@@ -5,28 +5,14 @@ defmodule Cog.Command.CommandResolver do
   alias Cog.Queries.Alias, as: AliasQuery
   alias Piper.Command.SemanticError
 
+  def find_bundle(<<":", _::binary>>=name) do
+    find_bundle_or_alias(name)
+  end
   def find_bundle(name) when is_binary(name) do
     if String.contains?(name, ":") do
       :identity
     else
-      case Repo.all(Command.bundle_for(name)) do
-        [bundle_name] ->
-          case get_alias_type(name) do
-            {:ok, alias_type} ->
-              SemanticError.new(name, {:ambiguous_alias, {bundle_name <> ":" <> name, alias_type <> ":" <> name}})
-            nil ->
-              {:ok, bundle_name}
-          end
-        [] ->
-          case get_alias_type(name) do
-            {:ok, alias_type} ->
-              {:ok, alias_type}
-            nil ->
-              SemanticError.new(name, :no_command)
-          end
-        bundle_names ->
-          SemanticError.new(name, {:ambiguous_command, bundle_names})
-      end
+      find_bundle_or_alias(name)
     end
   end
   def find_bundle(name) do
@@ -47,6 +33,27 @@ defmodule Cog.Command.CommandResolver do
         end
       _user_alias ->
         {:ok, "user"}
+    end
+  end
+
+  defp find_bundle_or_alias(name) do
+    case Repo.all(Command.bundle_for(name)) do
+      [bundle_name] ->
+        case get_alias_type(name) do
+          {:ok, alias_type} ->
+            SemanticError.new(name, {:ambiguous_alias, {bundle_name <> ":" <> name, alias_type <> ":" <> name}})
+          nil ->
+            {:ok, bundle_name}
+        end
+      [] ->
+        case get_alias_type(name) do
+          {:ok, alias_type} ->
+            {:ok, alias_type}
+          nil ->
+            SemanticError.new(name, :no_command)
+        end
+      bundle_names ->
+        SemanticError.new(name, {:ambiguous_command, bundle_names})
     end
   end
 

--- a/lib/cog/commands/alias/helpers.ex
+++ b/lib/cog/commands/alias/helpers.ex
@@ -67,7 +67,7 @@ defmodule Cog.Commands.Alias.Helpers do
   def error({:alias_not_found, alias}),
     do: "I can't find '#{alias}'. Please try again"
   def error(:bad_pattern),
-    do: "Bad pattern. Sorry, but that is an invalid pattern only letters numbers and the following special characters are allowed: *, -, _"
+    do: "Invalid alias name. Only emoji, letters, numbers, and the following special characters are allowed: *, -, _"
   def error(:too_many_wildcards),
     do: "Too many wildcards. You can only include one wildcard in a query"
   def error(:no_subcommand),

--- a/lib/cog/commands/alias/ls.ex
+++ b/lib/cog/commands/alias/ls.ex
@@ -130,7 +130,7 @@ defmodule Cog.Commands.Alias.Ls do
 
   # Check that only valid characters have been passed.
   defp valid_characters(pattern) do
-    case Regex.match?(~r/^[a-zA-Z0-9-_*]*$/, pattern) do
+    case Regex.match?(~r/^:?[a-zA-Z0-9-_*]+:?$/, pattern) do
       true ->
         :ok
       false ->

--- a/lib/cog/models/command.ex
+++ b/lib/cog/models/command.ex
@@ -40,11 +40,16 @@ defmodule Cog.Models.Command do
   name.
   """
   def split_name(name) do
-    case String.split(name, ":", parts: 2) do
+    case String.split(name, "::", parts: 2) do
       [bundle, command] ->
         {bundle, command}
-      [command] ->
-        {command, command}
+      [_] ->
+        case String.split(name, ":", parts: 2) do
+          [bundle, command] ->
+            {bundle, command}
+          [_] ->
+            {name, name}
+        end
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -61,7 +61,7 @@ defmodule Cog.Mixfile do
      {:hedwig, "~> 0.3.0"},
      {:gproc, "~> 0.5.0", override: true},
      {:html_entities, "~> 0.3.0"},
-     {:spanner, git: "git@github.com:operable/spanner", branch: "kevsmith/emojis"},
+     {:spanner, git: "git@github.com:operable/spanner", ref: "cc46321b5987c5c000dc46ed98f8fe8918239a88"},
      {:probe, github: "operable/probe", tag: "0.2"},
      {:exml, github: "paulgray/exml", tag: "2.2.1"},
      {:fumanchu, github: "operable/fumanchu", ref: "cog-0.2"},

--- a/mix.exs
+++ b/mix.exs
@@ -61,7 +61,7 @@ defmodule Cog.Mixfile do
      {:hedwig, "~> 0.3.0"},
      {:gproc, "~> 0.5.0", override: true},
      {:html_entities, "~> 0.3.0"},
-     {:spanner, github: "operable/spanner", branch: "kevsmith/enable-ssl"},
+     {:spanner, git: "git@github.com:operable/spanner", branch: "kevsmith/emojis"},
      {:probe, github: "operable/probe", tag: "0.2"},
      {:exml, github: "paulgray/exml", tag: "2.2.1"},
      {:fumanchu, github: "operable/fumanchu", ref: "cog-0.2"},

--- a/mix.exs
+++ b/mix.exs
@@ -61,7 +61,7 @@ defmodule Cog.Mixfile do
      {:hedwig, "~> 0.3.0"},
      {:gproc, "~> 0.5.0", override: true},
      {:html_entities, "~> 0.3.0"},
-     {:spanner, git: "git@github.com:operable/spanner", ref: "cc46321b5987c5c000dc46ed98f8fe8918239a88"},
+     {:spanner, github: "operable/spanner", ref: "cc46321b5987c5c000dc46ed98f8fe8918239a88"},
      {:probe, github: "operable/probe", tag: "0.2"},
      {:exml, github: "paulgray/exml", tag: "2.2.1"},
      {:fumanchu, github: "operable/fumanchu", ref: "cog-0.2"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"adz": {:git, "https://github.com/operable/adz.git", "601ceb3a19716ea635a7cd83c05f5593f5cf6c40", [tag: "0.2"]},
-  "carrier": {:git, "https://github.com/operable/carrier.git", "e0414896df27cf3228d5f1a258a7d9df80a8ee0c", [branch: "kevsmith/enable-ssl"]},
+  "carrier": {:git, "https://github.com/operable/carrier.git", "e0414896df27cf3228d5f1a258a7d9df80a8ee0c", [tag: "0.2"]},
   "certifi": {:hex, :certifi, "0.3.0"},
   "comeonin": {:hex, :comeonin, "2.1.1"},
   "connection": {:hex, :connection, "1.0.2"},
@@ -49,7 +49,7 @@
   "probe": {:git, "https://github.com/operable/probe.git", "c8ebf0877651b3cc5370e3f6ca7790a277106016", [tag: "0.2"]},
   "ranch": {:hex, :ranch, "1.2.1"},
   "slack": {:hex, :slack, "0.4.2"},
-  "spanner": {:git, "git@github.com:operable/spanner", "cc46321b5987c5c000dc46ed98f8fe8918239a88", [ref: "cc46321b5987c5c000dc46ed98f8fe8918239a88"]},
+  "spanner": {:git, "https://github.com/operable/spanner.git", "cc46321b5987c5c000dc46ed98f8fe8918239a88", [ref: "cc46321b5987c5c000dc46ed98f8fe8918239a88"]},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
   "uuid": {:hex, :uuid, "1.1.3"},
   "websocket_client": {:git, "https://github.com/jeremyong/websocket_client.git", "f6892c8b55004008ce2d52be7d98b156f3e34569", [ref: "f6892c8b55004008ce2d52be7d98b156f3e34569"]}}

--- a/mix.lock
+++ b/mix.lock
@@ -40,7 +40,7 @@
   "phoenix_ecto": {:hex, :phoenix_ecto, "2.0.1"},
   "phoenix_html": {:hex, :phoenix_html, "2.5.0"},
   "phoenix_live_reload": {:hex, :phoenix_live_reload, "1.0.3"},
-  "piper": {:git, "https://github.com/operable/piper.git", "b78b673c3d6e611e1151d896d4eda393605ef0f7", [ref: "b78b673c3d6e611e1151d896d4eda393605ef0f7"]},
+  "piper": {:git, "https://github.com/operable/piper.git", "861f43fecfe9d5e18808742f4e27c16225b7d2f5", [branch: "kevsmith/emojis"]},
   "plug": {:hex, :plug, "1.1.2"},
   "poison": {:hex, :poison, "1.5.2"},
   "poolboy": {:hex, :poolboy, "1.5.1"},
@@ -49,7 +49,7 @@
   "probe": {:git, "https://github.com/operable/probe.git", "c8ebf0877651b3cc5370e3f6ca7790a277106016", [tag: "0.2"]},
   "ranch": {:hex, :ranch, "1.2.1"},
   "slack": {:hex, :slack, "0.4.2"},
-  "spanner": {:git, "https://github.com/operable/spanner.git", "66268cb01370b125d30b13f6d28e65bf143127ee", [branch: "kevsmith/enable-ssl"]},
+  "spanner": {:git, "git@github.com:operable/spanner", "648fa770bf335cb6893c34aaae242926834d60b4", [branch: "kevsmith/emojis"]},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
   "uuid": {:hex, :uuid, "1.1.3"},
   "websocket_client": {:git, "https://github.com/jeremyong/websocket_client.git", "f6892c8b55004008ce2d52be7d98b156f3e34569", [ref: "f6892c8b55004008ce2d52be7d98b156f3e34569"]}}

--- a/mix.lock
+++ b/mix.lock
@@ -40,7 +40,7 @@
   "phoenix_ecto": {:hex, :phoenix_ecto, "2.0.1"},
   "phoenix_html": {:hex, :phoenix_html, "2.5.0"},
   "phoenix_live_reload": {:hex, :phoenix_live_reload, "1.0.3"},
-  "piper": {:git, "https://github.com/operable/piper.git", "861f43fecfe9d5e18808742f4e27c16225b7d2f5", [branch: "kevsmith/emojis"]},
+  "piper": {:git, "https://github.com/operable/piper.git", "c0f65733209d985d0a25b9372ba4ecc62ea77f7f", [ref: "c0f65733209d985d0a25b9372ba4ecc62ea77f7f"]},
   "plug": {:hex, :plug, "1.1.2"},
   "poison": {:hex, :poison, "1.5.2"},
   "poolboy": {:hex, :poolboy, "1.5.1"},
@@ -49,7 +49,7 @@
   "probe": {:git, "https://github.com/operable/probe.git", "c8ebf0877651b3cc5370e3f6ca7790a277106016", [tag: "0.2"]},
   "ranch": {:hex, :ranch, "1.2.1"},
   "slack": {:hex, :slack, "0.4.2"},
-  "spanner": {:git, "git@github.com:operable/spanner", "648fa770bf335cb6893c34aaae242926834d60b4", [branch: "kevsmith/emojis"]},
+  "spanner": {:git, "git@github.com:operable/spanner", "cc46321b5987c5c000dc46ed98f8fe8918239a88", [ref: "cc46321b5987c5c000dc46ed98f8fe8918239a88"]},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
   "uuid": {:hex, :uuid, "1.1.3"},
   "websocket_client": {:git, "https://github.com/jeremyong/websocket_client.git", "f6892c8b55004008ce2d52be7d98b156f3e34569", [ref: "f6892c8b55004008ce2d52be7d98b156f3e34569"]}}

--- a/test/integration/alias_execution_test.exs
+++ b/test/integration/alias_execution_test.exs
@@ -52,4 +52,11 @@ defmodule Integration.AliasExecutionTest do
     assert Regex.match?(~r/@vanstee Error expanding alias 'user:my-alias'. Expansion goes beyond the configured limit of '\d*'./,
                         response["data"]["response"])
   end
+
+  test "alias using slack emoji works", %{user: user} do
+    send_message(user, "@bot: alias new :boom: \"echo BOOM\"")
+    response = send_message(user, "@bot: :boom:")
+    assert Regex.match?(~r/BOOM/, response["data"]["response"])
+  end
+
 end

--- a/test/integration/commands/alias_test.exs
+++ b/test/integration/commands/alias_test.exs
@@ -332,7 +332,7 @@ defmodule Integration.Commands.AliasTest do
 
   test "list aliases with an invalid pattern", %{user: user} do
     response = send_message(user, "@bot: operable:alias ls \"% &my#-*\"")
-    assert response["data"]["response"] == "@vanstee Whoops! An error occurred. Bad pattern. Sorry, but that is an invalid pattern only letters numbers and the following special characters are allowed: *, -, _"
+    assert response["data"]["response"] == "@vanstee Whoops! An error occurred. Invalid alias name. Only emoji, letters, numbers, and the following special characters are allowed: *, -, _"
   end
 
   test "list aliases with too many wildcards", %{user: user} do
@@ -342,7 +342,7 @@ defmodule Integration.Commands.AliasTest do
 
   test "list aliases with a bad pattern and too many wildcards", %{user: user} do
     response = send_message(user, "@bot: operable:alias ls \"*m++%y-*\"")
-    assert response["data"]["response"] == "@vanstee Whoops! An error occurred. Too many wildcards. You can only include one wildcard in a query\nBad pattern. Sorry, but that is an invalid pattern only letters numbers and the following special characters are allowed: *, -, _"
+    assert response["data"]["response"] == "@vanstee Whoops! An error occurred. Too many wildcards. You can only include one wildcard in a query\nInvalid alias name. Only emoji, letters, numbers, and the following special characters are allowed: *, -, _"
   end
 
   test "passing too many args", %{user: user} do


### PR DESCRIPTION
This commit adds support for Slack emojis as command aliases. It incorporates parser changes in Piper which allow alias names like `:shipit:` to be parsed and recognized as potential command or alias names.

The following changes were made to Cog:

- Slight tweak to `CommandResolver` to recognize names starting with `:`
  as potential commands or aliases and look them up.
- Tweak to `Models.Command.split_name/1` to correctly split names like
  `user::pager:` or `somebundle::thumbsup:` into bundle and command
  parts.
- Added integration test to exercise emoji alias execution

Requires Piper PR [#10](https://github.com/operable/piper/pull/10)