### PR TITLE
Convert deprecated `Ecto.Changeset.cast/3` to `Ecto.Changeset.cast/4`

### DIFF
--- a/lib/cog/models/permission.ex
+++ b/lib/cog/models/permission.ex
@@ -32,6 +32,7 @@ defmodule Cog.Models.Permission do
   end
 
   @required_fields ~w(name)
+  @optional_fields ~w()
 
   summary_fields [:id, :name, :namespace]
   detail_fields [:id, :name, :namespace]
@@ -66,7 +67,7 @@ defmodule Cog.Models.Permission do
 
   def changeset(model, params) do
     model
-    |> Changeset.cast(params, @required_fields)
+    |> Changeset.cast(params, @required_fields, @optional_fields)
     |> Changeset.unique_constraint(:name, name: "permissions_namespace_id_name_index")
   end
 

--- a/lib/cog/models/role.ex
+++ b/lib/cog/models/role.ex
@@ -16,7 +16,7 @@ defmodule Cog.Models.Role do
   detail_fields [:id, :name]
 
   @required_fields ~w(name)
-  @optional_fields []
+  @optional_fields ~w()
 
   def changeset(model, params \\ :empty) do
     model

--- a/lib/cog/models/rule.ex
+++ b/lib/cog/models/rule.ex
@@ -17,6 +17,7 @@ defmodule Cog.Models.Rule do
   end
 
   @required_fields ~w(parse_tree score)
+  @optional_fields ~w()
 
   summary_fields [:id, :score, :parse_tree]
   detail_fields [:id, :score, :parse_tree]
@@ -34,7 +35,7 @@ defmodule Cog.Models.Rule do
 
   def changeset(model, params) do
     model
-    |> Changeset.cast(params, @required_fields)
+    |> Changeset.cast(params, @required_fields, @optional_fields)
     |> unique_constraint(:no_dupes, name: "rules_command_id_parse_tree_index")
   end
 

--- a/lib/cog/models/template.ex
+++ b/lib/cog/models/template.ex
@@ -13,10 +13,11 @@ defmodule Cog.Models.Template do
   end
 
   @required_fields ~w(adapter name source)
+  @optional_fields ~w()
 
   def changeset(model, params \\ :empty) do
     model
-    |> cast(params, @required_fields)
+    |> cast(params, @required_fields, @optional_fields)
     |> unique_constraint(:name, name: :templates_bundle_id_name_index)
   end
 end

--- a/lib/cog/models/token.ex
+++ b/lib/cog/models/token.ex
@@ -9,6 +9,8 @@ defmodule Cog.Models.Token do
   end
 
   @required_fields ~w(value)
+  @optional_fields ~w()
+
   summary_fields [:value]
   detail_fields [:value]
 
@@ -32,7 +34,7 @@ defmodule Cog.Models.Token do
   """
   def changeset(model, params) do
     model
-    |> cast(params, @required_fields)
+    |> cast(params, @required_fields, @optional_fields)
     |> unique_constraint(:users_tokens_must_be_unique, name: "tokens_user_id_value_index")
   end
 


### PR DESCRIPTION
Converts all `Ecto.Changeset.cast/3` to `Ecto.Changeset.cast/4`. The builds were a tad noisy.