### PR TITLE
add a special db_error message when an alias name is already in use

### DIFF
--- a/lib/cog/commands/alias/helpers.ex
+++ b/lib/cog/commands/alias/helpers.ex
@@ -101,7 +101,13 @@ defmodule Cog.Commands.Alias.Helpers do
     do: EctoJson.render(data)
 
   # Special errors that come when there are issues with the database.
-  defp db_errors(errors),
-    do: Enum.map_join(errors, "\n", fn({key, message}) -> "#{key} #{message}" end)
+  defp db_errors(errors) do
+    Enum.map_join(errors, "\n", fn
+      ({:name, "has already been taken"}) ->
+        "The alias name is already in use."
+      ({key, message}) ->
+        "#{key} #{message}"
+    end)
+  end
 
 end

--- a/lib/cog/commands/alias/helpers.ex
+++ b/lib/cog/commands/alias/helpers.ex
@@ -102,11 +102,8 @@ defmodule Cog.Commands.Alias.Helpers do
 
   # Special errors that come when there are issues with the database.
   defp db_errors(errors) do
-    Enum.map_join(errors, "\n", fn
-      ({:name, "has already been taken"}) ->
-        "The alias name is already in use."
-      ({key, message}) ->
-        "#{key} #{message}"
+    Enum.map_join(errors, "\n", fn({key, message}) ->
+        "#{key}: #{message}"
     end)
   end
 

--- a/lib/cog/models/site_command_alias.ex
+++ b/lib/cog/models/site_command_alias.ex
@@ -21,6 +21,6 @@ defmodule Cog.Models.SiteCommandAlias do
   def changeset(model, params) do
     model
     |> cast(params, @required_fields, @optional_fields)
-    |> unique_constraint(:name, name: :site_command_aliases_name_index, message: "The alias name is already in use")
+    |> unique_constraint(:name, name: :site_command_aliases_name_index, message: "The alias name is already in use.")
   end
 end

--- a/lib/cog/models/site_command_alias.ex
+++ b/lib/cog/models/site_command_alias.ex
@@ -21,6 +21,6 @@ defmodule Cog.Models.SiteCommandAlias do
   def changeset(model, params) do
     model
     |> cast(params, @required_fields, @optional_fields)
-    |> unique_constraint(:name, name: :site_command_aliases_name_index)
+    |> unique_constraint(:name, name: :site_command_aliases_name_index, message: "The alias name is already in use")
   end
 end

--- a/lib/cog/models/user_command_alias.ex
+++ b/lib/cog/models/user_command_alias.ex
@@ -23,7 +23,7 @@ defmodule Cog.Models.UserCommandAlias do
   def changeset(model, params) do
     model
     |> cast(params, @required_fields, @optional_fields)
-    |> unique_constraint(:name, name: :user_command_aliases_name_user_id_index)
+    |> unique_constraint(:name, name: :user_command_aliases_name_user_id_index, message: "The alias name is already in use")
   end
 end
 

--- a/lib/cog/models/user_command_alias.ex
+++ b/lib/cog/models/user_command_alias.ex
@@ -23,7 +23,7 @@ defmodule Cog.Models.UserCommandAlias do
   def changeset(model, params) do
     model
     |> cast(params, @required_fields, @optional_fields)
-    |> unique_constraint(:name, name: :user_command_aliases_name_user_id_index, message: "The alias name is already in use")
+    |> unique_constraint(:name, name: :user_command_aliases_name_user_id_index, message: "The alias name is already in use.")
   end
 end
 

--- a/test/integration/commands/alias_test.exs
+++ b/test/integration/commands/alias_test.exs
@@ -27,7 +27,7 @@ defmodule Integration.Commands.AliasTest do
     send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
 
     response = send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
-    assert response["data"]["response"] == "@vanstee Whoops! An error occurred. name has already been taken"
+    assert response["data"]["response"] == "@vanstee Whoops! An error occurred. The alias name is already in use."
   end
 
   test "removing an alias", %{user: user} do
@@ -237,7 +237,7 @@ defmodule Integration.Commands.AliasTest do
     send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
 
     response = send_message(user, "@bot: operable:alias mv user:my-new-alias site")
-    assert response["data"]["response"] == "@vanstee Whoops! An error occurred. name has already been taken"
+    assert response["data"]["response"] == "@vanstee Whoops! An error occurred. The alias name is already in use."
   end
 
   test "moving an alias to user when an alias with that name already exists in user", %{user: user} do
@@ -246,7 +246,7 @@ defmodule Integration.Commands.AliasTest do
     send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
 
     response = send_message(user, "@bot: operable:alias mv site:my-new-alias user")
-    assert response["data"]["response"] == "@vanstee Whoops! An error occurred. name has already been taken"
+    assert response["data"]["response"] == "@vanstee Whoops! An error occurred. The alias name is already in use."
   end
 
   test "an alias in the 'user' visibility should return 'user'", %{user: user} do

--- a/test/integration/commands/alias_test.exs
+++ b/test/integration/commands/alias_test.exs
@@ -27,7 +27,7 @@ defmodule Integration.Commands.AliasTest do
     send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
 
     response = send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
-    assert response["data"]["response"] == "@vanstee Whoops! An error occurred. The alias name is already in use."
+    assert response["data"]["response"] == "@vanstee Whoops! An error occurred. name: The alias name is already in use."
   end
 
   test "removing an alias", %{user: user} do
@@ -237,7 +237,7 @@ defmodule Integration.Commands.AliasTest do
     send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
 
     response = send_message(user, "@bot: operable:alias mv user:my-new-alias site")
-    assert response["data"]["response"] == "@vanstee Whoops! An error occurred. The alias name is already in use."
+    assert response["data"]["response"] == "@vanstee Whoops! An error occurred. name: The alias name is already in use."
   end
 
   test "moving an alias to user when an alias with that name already exists in user", %{user: user} do
@@ -246,7 +246,7 @@ defmodule Integration.Commands.AliasTest do
     send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
 
     response = send_message(user, "@bot: operable:alias mv site:my-new-alias user")
-    assert response["data"]["response"] == "@vanstee Whoops! An error occurred. The alias name is already in use."
+    assert response["data"]["response"] == "@vanstee Whoops! An error occurred. name: The alias name is already in use."
   end
 
   test "an alias in the 'user' visibility should return 'user'", %{user: user} do


### PR DESCRIPTION
Return a clearer and better formatted error message when the name already in use error occurs during alias creation.

resolves #313 