### PR TITLE
Don't require git SSH setup for scripted install

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -13,7 +13,7 @@ REPOS="cog relay cogctl relayctl"
 COG_REPO="https://github.com/operable/cog.git"
 RELAY_REPO="https://github.com/operable/relay.git"
 COGCTL_REPO="https://github.com/operable/cogctl.git"
-RELAYCTL_REPO="https://github.com/operable/relayctl"
+RELAYCTL_REPO="https://github.com/operable/relayctl.git"
 
 # All the executables needed to clone and
 # build Cog & Relay

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -10,10 +10,10 @@ MYCHECKSUM=`shasum ${MYFULLNAME} | cut -f1 -d' '`
 RELEASE_TAG="0.2"
 
 REPOS="cog relay cogctl relayctl"
-COG_REPO="git@github.com:operable/cog"
-RELAY_REPO="git@github.com:operable/relay"
-COGCTL_REPO="git@github.com:operable/cogctl"
-RELAYCTL_REPO="git@github.com:operable/relayctl"
+COG_REPO="https://github.com/operable/cog.git"
+RELAY_REPO="https://github.com/operable/relay.git"
+COGCTL_REPO="https://github.com/operable/cogctl.git"
+RELAYCTL_REPO="https://github.com/operable/relayctl"
 
 # All the executables needed to clone and
 # build Cog & Relay


### PR DESCRIPTION
GitHub HTTPS URLs don't require you to add your SSH key to your GitHub account prior to cloning.
This is probably a much easier user-experience for someone trying to build Cog, particularly on a machine that doesn't have a key-pair generated yet at all.