### PR TITLE
IRC adapter

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -34,6 +34,12 @@ config :cog, Cog.Adapters.HipChat,
   api_token: System.get_env("HIPCHAT_API_TOKEN"),
   mention_name: System.get_env("HIPCHAT_MENTION_NAME")
 
+config :cog, Cog.Adapters.IRC,
+  host: System.get_env("IRC_HOST"),
+  port: System.get_env("IRC_PORT"),
+  channel: System.get_env("IRC_CHANNEL"),
+  nick: System.get_env("IRC_NICK")
+
 # ========================================================================
 # Commands, Bundles, and Services
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -39,6 +39,9 @@ config :cog, Cog.Adapters.IRC,
   port: System.get_env("IRC_PORT"),
   channel: System.get_env("IRC_CHANNEL"),
   nick: System.get_env("IRC_NICK"),
+  user: System.get_env("IRC_USER"),
+  name: System.get_env("IRC_NAME"),
+  password: System.get_env("IRC_PASSWORD"),
   use_ssl: System.get_env("IRC_USE_SSL") || true
 
 # ========================================================================

--- a/config/config.exs
+++ b/config/config.exs
@@ -38,7 +38,8 @@ config :cog, Cog.Adapters.IRC,
   host: System.get_env("IRC_HOST"),
   port: System.get_env("IRC_PORT"),
   channel: System.get_env("IRC_CHANNEL"),
-  nick: System.get_env("IRC_NICK")
+  nick: System.get_env("IRC_NICK"),
+  use_ssl: System.get_env("IRC_USE_SSL") || true
 
 # ========================================================================
 # Commands, Bundles, and Services

--- a/lib/cog.ex
+++ b/lib/cog.ex
@@ -56,6 +56,7 @@ defmodule Cog do
 
   def adapter_module("slack"), do: {:ok, Cog.Adapters.Slack}
   def adapter_module("hipchat"), do: {:ok, Cog.Adapters.HipChat}
+  def adapter_module("irc"), do: {:ok, Cog.Adapters.IRC}
   def adapter_module("null"), do: {:ok, Cog.Adapters.Null}
   def adapter_module("test"), do: {:ok, Cog.Adapters.Test}
   def adapter_module(bad_adapter) do

--- a/lib/cog/adapter.ex
+++ b/lib/cog/adapter.ex
@@ -6,8 +6,8 @@ defmodule Cog.Adapter do
 
       @behaviour Cog.Adapter
 
-      def receive_message(room, user_id, text) do
-        GenServer.call(__MODULE__, {:receive_message, room, user_id, text})
+      def receive_message(sender, room, message) do
+        GenServer.call(__MODULE__, {:receive_message, sender, room, message})
       end
 
       def start_link() do
@@ -21,8 +21,9 @@ defmodule Cog.Adapter do
         {:ok, %{conn: conn}}
       end
 
-      def handle_call({:receive_message, sender, room, text}, _from, state) do
-        Carrier.Messaging.Connection.publish(state.conn, payload(sender, room, text), routed_by: "/bot/commands")
+      def handle_call({:receive_message, sender, room, message}, _from, state) do
+        message = payload(sender, room, message)
+        Carrier.Messaging.Connection.publish(state.conn, message, routed_by: "/bot/commands")
         {:reply, :ok, state}
       end
 

--- a/lib/cog/adapters/config.ex
+++ b/lib/cog/adapters/config.ex
@@ -28,6 +28,7 @@ defmodule Cog.Adapters.Config do
 
     * `:required` - A value must be set for this key.
     * `:integer` - Attempt to convert the value to an integer.
+    * `:boolean` - Attempt to convert the value to an boolean.
     * `:split` - Splits a String value at comma boundaries and returns a list of the results.
 
   ### Examples:
@@ -153,7 +154,16 @@ defmodule Cog.Adapters.Config do
               "The value for configuration key #{source} in #{@config}} must be an integer."
         end
       end
-
+      defp process_option(:boolean, true, _field_spec),
+        do: true
+      defp process_option(:boolean, "true", _field_spec),
+        do: true
+      defp process_option(:boolean, false, _field_spec),
+        do: false
+      defp process_option(:boolean, "false", _field_spec),
+        do: false
+      defp process_option(:boolean, _value, {_, _, source}),
+        do: raise ArgumentError, "The value for configuration key #{source} in #{@config}} must be a boolean."
       defp process_option(:required, value, field_spec) do
         case value do
           nil ->

--- a/lib/cog/adapters/config.ex
+++ b/lib/cog/adapters/config.ex
@@ -28,7 +28,7 @@ defmodule Cog.Adapters.Config do
 
     * `:required` - A value must be set for this key.
     * `:integer` - Attempt to convert the value to an integer.
-    * `:boolean` - Attempt to convert the value to an boolean.
+    * `:boolean` - Attempt to convert the value to a boolean.
     * `:split` - Splits a String value at comma boundaries and returns a list of the results.
 
   ### Examples:

--- a/lib/cog/adapters/irc.ex
+++ b/lib/cog/adapters/irc.ex
@@ -15,7 +15,7 @@ defmodule Cog.Adapters.IRC do
   end
 
   def mention_name(name) do
-    "@" <> name
+    name
   end
 
   def name() do

--- a/lib/cog/adapters/irc.ex
+++ b/lib/cog/adapters/irc.ex
@@ -1,0 +1,28 @@
+defmodule Cog.Adapters.IRC do
+  use Cog.Adapter
+  alias Cog.Adapters.IRC
+
+  def send_message(room, message) do
+    IRC.Connection.send_message(room, message)
+  end
+
+  def lookup_room(opts) do
+    # IRC.API.lookup_room(opts)
+  end
+
+  def lookup_direct_room(opts) do
+    # IRC.API.lookup_direct_room(opts)
+  end
+
+  def mention_name(name) do
+    "@" <> name
+  end
+
+  def name() do
+    "irc"
+  end
+
+  def display_name() do
+    "IRC"
+  end
+end

--- a/lib/cog/adapters/irc.ex
+++ b/lib/cog/adapters/irc.ex
@@ -7,11 +7,11 @@ defmodule Cog.Adapters.IRC do
   end
 
   def lookup_room(opts) do
-    # IRC.API.lookup_room(opts)
+    IRC.Connection.lookup_room(opts)
   end
 
   def lookup_direct_room(opts) do
-    # IRC.API.lookup_direct_room(opts)
+    IRC.Connection.lookup_direct_room(opts)
   end
 
   def mention_name(name) do

--- a/lib/cog/adapters/irc/config.ex
+++ b/lib/cog/adapters/irc/config.ex
@@ -2,8 +2,8 @@ defmodule Cog.Adapters.IRC.Config do
   @config Cog.Adapters.IRC
   @schema [irc: [{:host,    [:required]},
                  {:port,    [:required, :integer]},
-                 {:nick,    [:required]},
                  {:channel, [:required]},
+                 {:nick,    [:required]},
                  {:use_ssl, [:required, :boolean]}]]
 
   use Cog.Adapters.Config

--- a/lib/cog/adapters/irc/config.ex
+++ b/lib/cog/adapters/irc/config.ex
@@ -1,10 +1,12 @@
 defmodule Cog.Adapters.IRC.Config do
   @config Cog.Adapters.IRC
-  @schema [irc: [{:host,    [:required]},
-                 {:port,    [:required, :integer]},
-                 {:channel, [:required]},
-                 {:nick,    [:required]},
-                 {:use_ssl, [:required, :boolean]}]]
+  @schema [irc: [{:host,     [:required]},
+                 {:port,     [:required, :integer]},
+                 {:channel,  [:required]},
+                 {:nick,     [:required]},
+                 {:user,     []},
+                 {:password, []},
+                 {:use_ssl,  [:required, :boolean]}]]
 
   use Cog.Adapters.Config
 end

--- a/lib/cog/adapters/irc/config.ex
+++ b/lib/cog/adapters/irc/config.ex
@@ -1,0 +1,10 @@
+defmodule Cog.Adapters.IRC.Config do
+  @config Cog.Adapters.IRC
+  @schema [irc: [{:host,    [:required]},
+                 {:port,    [:required, :integer]},
+                 {:nick,    [:required]},
+                 {:channel, [:required]},
+                 {:use_ssl, [:required, :boolean]}]]
+
+  use Cog.Adapters.Config
+end

--- a/lib/cog/adapters/irc/connection.ex
+++ b/lib/cog/adapters/irc/connection.ex
@@ -81,10 +81,14 @@ defmodule Cog.Adapters.IRC.Connection do
     {:reply, {:error, :invalid_options}, state}
   end
 
-  # TODO: Support passing in a password, user and name
   def handle_info({:connected, _, _}, %{client: client, config: config} = state) do
-    nick = config[:irc][:nick]
-    ExIrc.Client.logon(client, nil, nick, nick, nick)
+    password = config[:irc][:password]
+    nick     = config[:irc][:nick]
+    user     = config[:irc][:user] || nick
+    name     = config[:irc][:name] || nick
+
+    ExIrc.Client.logon(client, password, nick, user, name)
+
     {:noreply, state}
   end
 
@@ -105,7 +109,7 @@ defmodule Cog.Adapters.IRC.Connection do
     {:noreply, state}
   end
 
-  def handle_info(message, state) do
+  def handle_info(_message, state) do
     {:noreply, state}
   end
 

--- a/lib/cog/adapters/irc/connection.ex
+++ b/lib/cog/adapters/irc/connection.ex
@@ -106,7 +106,6 @@ defmodule Cog.Adapters.IRC.Connection do
   end
 
   def handle_info(message, state) do
-    IO.inspect(message)
     {:noreply, state}
   end
 

--- a/lib/cog/adapters/irc/connection.ex
+++ b/lib/cog/adapters/irc/connection.ex
@@ -1,0 +1,66 @@
+defmodule Cog.Adapters.IRC.Connection do
+  use GenServer
+  alias Cog.Adapters.IRC
+
+  defstruct [:client, :host, :port, :nick, :channel]
+
+  def send_message(room, message) do
+    GenServer.call(__MODULE__, {:send_message, room, message})
+  end
+
+  def start_link(client, host, port, nick, channel) do
+    GenServer.start_link(__MODULE__, [client, host, port, nick, channel], name: __MODULE__)
+  end
+
+  def init([client, host, port, nick, channel]) do
+    ExIrc.Client.add_handler(client, self)
+    ExIrc.Client.connect!(client, host, port)
+    {:ok, %__MODULE__{client: client, host: host, port: port, nick: nick, channel: channel}}
+  end
+
+  def handle_call({:send_message, room, message}, _from, %{client: client} = state) do
+    ExIrc.Client.msg(client, :privmsg, room["name"], message)
+    {:reply, :ok, state}
+  end
+
+  def handle_info({:connected, _, _}, %{client: client, nick: nick} = state) do
+    ExIrc.Client.logon(client, nil, nick, nick, nick)
+    {:noreply, state}
+  end
+
+  def handle_info(:logged_in, %{client: client, channel: channel} = state) do
+    ExIrc.Client.join(client, channel)
+    {:noreply, state}
+  end
+
+  def handle_info({:received, message, nick, channel}, state) do
+    with {true, message} <- mentioned?(message, state.nick) do
+      sender = %{handle: nick, id: nick}
+      room = %{name: channel, id: channel}
+      IRC.receive_message(sender, room, message)
+    end
+
+    {:noreply, state}
+  end
+
+  def handle_info(message, state) do
+    IO.inspect(message)
+    {:noreply, state}
+  end
+
+  def terminate(_reason, %{client: client}) do
+    ExIrc.Client.stop!(client)
+    :ok
+  end
+
+  defp mentioned?(message, nick) do
+    case String.starts_with?(message, nick) do
+      true ->
+        ["", message] = String.split(message, nick)
+        message = Regex.replace(~r/^:\s*/, message, "")
+        {true, message}
+      false ->
+        false
+    end
+  end
+end

--- a/lib/cog/adapters/irc/supervisor.ex
+++ b/lib/cog/adapters/irc/supervisor.ex
@@ -7,17 +7,11 @@ defmodule Cog.Adapters.IRC.Supervisor do
   end
 
   def init(_) do
-    config = Application.get_env(:cog, IRC)
-    host = Keyword.get(config, :host)
-    port = Keyword.get(config, :port) |> String.to_integer
-    nick = Keyword.get(config, :nick)
-    channel = Keyword.get(config, :channel)
-
+    config = IRC.Config.fetch_config
     {:ok, client} = ExIrc.start_client!
 
     children = [worker(IRC, []),
-                worker(IRC.Connection, [client, host, port, nick, channel])]
-
+                worker(IRC.Connection, [[client: client, config: config]])]
     supervise(children, strategy: :one_for_all)
   end
 end

--- a/lib/cog/adapters/irc/supervisor.ex
+++ b/lib/cog/adapters/irc/supervisor.ex
@@ -1,0 +1,23 @@
+defmodule Cog.Adapters.IRC.Supervisor do
+  use Supervisor
+  alias Cog.Adapters.IRC
+
+  def start_link do
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def init(_) do
+    config = Application.get_env(:cog, IRC)
+    host = Keyword.get(config, :host)
+    port = Keyword.get(config, :port) |> String.to_integer
+    nick = Keyword.get(config, :nick)
+    channel = Keyword.get(config, :channel)
+
+    {:ok, client} = ExIrc.start_client!
+
+    children = [worker(IRC, []),
+                worker(IRC.Connection, [client, host, port, nick, channel])]
+
+    supervise(children, strategy: :one_for_all)
+  end
+end

--- a/lib/cog/adapters/slack/supervisor.ex
+++ b/lib/cog/adapters/slack/supervisor.ex
@@ -1,21 +1,21 @@
 defmodule Cog.Adapters.Slack.Supervisor do
   use Supervisor
-
   import Cog.Helpers, only: [ensure_integer: 1]
+  alias Cog.Adapters.Slack
 
   def start_link do
     Supervisor.start_link(__MODULE__, [], name: __MODULE__)
   end
 
   def init(_) do
-    config = Application.get_env(:cog, Cog.Adapters.Slack)
+    config = Application.get_env(:cog, Slack)
 
     api_token = fetch_required(config, :api_token)
     cache_ttl = ensure_integer(Keyword.get(config, :api_cache_ttl))
 
-    children = [worker(Cog.Adapters.Slack, []),
-                worker(Cog.Adapters.Slack.RTMConnector, [api_token]),
-                worker(Cog.Adapters.Slack.API, [api_token, cache_ttl])]
+    children = [worker(Slack, []),
+                worker(Slack.RTMConnector, [api_token]),
+                worker(Slack.API, [api_token, cache_ttl])]
     supervise(children, strategy: :one_for_all)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,8 @@ defmodule Cog.Mixfile do
                     :postgrex,
                     :phoenix_html,
                     :comeonin,
-                    :spanner],
+                    :spanner,
+                    :exirc],
      included_applications: [:emqttd],
      mod: {Cog, []}]
   end
@@ -65,6 +66,7 @@ defmodule Cog.Mixfile do
      {:probe, github: "operable/probe", tag: "0.2"},
      {:exml, github: "paulgray/exml", tag: "2.2.1"},
      {:fumanchu, github: "operable/fumanchu", ref: "cog-0.2"},
+     {:exirc, "~> 0.9.2"},
 
      {:phoenix_live_reload, "~> 1.0.3", only: :dev},
      {:earmark, "~> 0.2.1", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -14,6 +14,7 @@
   "enacl": {:git, "https://github.com/jlouis/enacl.git", "03f93c4f7d0cb56b5a86b445cb004a3a8de2278b", [tag: "0.15.0"]},
   "esockd": {:git, "git://github.com/emqtt/esockd.git", "e6c27801bb5331d064081ef6d6af291a2878038c", [branch: "master"]},
   "ex_doc": {:hex, :ex_doc, "0.11.4"},
+  "exirc": {:hex, :exirc, "0.9.2"},
   "exjsx": {:hex, :exjsx, "3.1.0"},
   "exml": {:git, "https://github.com/paulgray/exml.git", "4ae6dea65f97764663c43d0bafb177dc702b5c3f", [tag: "2.2.1"]},
   "fs": {:hex, :fs, "0.9.2"},

--- a/priv/repo/migrations/20160301224759_add_irc_chat_provider.exs
+++ b/priv/repo/migrations/20160301224759_add_irc_chat_provider.exs
@@ -1,0 +1,14 @@
+defmodule Cog.Repo.Migrations.AddIrcChatProvider do
+  use Ecto.Migration
+  use Cog.Queries
+  alias Cog.Repo
+  alias Cog.Models.ChatProvider
+
+  def up do
+    Repo.insert!(%ChatProvider{name: "irc"})
+  end
+
+  def down do
+    Repo.delete_all(from p in ChatProvider, where: p.name == "irc")
+  end
+end


### PR DESCRIPTION
The IRC adapter works. You can set options just as you'd expect which allows cog to connect to your IRC channel (currently only 1 channel is supported). Mentioned commands and spoken commands are supported, as well as user private message redirection.

Part of this PR was to take a fresh look at the new adapter refactor and see if it is well designed. I think the refactor has improved the interface but I think there are a few extra things we can add to make it easier to write adapters in the future:

* Remove `lookup_room` calls from the executor that pass along a string. This makes for some function definitions. We should instead implement it by having each adapter identify a string as a room or a user (used for redirection) and then having the executor call `lookup_room(name: room_name)` or `lookup_direct_room(name: user_name)`.
* Add some code to the base adapter module that handles converting a message with a mentioned command or spoken command into a raw command (stripping the bot's handle or the command prefix). Something like a `parse_command` function that returns `{true, raw_command}` or `false` should do for now.

One area that I would like some help with is writing an integration test. For now I figured we could go ahead and merge this, but it'd be nice to go back and write an integration test against a real IRC server. The main problem was finding a hosted IRC service. We could standup our own IRC server on each build node but that seemed like headache to manage.

Closes #307