### PR TITLE
Remove some unused command-related queries

### DIFF
--- a/lib/cog/queries/command.ex
+++ b/lib/cog/queries/command.ex
@@ -31,16 +31,6 @@ defmodule Cog.Queries.Command do
     where: c.name == ^command
   end
 
-  def options_for(%Command{id: id}) do
-    from co in CommandOption,
-    where: co.command_id == ^id,
-    order_by: co.required
-  end
-
-  def rules_for(%Command{id: id}) do
-    from r in Rule,
-    where: r.command_id == ^id
-  end
 
   def rules_for_cmd(name) do
     {ns, name} = Models.Command.split_name(name)

--- a/test/cog/rule_ingestion_test.exs
+++ b/test/cog/rule_ingestion_test.exs
@@ -1,6 +1,5 @@
 defmodule RuleIngestionTest do
   use Cog.ModelCase
-  alias Cog.Queries
   alias Piper.Permissions.Parser
 
   test "a valid rule gets parsed and saved" do
@@ -77,7 +76,7 @@ defmodule RuleIngestionTest do
     permission("s3:delete")
     inserted_rule = rule("when command is cog:s3 with option[op] == 'delete' must have s3:delete")
 
-    %Cog.Models.Rule{parse_tree: retrieved_tree} = Queries.Command.rules_for(command) |> Cog.Repo.one!
+    %Cog.Models.Rule{parse_tree: retrieved_tree} = Repo.one!(Ecto.assoc(command, :rules))
     assert ^retrieved_tree = inserted_rule.parse_tree
   end
 


### PR DESCRIPTION
`Cog.Queries.Command.options_for/1` wasn't used.

`Cog.Queries.Command.rules_for/1` was only used in a test, which is
now rewritten.