### PR TITLE
Adapters log errors and then exit on failed configuration

### DIFF
--- a/lib/cog/adapters/config.ex
+++ b/lib/cog/adapters/config.ex
@@ -224,7 +224,7 @@ defmodule Cog.Adapters.Config do
 
   defp apply_rule(:split, nil),
     do: {:ok, nil}
-  defp apply_rule(:split, {:ok, value}) do
+  defp apply_rule(:split, value) do
     case value do
       value when is_binary(value) ->
         {:ok, String.split(value, ",")}

--- a/lib/cog/adapters/config.ex
+++ b/lib/cog/adapters/config.ex
@@ -3,11 +3,11 @@ defmodule Cog.Adapters.Config do
 
   @moduledoc """
   The Config module is used to ingest adapter configuration that is specified
-  in Mix, apply validations and type coercion, cache it in the state of a
-  GenServer, and make it available to the adapter. To use it, create new module
-  `use Cog.Adapters.Config` with a keyword list containing a `schema` key with
-  your scheam defined. This module assumes that your config is stored under the
-  `:cog` Mix configuration with a key of the new module's name.
+  in Mix and apply validations and type coercion. To use it, create new module
+  `use Cog.Adapters.Config` with a keyword list containing a `key` key for the
+  module under which your config lives and a `schema` key with your schema
+  defined. This module assumes that your config is stored under the `:cog` Mix
+  configuration with a key of the new module's name.
 
   The `schema` value should be a list of field specifications which are used to
   extract values from Mix configuration and transform them into adapter

--- a/lib/cog/adapters/config.ex
+++ b/lib/cog/adapters/config.ex
@@ -50,10 +50,11 @@ defmodule Cog.Adapters.Config do
 
       defmodule My.Adapter.SimpleConfig do
         use Cog.Adapters.Config,
+          key: Example.Config,
           schema: [:name, :description, :inital_size, :max_size]
       end
       
-      iex(1)> My.Adapter.SimpleConfig.config
+      iex(1)> My.Adapter.SimpleConfig.fetch_config!
       %{name: "Example", description: "My Example Configuration",
         initial_size: 123, max_size: 200}
       
@@ -61,6 +62,7 @@ defmodule Cog.Adapters.Config do
 
       defmodule My.Adapter.ComplexConfig do
         use Cog.Adapters.Config,
+          key: Example.Config,
           schema: [:strings, [{:name, [:required]},
                               :description
                               {:version, :hardcode, "v0.1"}],
@@ -68,7 +70,7 @@ defmodule Cog.Adapters.Config do
                               {:max, [:required, :integer], :max_size}]]
       end
       
-      iex(1)> My.Adapter.ComplexConfig.config
+      iex(1)> My.Adapter.ComplexConfig.fetch_config!
       %{strings: %{name: "Example", decription: "My Example Configuration"
                    version: "v0.1"},
         numbers: %{size: 123, max: 200}}

--- a/lib/cog/adapters/hipchat/api.ex
+++ b/lib/cog/adapters/hipchat/api.ex
@@ -1,4 +1,5 @@
 defmodule Cog.Adapters.HipChat.API do
+  alias Cog.Adapters.HipChat
   require Logger
 
   use HTTPoison.Base
@@ -146,7 +147,7 @@ defmodule Cog.Adapters.HipChat.API do
   end
 
   defp api_token do
-    Cog.Adapters.HipChat.Config.fetch_config(:api)[:token]
+    config = HipChat.Config.fetch_config!
+    config[:api][:token]
   end
-
 end

--- a/lib/cog/adapters/hipchat/config.ex
+++ b/lib/cog/adapters/hipchat/config.ex
@@ -1,17 +1,13 @@
 defmodule Cog.Adapters.HipChat.Config do
-
-  @config Cog.Adapters.HipChat
-  @schema [xmpp:
-             [{:jid, [:required], :xmpp_jid},
-              {:password, [:required], :xmpp_password},
-              {:nickname, [:required], :xmpp_nickname},
-              {:resource, [:required], :xmpp_resource},
-              {:rooms, [:required, :split], :xmpp_rooms},
-              {:handlers, :hardcode, [{Cog.Adapters.HipChat.XMPPHandler, %{}}]}],
-           api:
-             [{:token, [:required], :api_token},
-              {:mention_name, [:required]}]]
-
-  use Cog.Adapters.Config
-
+  use Cog.Adapters.Config,
+    schema: [xmpp:
+               [{:jid, [:required], :xmpp_jid},
+                {:password, [:required], :xmpp_password},
+                {:nickname, [:required], :xmpp_nickname},
+                {:resource, [:required], :xmpp_resource},
+                {:rooms, [:required, :split], :xmpp_rooms},
+                {:handlers, :hardcode, [{Cog.Adapters.HipChat.XMPPHandler, %{}}]}],
+             api:
+               [{:token, [:required], :api_token},
+                {:mention_name, [:required]}]]
 end

--- a/lib/cog/adapters/hipchat/config.ex
+++ b/lib/cog/adapters/hipchat/config.ex
@@ -1,5 +1,6 @@
 defmodule Cog.Adapters.HipChat.Config do
   use Cog.Adapters.Config,
+    key: Cog.Adapters.HipChat,
     schema: [xmpp:
                [{:jid, [:required], :xmpp_jid},
                 {:password, [:required], :xmpp_password},

--- a/lib/cog/adapters/hipchat/connection.ex
+++ b/lib/cog/adapters/hipchat/connection.ex
@@ -110,7 +110,7 @@ defmodule Cog.Adapters.HipChat.Connection do
   end
 
   defp mention_name() do
-    config = HipChat.Config.fetch_config!(:api)
+    config = HipChat.Config.fetch_config!
     config[:api][:mention_name]
   end
 end

--- a/lib/cog/adapters/hipchat/connection.ex
+++ b/lib/cog/adapters/hipchat/connection.ex
@@ -6,11 +6,13 @@ defmodule Cog.Adapters.HipChat.Connection do
   defstruct xmpp_conn: nil
 
   def start_link() do
-    GenServer.start_link(__MODULE__, HipChat.Config.fetch_config, name: __MODULE__)
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
-  def init(config) do
+  def init([]) do
     HipChat.API.start
+
+    config = HipChat.Config.fetch_config!
 
     {:ok, xmpp_conn} = config[:xmpp]
     |> Map.put(:config, xmpp_server_options)
@@ -108,7 +110,7 @@ defmodule Cog.Adapters.HipChat.Connection do
   end
 
   defp mention_name() do
-    HipChat.Config.fetch_config(:api)
-    |> Access.get(:mention_name)
+    config = HipChat.Config.fetch_config!(:api)
+    config[:api][:mention_name]
   end
 end

--- a/lib/cog/adapters/hipchat/supervisor.ex
+++ b/lib/cog/adapters/hipchat/supervisor.ex
@@ -7,10 +7,8 @@ defmodule Cog.Adapters.HipChat.Supervisor do
   end
 
   def init(_) do
-    config = HipChat.Config.fetch_config!
-
     children = [worker(HipChat, []),
-                worker(HipChat.Connection, [config])]
+                worker(HipChat.Connection, [])]
 
     supervise(children, strategy: :one_for_all)
   end

--- a/lib/cog/adapters/hipchat/supervisor.ex
+++ b/lib/cog/adapters/hipchat/supervisor.ex
@@ -1,13 +1,17 @@
 defmodule Cog.Adapters.HipChat.Supervisor do
   use Supervisor
+  alias Cog.Adapters.HipChat
 
   def start_link() do
     Supervisor.start_link(__MODULE__, [])
   end
 
   def init(_) do
-    children = [worker(Cog.Adapters.HipChat, []),
-                worker(Cog.Adapters.HipChat.Connection, [])]
+    config = HipChat.Config.fetch_config!
+
+    children = [worker(HipChat, []),
+                worker(HipChat.Connection, [config])]
+
     supervise(children, strategy: :one_for_all)
   end
 end

--- a/lib/cog/adapters/irc/config.ex
+++ b/lib/cog/adapters/irc/config.ex
@@ -1,12 +1,13 @@
 defmodule Cog.Adapters.IRC.Config do
-  @config Cog.Adapters.IRC
-  @schema [irc: [{:host,     [:required]},
-                 {:port,     [:required, :integer]},
-                 {:channel,  [:required]},
-                 {:nick,     [:required]},
-                 {:user,     []},
-                 {:password, []},
-                 {:use_ssl,  [:required, :boolean]}]]
-
-  use Cog.Adapters.Config
+  use Cog.Adapters.Config,
+    key: Cog.Adapters.IRC,
+    schema:
+      [irc:
+        [{:host,    [:required]},
+         {:port,    [:required, :integer]},
+         {:channel, [:required]},
+         {:nick,    [:required]},
+         :user,
+         :password,
+         {:use_ssl, [:required, :boolean]}]]
 end

--- a/lib/cog/adapters/irc/supervisor.ex
+++ b/lib/cog/adapters/irc/supervisor.ex
@@ -7,7 +7,7 @@ defmodule Cog.Adapters.IRC.Supervisor do
   end
 
   def init(_) do
-    config = IRC.Config.fetch_config
+    config = IRC.Config.fetch_config!
     {:ok, client} = ExIrc.start_client!
 
     children = [worker(IRC, []),

--- a/test/cog/adapters/config_test.exs
+++ b/test/cog/adapters/config_test.exs
@@ -95,26 +95,11 @@ defmodule Cog.Adapters.ConfigTest do
                 how_many_cheeseburgers: 5],
                Cog.Adapters.ConfigTest.TestConfig)
 
-    {:ok, config} = TestConfig.config
+    {:ok, config} = TestConfig.fetch_config
 
     assert config == %{testy: "mctesterson",
                        double: "check",
                        how_many_cheeseburgers: 5}
-  end
-
-  test "configs are cached" do
-    defmodule TestCachedConfig do
-      use Cog.Adapters.Config,
-        schema: [{:testy, [:required], :testy}]
-    end
-
-    put_config([testy: "mctesterson"], Cog.Adapters.ConfigTest.TestCachedConfig)
-    {:ok, config} = TestCachedConfig.config
-    assert config == %{testy: "mctesterson"}
-
-    put_config([testy: "mcnuggets"], Cog.Adapters.ConfigTest.TestCachedConfig)
-    {:ok, config} = TestCachedConfig.config
-    assert config == %{testy: "mctesterson"}
   end
 
   defp put_config(config, module \\ TestConfig) do

--- a/test/cog/adapters/config_test.exs
+++ b/test/cog/adapters/config_test.exs
@@ -1,0 +1,123 @@
+defmodule Cog.Adapters.ConfigTest do
+  use ExUnit.Case, async: true
+  alias Cog.Adapters.Config
+
+  test "simple config" do
+    put_config(
+      name: "Example",
+      description: "My Example Configuration",
+      initial_size: "123",
+      max_size: 200
+    )
+
+    schema = [:name, :description, :initial_size, :max_size]
+
+    {:ok, config} = Config.fetch_config(TestConfig, schema)
+
+    assert config == %{
+      name: "Example",
+      description: "My Example Configuration",
+      initial_size: "123",
+      max_size: 200
+    }
+  end
+
+  test "config mapping" do
+    put_config(
+      name: "Example",
+      description: "My Example Configuration",
+      initial_size: "123",
+      max_size: 200
+    )
+
+    schema = [
+      strings: [
+        {:name, [:required]},
+        :description,
+        {:version, :hardcode, "v0.1"}
+      ],
+      numbers: [
+        {:size, [:integer], :initial_size},
+        {:max, [:required, :integer], :max_size}
+      ]
+    ]
+
+    {:ok, config} = Config.fetch_config(TestConfig, schema)
+
+    assert config == %{
+      strings: %{
+        name: "Example",
+        description: "My Example Configuration",
+        version: "v0.1"
+      },
+      numbers: %{
+        size: 123,
+        max: 200
+      }
+    }
+  end
+
+  test "config with mising keys" do
+    put_config([])
+    {:error, config} = Config.fetch_config(TestConfig, [{:testy, [:required], :testy}])
+    assert config == %{testy: [:missing_required_key]}
+  end
+
+  test "config with uncoercable types" do
+    put_config(how_many_cheeseburgers: "five")
+    {:error, config} = Config.fetch_config(TestConfig, [{:how_many_cheeseburgers, [:integer], :how_many_cheeseburgers}])
+    assert config == %{how_many_cheeseburgers: [:unable_to_parse_integer]}
+  end
+
+  test "config with correct and incorrect values" do
+    put_config(double: "check",
+               how_many_cheeseburgers: "five",
+               another: "env var")
+
+    {:error, config} = Config.fetch_config(TestConfig,
+                                           [{:testy, [:required, :boolean]},
+                                             {:double, :hardcode, "triple"},
+                                             {:how_many_cheeseburgers, [:integer]},
+                                             {:optional, []}])
+
+    assert config == %{testy: [:missing_required_key],
+                       how_many_cheeseburgers: [:unable_to_parse_integer]}
+  end
+
+  test "module with config" do
+    defmodule TestConfig do
+      use Cog.Adapters.Config,
+        schema: [:testy, :double, :how_many_cheeseburgers]
+    end
+
+    put_config([testy: "mctesterson",
+                double: "check",
+                how_many_cheeseburgers: 5],
+               Cog.Adapters.ConfigTest.TestConfig)
+
+    {:ok, config} = TestConfig.config
+
+    assert config == %{testy: "mctesterson",
+                       double: "check",
+                       how_many_cheeseburgers: 5}
+  end
+
+  test "configs are cached" do
+    defmodule TestCachedConfig do
+      use Cog.Adapters.Config,
+        schema: [{:testy, [:required], :testy}]
+    end
+
+    put_config([testy: "mctesterson"], Cog.Adapters.ConfigTest.TestCachedConfig)
+    {:ok, config} = TestCachedConfig.config
+    assert config == %{testy: "mctesterson"}
+
+    put_config([testy: "mcnuggets"], Cog.Adapters.ConfigTest.TestCachedConfig)
+    {:ok, config} = TestCachedConfig.config
+    assert config == %{testy: "mctesterson"}
+  end
+
+  defp put_config(config, module \\ TestConfig) do
+    Application.put_env(:cog, module, config)
+  end
+end


### PR DESCRIPTION
Now if `Cog.Adapters.Config` is used to require keys or specifies types, the adapter will fail to startup when the config is invalid and any specific errors will be logged as errors. Here's an example of what happens if you forget to include HipChat's config.

```
2016-03-08T16:31:31.0519  (Cog.Adapters.Config:115) [error] Required key :mention_name was not provided
2016-03-08T16:31:31.0519  (Cog.Adapters.Config:115) [error] Required key :token was not provided
2016-03-08T16:31:31.0519  (Cog.Adapters.Config:115) [error] Required key :jid was not provided
2016-03-08T16:31:31.0519  (Cog.Adapters.Config:115) [error] Required key :password was not provided
2016-03-08T16:31:31.0519  (Cog.Adapters.Config:115) [error] Required key :rooms was not provided
2016-03-08T16:31:31.0535  () [info] Application cog exited: Cog.start(:normal, []) returned an error: shutdown: failed to start child: Cog.Adapters.HipChat.Supervisor
    ** (EXIT) an exception was raised:
        ** (RuntimeError) Invalid config found for Cog.Adapters.HipChat
            (cog) lib/cog/adapters/config.ex:116: Cog.Adapters.Config.fetch_config!/2
            (cog) lib/cog/adapters/hipchat/supervisor.ex:10: Cog.Adapters.HipChat.Supervisor.init/1
            (stdlib) supervisor.erl:272: :supervisor.init/1
            (stdlib) gen_server.erl:328: :gen_server.init_it/6
            (stdlib) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
```

To accomplish this I had to refactor the `Cog.Adapters.Config`. It's no longer a `GenServer` with a supervisor. If caching is required, it should be sent into a process as config. Adding that work to the HipChat adapter will happen in a future PR.