### PR TITLE
Issue #362: Make first_name and last_name optional fields

### DIFF
--- a/lib/cog/models/user.ex
+++ b/lib/cog/models/user.ex
@@ -30,8 +30,8 @@ defmodule Cog.Models.User do
     timestamps
   end
 
-  @required_fields ~w(username first_name last_name email_address)
-  @optional_fields ~w(password)
+  @required_fields ~w(username email_address)
+  @optional_fields ~w(first_name last_name password)
 
   summary_fields [:id, :first_name, :last_name, :email_address, :username]
   detail_fields [:id, :first_name, :last_name, :email_address, :username]

--- a/priv/repo/migrations/20160309201354_first_name_last_name_optional.exs
+++ b/priv/repo/migrations/20160309201354_first_name_last_name_optional.exs
@@ -1,0 +1,10 @@
+defmodule Cog.Repo.Migrations.FirstNameLastNameOptional do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      modify :first_name, :text, null: true
+      modify :last_name, :text, null: true
+    end
+  end
+end


### PR DESCRIPTION
The first and last names in the User model should be optional fields. We allow the database to accept null values for first and last names.

Fixes #362