### PR TITLE
Add a basic glossary outline

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -1,0 +1,22 @@
+# Cog Glossary
+
+## Bundle
+## Command
+### Subcommand
+## Group
+## Permission
+  * A way to define what commands can be accessed
+  * Come with bundles
+  * Can be created custom in the `site:` namespace
+
+### Examples:
+  * `operable:manage_commands`
+  * `ec2:delete`
+
+## Relay
+## Role
+  * Group of permissions
+  * Can be attached to a group
+## Rule
+## Tag
+## User


### PR DESCRIPTION
This starts the basic of a glossary in the repo. This is something we've talked about a bit while moving forward in development and I wanted to get a structure started so that we could start adding to it.

Some of this information is already in the Wiki so you're probably asking yourself "Why would we move this into the repo?" I'm glad you asked!

1. Moving it into the repo allows it to be versioned alongside the code. As the code changes and new ideas and concepts are added and removed, this file can change with the code. It may fall out of date at periods, that inevitable but if properly maintained, you can look back at a previous release and understand the concepts that are particular to that release that may have changed in a newer release.

2. Wikis do not have any way of reviewing feedback. If I have something I'd like to add to the Wiki and I add it, it may be 100% wrong and no one realizes that. Moving this to the repo allows me to get feedback before it's merged.

3. Wikis do not allow external contributions (at least not that I'm aware of). I'd like to be able to update this without having access to the repo. That's not possible with a Wiki. Moving this also makes it easy for the community to get involved with updating it.

I haven't filled in much as my understanding is still kind of vague but I wanted something to start adding PRs against.