### PR TITLE
Check HipChat config when starting the HipChat Adapater

### DIFF
--- a/lib/cog/adapters/hipchat/api.ex
+++ b/lib/cog/adapters/hipchat/api.ex
@@ -145,18 +145,18 @@ defmodule Cog.Adapters.HipChat.API do
     end
   end
 
-  def include_headers(options, config) do
+  defp include_headers(options, config) do
     headers = request_headers(config)
     Keyword.update(options, :headers, headers, &(headers ++ &1))
   end
 
-  def request_headers(%{token: token}) do
+  defp request_headers(%{token: token}) do
     ["Accept":        "application/json",
      "Content-Type":  "application/json",
      "Authorization": "Bearer #{token}"]
   end
 
-  def encode_body(options) do
+  defp encode_body(options) do
     case Keyword.has_key?(options, :body) do
       true ->
         Keyword.update!(options, :body, &Poison.encode!/1)
@@ -165,15 +165,15 @@ defmodule Cog.Adapters.HipChat.API do
     end
   end
 
-  def normalize_user(%{"id" => id, "mention_name" => handle, "name" => name}) do
+  defp normalize_user(%{"id" => id, "mention_name" => handle, "name" => name}) do
     %{id: id, handle: handle, name: name}
   end
 
-  def normalize_room(%{"id" => id, "name" => name}) do
+  defp normalize_room(%{"id" => id, "name" => name}) do
     %{id: id, name: name}
   end
 
-  def normalize_message(%{"message" => message}) do
+  defp normalize_message(%{"message" => message}) do
     message
   end
 end

--- a/lib/cog/adapters/hipchat/api.ex
+++ b/lib/cog/adapters/hipchat/api.ex
@@ -1,6 +1,5 @@
 defmodule Cog.Adapters.HipChat.API do
   use GenServer
-  alias Cog.Adapters.HipChat
 
   @base_uri "https://api.hipchat.com/v2"
   @timeout 15000 # 15 seconds

--- a/lib/cog/adapters/hipchat/api.ex
+++ b/lib/cog/adapters/hipchat/api.ex
@@ -76,13 +76,9 @@ defmodule Cog.Adapters.HipChat.API do
 
   def handle_call({:lookup_room, name: room_name}, _from, state) do
     uri = "/room/#{room_name}"
-    result = get(state.client, uri)
 
-    result = case result do
-      {:ok, room} ->
-        {:ok, normalize_room(room)}
-      error ->
-        error
+    result = with {:ok, room} <- get(state.client, uri) do
+      {:ok, normalize_room(room)}
     end
 
     {:reply, result, state}
@@ -92,11 +88,8 @@ defmodule Cog.Adapters.HipChat.API do
     uri = "/user/#{user_id}"
     result = get(state.client, uri)
 
-    result = case result do
-      {:ok, user} ->
-        {:ok, normalize_user(user)}
-      error ->
-        error
+    result = with {:ok, user} <- result do
+      {:ok, normalize_user(user)}
     end
 
     {:reply, result, state}
@@ -106,11 +99,8 @@ defmodule Cog.Adapters.HipChat.API do
     uri = "/user"
     result = get(state.client, uri)
 
-    result = case result do
-      {:ok, %{"items" => users}} ->
-        {:ok, Enum.map(users, &normalize_user/1)}
-      error ->
-        error
+    result = with {:ok, %{"items" => users}} <- result do
+      {:ok, Enum.map(users, &normalize_user/1)}
     end
 
     {:reply, result, state}
@@ -122,11 +112,8 @@ defmodule Cog.Adapters.HipChat.API do
     uri = path <> "?" <> query
     result = get(state.client, uri)
 
-    result = case result do
-      {:ok, %{"items" => [_sent_message, message|_]}} ->
-        {:ok, normalize_message(message)}
-      error ->
-        error
+    result = with {:ok, %{"items" => [_sent_message, message|_]}} <- result do
+      {:ok, normalize_message(message)}
     end
 
     {:reply, result, state}

--- a/lib/cog/adapters/hipchat/supervisor.ex
+++ b/lib/cog/adapters/hipchat/supervisor.ex
@@ -7,7 +7,10 @@ defmodule Cog.Adapters.HipChat.Supervisor do
   end
 
   def init(_) do
+    config = HipChat.Config.fetch_config!
+
     children = [worker(HipChat, []),
+                worker(HipChat.API, [config]),
                 worker(HipChat.Connection, [])]
 
     supervise(children, strategy: :one_for_all)

--- a/lib/cog/adapters/hipchat/supervisor.ex
+++ b/lib/cog/adapters/hipchat/supervisor.ex
@@ -11,7 +11,7 @@ defmodule Cog.Adapters.HipChat.Supervisor do
 
     children = [worker(HipChat, []),
                 worker(HipChat.API, [config]),
-                worker(HipChat.Connection, [])]
+                worker(HipChat.Connection, [config])]
 
     supervise(children, strategy: :one_for_all)
   end

--- a/test/cog/adapters/hipchat/api_test.exs
+++ b/test/cog/adapters/hipchat/api_test.exs
@@ -11,7 +11,7 @@ defmodule Cog.Adapters.HipChat.APITest do
   end
 
   test "looking up a room" do
-    assert {:ok, %{"name" => "ci_bot_testing"}} = HipChat.API.lookup_room(name: "ci_bot_testing")
+    assert {:ok, %{id: 2223837, name: "ci_bot_testing"}} = HipChat.API.lookup_room(name: "ci_bot_testing")
   end
 
   test "looking up a room that doesn't exist"  do
@@ -24,6 +24,6 @@ defmodule Cog.Adapters.HipChat.APITest do
 
   test "sending a message" do
     {:ok, room} = HipChat.API.lookup_room(name: "ci_bot_testing")
-    assert {:ok, _} = HipChat.API.send_message(room, "test")
+    assert {:ok, _} = HipChat.API.send_message(%{"id" => room.id}, "test")
   end
 end

--- a/test/cog/adapters/hipchat/api_test.exs
+++ b/test/cog/adapters/hipchat/api_test.exs
@@ -1,0 +1,29 @@
+defmodule Cog.Adapters.HipChat.APITest do
+  use ExUnit.Case
+  alias Cog.Adapters.HipChat
+
+  @moduletag :hipchat
+
+  setup do
+    config = HipChat.Config.fetch_config!
+    HipChat.API.start_link(config)
+    :ok
+  end
+
+  test "looking up a room" do
+    assert {:ok, %{"name" => "ci_bot_testing"}} = HipChat.API.lookup_room(name: "ci_bot_testing")
+  end
+
+  test "looking up a room that doesn't exist"  do
+    assert {:error, %{"message" => "Room 'banana_stand' not found"}} = HipChat.API.lookup_room(name: "banana_stand")
+  end
+
+  test "looking up a direct room" do
+    assert {:ok, %{"direct" => 479543}} = HipChat.API.lookup_direct_room(user_id: 479543)
+  end
+
+  test "sending a message" do
+    {:ok, room} = HipChat.API.lookup_room(name: "ci_bot_testing")
+    assert {:ok, _} = HipChat.API.send_message(room, "test")
+  end
+end

--- a/test/support/adapters/hipchat/helpers.ex
+++ b/test/support/adapters/hipchat/helpers.ex
@@ -9,14 +9,16 @@ defmodule Cog.Adapters.HipChat.Helpers do
   @timeout 120000 # 2 minutes
 
   def send_message(%User{username: _username}, message) do
-    HipChat.send_message(%{"id" => @room}, message)
+    {:ok, message} = HipChat.send_message(%{"id" => @room}, message)
+    message
   end
 
-  def assert_response(message, [after: %{"id" => id}]) do
+  def assert_response(message, after: %{"id" => id}) do
     :timer.sleep(@interval)
 
     last_message_func = fn ->
-      HipChat.API.retrieve_last_message(@room, id)
+      {:ok, message} = HipChat.API.retrieve_last_message(@room, id)
+      message
     end
 
     Assertions.polling_assert(message, last_message_func, @interval, @timeout)


### PR DESCRIPTION
We now validate the config and then also try to make an authenticated request when starting the HipChat.API process. To do that (and avoid having to cache the config) we converted the HipChat.API module into a GenServer so we have a good place to check the config and crash the entire Cog application as well as hold onto the config between API calls.