### PR TITLE
send a room map to send_message instead of just the id

### DIFF
--- a/lib/cog/adapters/slack/rtm_connector.ex
+++ b/lib/cog/adapters/slack/rtm_connector.ex
@@ -108,7 +108,10 @@ defmodule Cog.Adapters.Slack.RTMConnector do
                               fn() -> handle_command(room, user_id, text, state) end}
                          end
     unless message == nil do
-      Slack.API.send_message(channel, message)
+      {:ok, room} = Slack.API.lookup_room(id: channel)
+      room = %{"id" => room.id,
+               "name" => room.name}
+      Slack.API.send_message(room, message)
     end
     handler.()
   end


### PR DESCRIPTION
Cog was silently failing when a user tried to edit a command. The issue centered around us sending the channel id to send_message instead of a room map.

resolves #405