### PR TITLE
Peck/edited commands fix

### DIFF
--- a/lib/cog/adapters/slack/api.ex
+++ b/lib/cog/adapters/slack/api.ex
@@ -15,8 +15,8 @@ defmodule Cog.Adapters.Slack.API do
     GenServer.start_link(__MODULE__, config, name: @server_name)
   end
 
-  def send_message(room, message) when is_binary(message) do
-    GenServer.call(@server_name, {:send_message, room, message}, :infinity)
+  def send_message(%{"id" => id}, message) when is_binary(message) do
+    GenServer.call(@server_name, {:send_message, id, message}, :infinity)
   end
 
   def lookup_user(key) when is_tuple(hd(key)) do
@@ -98,8 +98,8 @@ defmodule Cog.Adapters.Slack.API do
     end
   end
 
-  def handle_call({:send_message, room, message}, _from, state) do
-    result = call_api!("chat.postMessage", state.token, body: %{channel: room["id"], text: message, as_user: true, parse: "full"})
+  def handle_call({:send_message, room_id, message}, _from, state) do
+    result = call_api!("chat.postMessage", state.token, body: %{channel: room_id, text: message, as_user: true, parse: "full"})
     reply = case result["ok"] do
       true ->
         {:ok, result["message"]}

--- a/lib/cog/adapters/slack/rtm_connector.ex
+++ b/lib/cog/adapters/slack/rtm_connector.ex
@@ -108,10 +108,7 @@ defmodule Cog.Adapters.Slack.RTMConnector do
                               fn() -> handle_command(room, user_id, text, state) end}
                          end
     unless message == nil do
-      {:ok, room} = Slack.API.lookup_room(id: channel)
-      room = %{"id" => room.id,
-               "name" => room.name}
-      Slack.API.send_message(room, message)
+      Slack.API.send_message(%{"id" => channel}, message)
     end
     handler.()
   end

--- a/lib/cog/adapters/slack/rtm_connector.ex
+++ b/lib/cog/adapters/slack/rtm_connector.ex
@@ -108,7 +108,10 @@ defmodule Cog.Adapters.Slack.RTMConnector do
                               fn() -> handle_command(room, user_id, text, state) end}
                          end
     unless message == nil do
-      Slack.API.send_message(channel, message)
+      {:ok, room} = Slack.API.lookup_room(id: channel)
+      room = %{"id" => room.id,
+               "name" => room.name}
+      Slack.API.send_message(room, message)
     end
     handler.()
   end

--- a/test/integration/slack_test.exs
+++ b/test/integration/slack_test.exs
@@ -10,6 +10,13 @@ defmodule Integration.SlackTest do
     {:ok, %{user: user}}
   end
 
+  test "editing a command", %{user: user} do
+    user |> with_permission("operable:st-echo")
+
+    message = send_edited_message(user, "@deckard: operable:st-echo test")
+    assert_edited_response "@botci Executing edited command 'operable:st-echo test'\ntest", after: message
+  end
+
   test "running the st-echo command", %{user: user} do
     user |> with_permission("operable:st-echo")
 


### PR DESCRIPTION
Cog was silently failing when a user tried to edit a command. The issue centered around us sending the channel id to send_message instead of a room map.

resolves #405