### PR TITLE
Decouple room lookup and membership check

### DIFF
--- a/lib/cog.ex
+++ b/lib/cog.ex
@@ -9,15 +9,18 @@ defmodule Cog do
     children = build_children(Mix.env, System.get_env("NOCHAT"), adapter_supervisor)
 
     opts = [strategy: :one_for_one, name: Cog.Supervisor]
-    started = Supervisor.start_link(children, opts)
-
-    # Verify the latest schema migration after starting the database worker
-    {sm_status, sm_message} = verify_schema_migration()
-    log_message(sm_status, sm_message)
-    if sm_status == :error do
-      abort_cog()
-    else
-      started
+    case Supervisor.start_link(children, opts) do
+      {:ok, top_sup} ->
+        # Verify the latest schema migration after starting the database worker
+        {sm_status, sm_message} = verify_schema_migration()
+        log_message(sm_status, sm_message)
+        if sm_status == :error do
+          abort_cog()
+        else
+          {:ok, top_sup}
+        end
+      error ->
+        error
     end
   end
 

--- a/lib/cog/adapter.ex
+++ b/lib/cog/adapter.ex
@@ -74,6 +74,8 @@ defmodule Cog.Adapter do
 
   @callback lookup_direct_room(lookup_opts()) :: lookup_result()
 
+  @callback room_writeable?(lookup_opts()) :: boolean() | {:error, any}
+
   @callback mention_name(String.t) :: String.t
 
   @callback name() :: String.t

--- a/lib/cog/adapters/hipchat.ex
+++ b/lib/cog/adapters/hipchat.ex
@@ -14,6 +14,11 @@ defmodule Cog.Adapters.HipChat do
     HipChat.API.lookup_direct_room(opts)
   end
 
+  # TODO: Research a real implementation
+  def room_writeable?(_opts) do
+    true
+  end
+
   def mention_name(name) do
     "@" <> name
   end

--- a/lib/cog/adapters/irc.ex
+++ b/lib/cog/adapters/irc.ex
@@ -14,6 +14,11 @@ defmodule Cog.Adapters.IRC do
     IRC.Connection.lookup_direct_room(opts)
   end
 
+  # TODO: Research a real implementation
+  def room_writeable?(_opts) do
+    true
+  end
+
   def mention_name(name) do
     name
   end

--- a/lib/cog/adapters/null.ex
+++ b/lib/cog/adapters/null.ex
@@ -18,6 +18,10 @@ defmodule Cog.Adapters.Null do
     {:error, :not_implemented}
   end
 
+  def room_writeable?(_opts) do
+    true
+  end
+
   def mention_name(name) do
     "@" <> name
   end

--- a/lib/cog/adapters/slack.ex
+++ b/lib/cog/adapters/slack.ex
@@ -16,15 +16,10 @@ defmodule Cog.Adapters.Slack do
 
   def room_writeable?(opts) do
     case lookup_room(opts) do
-      {:ok, room} ->
-        case Slack.RTMConnector.assigned_userid() do
-          {:ok, userid} ->
-            is_member?(room, userid)
-          error ->
-            error
-        end
-      error ->
-        error
+      {:ok, %{is_member: is_member}} ->
+        is_member
+      _ ->
+        true
     end
   end
 
@@ -40,7 +35,4 @@ defmodule Cog.Adapters.Slack do
     "Slack"
   end
 
-  defp is_member?(%{members: members}, userid),
-    do: Enum.member?(members, userid)
-  defp is_member?(_room, _userid), do: true
 end

--- a/lib/cog/adapters/slack.ex
+++ b/lib/cog/adapters/slack.ex
@@ -14,6 +14,20 @@ defmodule Cog.Adapters.Slack do
     Slack.API.lookup_direct_room(opts)
   end
 
+  def room_writeable?(opts) do
+    case lookup_room(opts) do
+      {:ok, room} ->
+        case Slack.RTMConnector.assigned_userid() do
+          {:ok, userid} ->
+            is_member?(room, userid)
+          error ->
+            error
+        end
+      error ->
+        error
+    end
+  end
+
   def mention_name(name) do
     "@" <> name
   end
@@ -25,4 +39,8 @@ defmodule Cog.Adapters.Slack do
   def display_name() do
     "Slack"
   end
+
+  defp is_member?(%{members: members}, userid),
+    do: Enum.member?(members, userid)
+  defp is_member?(_room, _userid), do: true
 end

--- a/lib/cog/adapters/slack/api.ex
+++ b/lib/cog/adapters/slack/api.ex
@@ -269,8 +269,8 @@ defmodule Cog.Adapters.Slack.API do
   #
   # We extract only the information we care about, and use atom keys
   # instead of strings.
-  defp cache_item(%{"is_channel" => true, "id" => id, "name" => name, "members" => members}),
-    do: %{id: id, name: name, members: members}
+  defp cache_item(%{"is_channel" => true, "id" => id, "name" => name, "is_member" => is_member}),
+    do: %{id: id, name: name, is_member: is_member}
   defp cache_item(%{"is_group" => true, "id" => id, "name" => name}),
     do: %{id: id, name: name}
   # users have names, but not "is_user" fields :( they do have profiles, though

--- a/lib/cog/adapters/slack/api.ex
+++ b/lib/cog/adapters/slack/api.ex
@@ -164,12 +164,8 @@ defmodule Cog.Adapters.Slack.API do
     result = call_api!("channels.info", state.token, body: %{channel: id})
     reply = if result["ok"] do
       channel = result["channel"]
-      if is_member?(channel) do
-        cached = cache(channel, state.ttl)
-        {:ok, cached}
-      else
-        {:error, :not_a_member}
-      end
+      cached = cache(channel, state.ttl)
+      {:ok, cached}
     else
       {:error, result["error"]}
     end
@@ -180,21 +176,14 @@ defmodule Cog.Adapters.Slack.API do
     reply = if result["ok"] do
       channels = result["channels"]
 
-      # Cache all the channels we need to, and return their cache representations
-      cached = Enum.filter_map(channels, &is_member?/1, &cache(&1, state.ttl))
+      # Cache all the channels and return their cache representations
+      cached = Enum.map(channels, &cache(&1, state.ttl))
 
       case Enum.find(cached, &is_channel_named?(&1, name)) do
         channel when not(is_nil(channel)) ->
           {:ok, channel}
         _ ->
-          # if it's in the original list from the API, then we're not
-          # a member; If it wasn't there, then it  doesn't exist
-          case Enum.find(channels, &is_channel_named?(&1, name)) do
-            nil ->
-              {:error, :not_found}
-            _ ->
-              {:error, :not_a_member}
-          end
+          {:error, :not_found}
       end
     else
       {:error, result["error"]}
@@ -221,14 +210,6 @@ defmodule Cog.Adapters.Slack.API do
   defp is_channel_named?(%{name: name}, name), do: true
   defp is_channel_named?(%{"name" => name}, name), do: true
   defp is_channel_named?(_, _), do: false
-
-  # Given a Slack channel object, return whether the API user (i.e.,
-  # the bot) is a member.
-  #
-  # We can currently only redirect to channels that the bot is a
-  # member of.
-  defp is_member?(%{"is_member" => is_member}),
-    do: is_member
 
   ########################################################################
   # Cache-related Functions
@@ -288,8 +269,8 @@ defmodule Cog.Adapters.Slack.API do
   #
   # We extract only the information we care about, and use atom keys
   # instead of strings.
-  defp cache_item(%{"is_channel" => true, "id" => id, "name" => name}),
-    do: %{id: id, name: name}
+  defp cache_item(%{"is_channel" => true, "id" => id, "name" => name, "members" => members}),
+    do: %{id: id, name: name, members: members}
   defp cache_item(%{"is_group" => true, "id" => id, "name" => name}),
     do: %{id: id, name: name}
   # users have names, but not "is_user" fields :( they do have profiles, though

--- a/lib/cog/adapters/slack/rtm_connector.ex
+++ b/lib/cog/adapters/slack/rtm_connector.ex
@@ -46,14 +46,6 @@ defmodule Cog.Adapters.Slack.RTMConnector do
     __MODULE__.start_link(token, @initial_state)
   end
 
-  @doc """
-  Returns the bot's Slack-assigned userid
-  """
-  def assigned_userid() do
-    # Retry a few times to avoid race conditions at startup
-    assigned_userid(5)
-  end
-
   ########################################################################
   # Slack callbacks
   #
@@ -222,28 +214,6 @@ defmodule Cog.Adapters.Slack.RTMConnector do
           true ->
             :ignore
         end
-    end
-  end
-
-  defp assigned_userid(0) do
-    {:error, :timeout}
-  end
-  defp assigned_userid(count) do
-    rtmpid = :erlang.whereis(__MODULE__)
-    # if RTM process isn't running yet sleep for a bit and try again
-    if rtmpid == :undefined do
-      :timer.sleep(500)
-      assigned_userid(count - 1)
-    end
-    # Use a ref to avoid interleaved receives
-    ref = :erlang.make_ref()
-    send(rtmpid, {:assigned_userid, ref, self()})
-    receive do
-      {^ref, result} ->
-        result
-    # Use 5000 for timeout to be consistent w/GenServer
-    after 5000 ->
-        {:error, :timeout}
     end
   end
 

--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -345,7 +345,11 @@ defmodule Cog.Command.Pipeline.Executor do
     adapter = String.to_existing_atom(state.request["module"])
     case adapter.lookup_room(redir) do
       {:ok, room} ->
-        {:ok, room}
+        if adapter.room_writeable?(id: room.id) == true do
+          {:ok, room}
+        else
+          {:error, {:not_a_member, redir}}
+        end
       {:error, reason} ->
         Logger.error("Error resolving redirect '#{redir}' with adapter #{adapter}: #{inspect reason}")
         {:error, {reason, redir}}

--- a/test/support/adapters/test.ex
+++ b/test/support/adapters/test.ex
@@ -19,6 +19,10 @@ defmodule Cog.Adapters.Test do
     {:ok, %{id: "channel1"}}
   end
 
+  def room_writeable?(_opts) do
+    true
+  end
+
   def mention_name(name) do
     "@" <> name
   end


### PR DESCRIPTION
This commit separates room membership checks from room lookups. This is
achieved by adding a new public API function to the `Cog.Adapter`
behavior: `room_writeable?/1` which returns true when the bot is
permitted to send messages to a room, false when it's not, and an error
tuple for all other cases. All adapters except Slack always return true.

The Slack adapter returns true if the bot is a member of the room
otherwise false (or error if the API call fails). This allows us to
catch the case where a user redirects output to room(s) where their Cog
instance is not present.

The executor uses this check to detect invalid redirects.

Fixes #410