### PR TITLE
Add ExCoveralls for test coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ erl_crash.dump
 *.pem
 /data
 Mnesia.*
+/cover

--- a/Makefile
+++ b/Makefile
@@ -56,4 +56,9 @@ test-watch: export MIX_ENV = test
 test-watch: reset-db
 	mix test.watch $(TEST)
 
+coverage: export MIX_ENV = test
+coverage: reset-db
+coverage:
+	mix coveralls.html
+
 .PHONY: ci ci-setup ci-cleanup test

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,12 @@ defmodule Cog.Mixfile do
      deps: deps,
      elixirc_paths: elixirc_paths(Mix.env),
      compilers: [:phoenix] ++ Mix.compilers,
-     aliases: aliases]
+     aliases: aliases,
+     test_coverage: [tool: ExCoveralls],
+     preferred_cli_env: ["coveralls": :test,
+                         "coveralls.html": :test,
+                         "coveralls.post": :test]
+    ]
   end
 
   def application do
@@ -71,7 +76,8 @@ defmodule Cog.Mixfile do
      {:phoenix_live_reload, "~> 1.0.3", only: :dev},
      {:earmark, "~> 0.2.1", only: :dev},
      {:ex_doc, "~> 0.10", only: :dev},
-     {:mix_test_watch, "~> 0.1.1", only: :test}
+     {:mix_test_watch, "~> 0.1.1", only: :test},
+     {:excoveralls, "~> 0.5", only: :test}
 
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -15,6 +15,7 @@
   "esockd": {:git, "git://github.com/emqtt/esockd.git", "e6c27801bb5331d064081ef6d6af291a2878038c", [branch: "master"]},
   "ex_doc": {:hex, :ex_doc, "0.11.4"},
   "ex_json_schema": {:hex, :ex_json_schema, "0.3.1"},
+  "excoveralls": {:hex, :excoveralls, "0.5.1"},
   "exirc": {:hex, :exirc, "0.9.2"},
   "exjsx": {:hex, :exjsx, "3.1.0"},
   "exml": {:git, "https://github.com/paulgray/exml.git", "4ae6dea65f97764663c43d0bafb177dc702b5c3f", [tag: "2.2.1"]},


### PR DESCRIPTION
Run `make coverage` to run tests, producing a coverage report. An
overview will be printed to the terminal, but open
`cover/excoveralls.html` for a more detailed report.

Does not (yet?) post anything to coveralls.io.