### PR TITLE
Use provider user id to lookup cog user

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -21,7 +21,7 @@ config :cog, :message_bus,
 
 config :cog, Cog.Adapters.Slack,
   api_token: System.get_env("SLACK_API_TOKEN"),
-  api_cache_ttl: System.get_env("SLACK_API_CACHE_TTL") || 900
+  api_cache_ttl: System.get_env("SLACK_API_CACHE_TTL") || 60
 
 config :cog, Cog.Adapters.HipChat,
   xmpp_jid: System.get_env("HIPCHAT_XMPP_JID"),

--- a/lib/cog/adapter.ex
+++ b/lib/cog/adapter.ex
@@ -76,6 +76,8 @@ defmodule Cog.Adapter do
 
   @callback room_writeable?(lookup_opts()) :: boolean() | {:error, any}
 
+  @callback lookup_user(lookup_opts()) :: lookup_result()
+
   @callback mention_name(String.t) :: String.t
 
   @callback name() :: String.t

--- a/lib/cog/adapters/hipchat.ex
+++ b/lib/cog/adapters/hipchat.ex
@@ -19,6 +19,10 @@ defmodule Cog.Adapters.HipChat do
     true
   end
 
+  def lookup_user(opts) do
+    HipChat.API.lookup_user(opts)
+  end
+
   def mention_name(name) do
     "@" <> name
   end

--- a/lib/cog/adapters/irc.ex
+++ b/lib/cog/adapters/irc.ex
@@ -19,6 +19,10 @@ defmodule Cog.Adapters.IRC do
     true
   end
 
+  def lookup_user(opts) do
+    IRC.Connection.lookup_user(opts)
+  end
+
   def mention_name(name) do
     name
   end

--- a/lib/cog/adapters/null.ex
+++ b/lib/cog/adapters/null.ex
@@ -22,6 +22,10 @@ defmodule Cog.Adapters.Null do
     true
   end
 
+  def lookup_user(_opts) do
+    {:error, :not_implemented}
+  end
+
   def mention_name(name) do
     "@" <> name
   end

--- a/lib/cog/adapters/slack.ex
+++ b/lib/cog/adapters/slack.ex
@@ -23,6 +23,10 @@ defmodule Cog.Adapters.Slack do
     end
   end
 
+  def lookup_user(opts) do
+    Slack.API.lookup_user(opts)
+  end
+
   def mention_name(name) do
     "@" <> name
   end

--- a/lib/cog/adapters/slack/api.ex
+++ b/lib/cog/adapters/slack/api.ex
@@ -4,7 +4,7 @@ defmodule Cog.Adapters.Slack.API do
 
   defstruct token: nil, ttl: nil
 
-  @default_ttl 900
+  @default_ttl 60 # 1 minute
   @slack_api "https://slack.com/api/"
   @server_name :slack_api
   @user_cache :slack_api_users

--- a/lib/cog/commands/helpers.ex
+++ b/lib/cog/commands/helpers.ex
@@ -12,9 +12,9 @@ defmodule Cog.Commands.Helpers do
   @doc """
   Gets the current user based on the handle and provider.
   """
-  def get_user(%{"handle" => handle, "provider" => provider}) do
-    Queries.User.for_handle(handle, provider)
-    |> Repo.one
+  def get_user(%{"id" => id, "provider" => provider}) do
+    Queries.User.for_chat_provider_user_id(id, provider)
+    |> Repo.one!
   end
 
   @doc """

--- a/lib/cog/models/chat_handle.ex
+++ b/lib/cog/models/chat_handle.ex
@@ -12,11 +12,11 @@ defmodule Cog.Models.ChatHandle do
     timestamps
   end
 
-  @required_fields ~w(handle user_id provider_id)
+  @required_fields ~w(handle user_id provider_id chat_provider_user_id)
   @optional_fields ~w()
 
-  summary_fields [:id, :handle, :user_id, :provider_id]
-  detail_fields [:id, :handle, :user, :chat_provider]
+  summary_fields [:id, :handle, :user_id, :provider_id, :chat_provider_user_id]
+  detail_fields [:id, :handle, :user, :chat_provider, :chat_provider_user_id]
 
   def changeset(model, params \\ :empty) do
     model

--- a/lib/cog/models/chat_handle.ex
+++ b/lib/cog/models/chat_handle.ex
@@ -5,6 +5,7 @@ defmodule Cog.Models.ChatHandle do
 
   schema "chat_handles" do
     field :handle, :string
+    field :chat_provider_user_id, :string
     belongs_to :user, Cog.Models.User
     belongs_to :chat_provider, Cog.Models.ChatProvider, foreign_key: :provider_id, type: :integer
 

--- a/lib/cog/models/user_command_alias.ex
+++ b/lib/cog/models/user_command_alias.ex
@@ -2,8 +2,6 @@ defmodule Cog.Models.UserCommandAlias do
   use Cog.Model
   use Cog.Models
 
-  require Logger
-
   schema "user_command_aliases" do
     field :name, :string
     field :pipeline, :string

--- a/lib/cog/queries.ex
+++ b/lib/cog/queries.ex
@@ -2,7 +2,7 @@ defmodule Cog.Queries do
   defmacro __using__(_) do
     quote do
       use Cog.Models
-      import Ecto.Query, only: [from: 2]
+      import Ecto.Query, only: [from: 2, where: 3]
     end
   end
 end

--- a/lib/cog/queries/alias.ex
+++ b/lib/cog/queries/alias.ex
@@ -1,34 +1,17 @@
 defmodule Cog.Queries.Alias do
   use Cog.Queries
   import Ecto.Query, only: [from: 2, where: 2]
+  alias Cog.Models.UserCommandAlias
+  alias Cog.Models.SiteCommandAlias
 
-  def user_matching(pattern, handle, provider) do
-    from a in UserCommandAlias,
-    join: u in assoc(a, :user),
-    join: ch in assoc(u, :chat_handles),
-    join: cp in assoc(ch, :chat_provider),
-    where: ch.handle == ^handle,
-    where: cp.name == ^provider,
+  def for_user(query \\ UserCommandAlias, user_id) do
+    from a in query,
+    where: a.user_id == ^user_id
+  end
+
+  def matching(query \\ UserCommandAlias, pattern) do
+    from a in query,
     where: like(a.name, ^pattern)
-  end
-
-  def site_matching(pattern) do
-    from a in SiteCommandAlias,
-    where: like(a.name, ^pattern)
-  end
-
-  def user_aliases(handle, provider) do
-    from a in UserCommandAlias,
-    join: u in assoc(a, :user),
-    join: ch in assoc(u, :chat_handles),
-    join: cp in assoc(ch, :chat_provider),
-    where: ch.handle == ^handle,
-    where: cp.name == ^provider
-  end
-
-  def site_aliases() do
-    from a in SiteCommandAlias,
-    select: a
   end
 
   def user_alias_by_name(%Cog.Models.User{id: user_id}, alias_name) do
@@ -39,5 +22,4 @@ defmodule Cog.Queries.Alias do
 
   def site_alias_by_name(name),
     do: SiteCommandAlias |> where(name: ^name)
-
 end

--- a/lib/cog/queries/chat_handle.ex
+++ b/lib/cog/queries/chat_handle.ex
@@ -1,0 +1,8 @@
+defmodule Cog.Queries.ChatHandle do
+  use Cog.Queries
+
+  def for_user_id(query \\ ChatHandle, user_id) do
+    from ch in query,
+    where: ch.user_id == ^user_id
+  end
+end

--- a/lib/cog/queries/user.ex
+++ b/lib/cog/queries/user.ex
@@ -9,6 +9,14 @@ defmodule Cog.Queries.User do
     preload: [:chat_handles]
   end
 
+  def for_chat_provider_user_id(chat_provider_user_id, provider) when is_binary(provider) do
+    from u in User,
+    join: ch in assoc(u, :chat_handles),
+    join: cp in assoc(ch, :chat_provider),
+    where: ch.chat_provider_user_id == ^chat_provider_user_id and cp.name == ^provider,
+    preload: [:chat_handles]
+  end
+
   @doc """
   Given a user id, returns the list of chat handles.
   """

--- a/lib/cog/queries/user.ex
+++ b/lib/cog/queries/user.ex
@@ -1,45 +1,6 @@
 defmodule Cog.Queries.User do
   use Cog.Queries
 
-  def for_handle(handle, provider) when is_binary(provider) do
-    from u in User,
-    join: ch in assoc(u, :chat_handles),
-    join: cp in assoc(ch, :chat_provider),
-    where: ch.handle == ^handle and cp.name == ^provider,
-    preload: [:chat_handles]
-  end
-
-  def for_chat_provider_user_id(chat_provider_user_id, provider) when is_binary(provider) do
-    from u in User,
-    join: ch in assoc(u, :chat_handles),
-    join: cp in assoc(ch, :chat_provider),
-    where: ch.chat_provider_user_id == ^chat_provider_user_id and cp.name == ^provider,
-    preload: [:chat_handles]
-  end
-
-  @doc """
-  Given a user id, returns the list of chat handles.
-  """
-  def handles(user_id) do
-    from c in ChatHandle,
-    where: c.user_id == ^user_id,
-    preload: [:chat_provider]
-  end
-
-  @doc """
-  Given a `username` and `password`, find the User they belong to.
-  The `password` is encoded and queried against the `password_digest`
-  field along with the `username`.
-
-  If the user does not exist or the password is invalid, the query
-  returns nothing.
-  """
-  def for_username_password(username, password) do
-    from u in Cog.Models.User,
-    where: u.username == ^username and u.password_digest == ^Cog.Passwords.encode(password),
-    select: u
-  end
-
   @doc """
   Given a `token`, find the User it belongs to. `ttl_in_seconds` is
   the current amount of time that a token can be considered valid; if
@@ -81,15 +42,16 @@ defmodule Cog.Queries.User do
   The queryable that is given must ultimately resolve to a user, and
   if not given, defaults to the `User` model for maximum flexibility
   """
-  # TODO: This is identical to `for_handle/2` but without the
-  #     where: ch.handle == ^handle
-  # fragment
-  def with_chat_handle_for(queryable \\ User, provider) do
+  def for_chat_provider(queryable \\ User, chat_provider_name) when is_binary(chat_provider_name) do
     from u in queryable,
     join: ch in assoc(u, :chat_handles),
     join: cp in assoc(ch, :chat_provider),
-    where: cp.name == ^provider,
-    preload: [chat_handles: ch]
+    where: cp.name == ^chat_provider_name
   end
 
+  def for_chat_provider_user_id(chat_provider_user_id, chat_provider_name) do
+    chat_provider_name
+    |> for_chat_provider
+    |> where([_u, ch], ch.chat_provider_user_id == ^chat_provider_user_id)
+  end
 end

--- a/lib/cog/support/model_utilities.ex
+++ b/lib/cog/support/model_utilities.ex
@@ -106,7 +106,8 @@ defmodule Cog.Support.ModelUtilities do
     user
     |> Ecto.Model.build(:chat_handles,
                         %{provider_id: provider.id,
-                          handle: user.username})
+                          handle: user.username,
+                          chat_provider_user_id: user.username})
     |> Repo.insert!
 
     user

--- a/priv/repo/migrations/20160317183129_add_chat_provider_user_id_to_chat_handles.exs
+++ b/priv/repo/migrations/20160317183129_add_chat_provider_user_id_to_chat_handles.exs
@@ -1,8 +1,6 @@
 defmodule Cog.Repo.Migrations.AddChatProviderUserIdToChatHandles do
   use Ecto.Migration
   use Cog.Queries
-  alias Cog.Repo
-  alias Cog.Models.ChatHandle
 
   def change do
     alter table(:chat_handles) do

--- a/priv/repo/migrations/20160317183129_add_chat_provider_user_id_to_chat_handles.exs
+++ b/priv/repo/migrations/20160317183129_add_chat_provider_user_id_to_chat_handles.exs
@@ -1,0 +1,20 @@
+defmodule Cog.Repo.Migrations.AddChatProviderUserIdToChatHandles do
+  use Ecto.Migration
+  use Cog.Queries
+  alias Cog.Repo
+  alias Cog.Models.ChatHandle
+
+  def change do
+    alter table(:chat_handles) do
+      add :chat_provider_user_id, :text
+    end
+
+    create unique_index(:chat_handles, [:provider_id, :chat_provider_user_id])
+
+    execute("UPDATE chat_handles SET chat_provider_user_id = handle")
+
+    alter table(:chat_handles) do
+      modify :chat_provider_user_id, :text, null: false
+    end
+  end
+end

--- a/test/cog/user_test.exs
+++ b/test/cog/user_test.exs
@@ -12,8 +12,8 @@ defmodule UserTest do
 
   test "retrieving user includes chat handles", %{user: user} do
     # with_chat_handle_for registers a handle that is the same as the username
-    user |> with_chat_handle_for("slack")
-    found_user = Repo.one!(Cog.Queries.User.for_handle(user.username, "slack"))
+    user |> with_chat_handle_for("test")
+    found_user = Repo.one!(Cog.Queries.User.for_handle(user.username, "test"))
 
     assert(found_user.id == user.id)
 

--- a/test/cog/user_test.exs
+++ b/test/cog/user_test.exs
@@ -10,18 +10,6 @@ defmodule UserTest do
            permission: permission("test:creation")]}
   end
 
-  test "retrieving user includes chat handles", %{user: user} do
-    # with_chat_handle_for registers a handle that is the same as the username
-    user |> with_chat_handle_for("test")
-    found_user = Repo.one!(Cog.Queries.User.for_handle(user.username, "test"))
-
-    assert(found_user.id == user.id)
-
-    assert(length(found_user.chat_handles) == 1)
-    retrieved_handle = Enum.at(found_user.chat_handles, 0)
-    assert(retrieved_handle.handle == user.username)
-  end
-
   test "permissions may be granted directly to users", %{user: user, permission: permission} do
     :ok = Permittable.grant_to(user, permission)
     assert_permission_is_granted(user, permission)

--- a/test/integration/redirect_test.exs
+++ b/test/integration/redirect_test.exs
@@ -13,7 +13,7 @@ defmodule Integration.RedirectTest do
 
     expected_response = %{"adapter" => "test",
                           "response" => "test_here",
-                          "room" => %{"id" => 1, "name" => "general"}}
+                          "room" => %{"id" => "general", "name" => "general"}}
 
     assert response["data"] == expected_response
   end
@@ -23,7 +23,7 @@ defmodule Integration.RedirectTest do
 
     expected_response = %{"adapter" => "test",
                           "response" => "test_general",
-                          "room" => %{"id" => 1, "name" => "general"}}
+                          "room" => %{"id" => "general", "name" => "general"}}
 
     assert response["data"] == expected_response
   end
@@ -33,7 +33,7 @@ defmodule Integration.RedirectTest do
 
     expected_response = %{"adapter" => "test",
                           "response" => "test_general",
-                          "room" => %{"id" => 1, "name" => "general"}}
+                          "room" => %{"id" => "general", "name" => "general"}}
 
     assert response["data"] == expected_response
   end
@@ -53,7 +53,7 @@ defmodule Integration.RedirectTest do
 
     expected_response = %{"adapter" => "test",
                           "response" => "test_vanstee",
-                          "room" => %{"id" => 1, "name" => "vanstee"}}
+                          "room" => %{"id" => "vanstee", "name" => "vanstee"}}
 
     assert response["data"] == expected_response
   end
@@ -63,7 +63,7 @@ defmodule Integration.RedirectTest do
 
     expected_response = %{"adapter" => "test",
                           "response" => "test_vanstee",
-                          "room" => %{"id" => 1, "name" => "direct"}}
+                          "room" => %{"id" => "vanstee", "name" => "direct"}}
 
     assert response["data"] == expected_response
   end

--- a/test/support/adapters/test.ex
+++ b/test/support/adapters/test.ex
@@ -5,14 +5,14 @@ defmodule Cog.Adapters.Test do
     {:error, :not_implemented}
   end
 
-  def lookup_room("@" <> _) do
-    {:ok, %{id: 1, name: "direct"}}
+  def lookup_room("@" <> user) do
+    {:ok, %{id: user, name: "direct"}}
   end
   def lookup_room("#" <> room) do
-    {:ok, %{id: 1, name: room}}
+    {:ok, %{id: room, name: room}}
   end
   def lookup_room(room_or_user) do
-    {:ok, %{id: 1, name: room_or_user}}
+    {:ok, %{id: room_or_user, name: room_or_user}}
   end
 
   def lookup_user(handle: "vansterminator") do

--- a/test/support/adapters/test.ex
+++ b/test/support/adapters/test.ex
@@ -15,6 +15,14 @@ defmodule Cog.Adapters.Test do
     {:ok, %{id: 1, name: room_or_user}}
   end
 
+  def lookup_user(handle: "vansterminator") do
+    {:ok, %{id: "U024BE7LG", handle: "vansterminator"}}
+  end
+
+  def lookup_user(handle: "updated-user") do
+    {:ok, %{id: "U024BE7LK", handle: "updated-user"}}
+  end
+
   def lookup_direct_room(_user_id) do
     {:ok, %{id: "channel1"}}
   end

--- a/test/support/adapters/test.ex
+++ b/test/support/adapters/test.ex
@@ -23,6 +23,10 @@ defmodule Cog.Adapters.Test do
     {:ok, %{id: "U024BE7LK", handle: "updated-user"}}
   end
 
+  def lookup_user(handle: handle) do
+    {:ok, %{id: handle, handle: handle}}
+  end
+
   def lookup_direct_room(_user_id) do
     {:ok, %{id: "channel1"}}
   end

--- a/test/support/adapters/test/helpers.ex
+++ b/test/support/adapters/test/helpers.ex
@@ -7,8 +7,8 @@ defmodule Cog.Adapters.Test.Helpers do
   def send_message(%User{username: username}, "@bot: " <> message) do
     {:ok, mq_conn} = Connection.connect
     reply_topic = "/bot/adapters/test/#{:erlang.unique_integer([:positive, :monotonic])}"
-    payload = %{sender: %{id: 1, handle: username},
-                room: %{id: 1, name: "general"},
+    payload = %{sender: %{id: username, handle: username},
+                room: %{id: "general", name: "general"},
                 text: message,
                 adapter: "test",
                 module: Cog.Adapters.Test,

--- a/web/controllers/v1/chat_handle_controller.ex
+++ b/web/controllers/v1/chat_handle_controller.ex
@@ -4,6 +4,7 @@ defmodule Cog.V1.ChatHandleController do
   alias Cog.Models.EctoJson
   alias Cog.Models.ChatHandle
   alias Cog.Models.ChatProvider
+  alias Cog.Queries
 
   plug Cog.Plug.Authentication
   plug Cog.Plug.Authorization, permission: "#{Cog.embedded_bundle}:manage_users"
@@ -11,14 +12,17 @@ defmodule Cog.V1.ChatHandleController do
   plug :scrub_params, "chat_handle" when action in [:create, :update]
 
   def index(conn, %{"id" => user_id}) do
-    chat_handles = Cog.Queries.User.handles(user_id)
+    chat_handles = Queries.ChatHandle.for_user_id(user_id)
     |> Repo.all
     |> Repo.preload([:chat_provider, :user])
+
     json(conn, EctoJson.render(chat_handles, envelope: :chat_handles))
   end
   def index(conn, _params) do
-    chat_handles = Repo.all(ChatHandle)
+    chat_handles = ChatHandle
+    |> Repo.all
     |> Repo.preload([:chat_provider, :user])
+
     json(conn, EctoJson.render(chat_handles, envelope: :chat_handles))
   end
 


### PR DESCRIPTION
We needed to lookup a user and their permissions with the internal id their chat provider users, since handles can be changed (or swaped) leading to someone stealing old permissions. Here's the break down of what changed:

* [x] Add chat_provider_user_id column (not null) to chat_handles table
* [x] Include chat_provider_user_id field when creating chat-handles via the api. The call will remain the same, but we'll ask the adapter for the chat_provider_user_id before creating the record
* [x] When looking up the rules for the user, force the call to be made with the id rather than the handle (for IRC and test adapters the id will be the handle so those calls will still work).
* [x] Add `lookup_user` callback to adapters
* [x] Decrease ttl on slack caches
* [x] Rework alias commands to lookup user with provider_user_id

Closes https://github.com/operable/cog/issues/353