### PR TITLE
Fix interpolation of bundle name in deactivated bundle error

### DIFF
--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -258,7 +258,7 @@ defmodule Cog.Command.Pipeline.Executor do
           {:next_state, :wait_for_command, updated_state, @command_timeout}
       end
     else
-      msg = "The `#{bundle}` bundle is currently disabled"
+      msg = "The #{inspect(bundle.name)} bundle is currently disabled"
       Helpers.send_error(msg, state.request, state.mq_conn)
       fail_pipeline(state, :no_relays, msg)
     end


### PR DESCRIPTION
Trying to run a command from a deactivated bundle errored out with:

```
** Reason for termination = 
** {%Protocol.UndefinedError{description: nil, protocol: String.Chars,
  value: %Cog.Models.Bundle{__meta__: #Ecto.Schema.Metadata<:loaded>,
   commands: #Ecto.Association.NotLoaded<association :commands is not loaded>,
   config_file: %{"bundle" => %{"name" => "graph"},
     "commands" => [%{"documentation" => "graph --x=\"timestamp\" --y=\"total\" --format=<format> - Read JSON data piped from the previous command and turn it into a graph",
        "enforcing" => false,
        "executable" => "/Users/vanstee/Code/operable/graph/graph.rb",
        "name" => "graph",
        "options" => [%{"name" => "x", "required" => true, "type" => "string"},
         %{"name" => "y", "required" => true, "type" => "string"},
         %{"name" => "format", "required" => false, "type" => "string"}],
        "version" => "0.0.1"}], "permissions" => [], "rules" => [],
     "templates" => []}, enabled: false,
   id: "af48eee3-64a1-4c9a-b3d2-e2bc02580669" (truncated)
```

Now it correctly responds to the user in chat:

```
@vanstee Whoops! An error occurred. The "graph" bundle is currently disabled
```