### PR TITLE
Token controller handles missing or nil parameters

### DIFF
--- a/test/controllers/v1/token_controller_test.exs
+++ b/test/controllers/v1/token_controller_test.exs
@@ -32,4 +32,16 @@ defmodule Cog.V1.TokenControllerTest do
     assert json_response(conn, 403)["error"] == "Invalid username/password"
   end
 
+  test "fails to provide token if username is not provided", %{conn: conn} do
+    conn = post(conn, "/v1/token",
+                %{"password" => "not_even_close"})
+    assert json_response(conn, 401)["error"] == "Must supply both a username and password"
+  end
+
+  test "fails to provide token if password is not provided", %{conn: conn} do
+    conn = post(conn, "/v1/token",
+                %{"username" => "little_bobby_tables"})
+    assert json_response(conn, 401)["error"] == "Must supply both a username and password"
+  end
+
 end

--- a/test/controllers/v1/token_controller_test.exs
+++ b/test/controllers/v1/token_controller_test.exs
@@ -22,14 +22,14 @@ defmodule Cog.V1.TokenControllerTest do
     user("tester")
     conn = post(conn, "/v1/token",
                 %{"username" => "not_tester", "password" => "tester"})
-    assert json_response(conn, 403)["errors"] != %{}
+    assert json_response(conn, 403)["error"] == "Invalid username/password"
   end
 
   test "does not create resource and renders errors when password is invalid", %{conn: conn} do
     user("tester")
     conn = post(conn, "/v1/token",
                 %{"username" => "tester", "password" => "wrong_password"})
-    assert json_response(conn, 403)["errors"] != %{}
+    assert json_response(conn, 403)["error"] == "Invalid username/password"
   end
 
 end

--- a/web/controllers/v1/token_controller.ex
+++ b/web/controllers/v1/token_controller.ex
@@ -7,7 +7,8 @@ defmodule Cog.V1.TokenController do
   alias Cog.Passwords
 
   def create(conn, %{"username" => username,
-                     "password" => password}) do
+                     "password" => password}) when not(is_nil(username))
+                                               and not(is_nil (password)) do
     case Repo.get_by(User, username: username) do
       %User{} = user ->
         verify_password(user, conn, password)
@@ -17,6 +18,11 @@ defmodule Cog.V1.TokenController do
         |> put_status(:forbidden)
         |> json(%{error: "Invalid username/password"})
     end
+  end
+  def create(conn, _params) do
+    conn
+    |> put_status(:unauthorized)
+    |> json(%{error: "Must supply both a username and password"})
   end
 
   defp verify_password(user, conn, password) do


### PR DESCRIPTION
Previously, the controller would crash if either the username or password were not provided, or were nil.

Related to #371