### PR TITLE
Use consistent errors param

### DIFF
--- a/test/controllers/v1/group_membership_controller_test.exs
+++ b/test/controllers/v1/group_membership_controller_test.exs
@@ -144,7 +144,7 @@ defmodule Cog.V1.GroupMembershipController.Test do
     conn = api_request(requestor, :post, "/v1/groups/#{group.id}/membership",
                        body: %{"members" => %{"users" => %{"add" => [existing_user.username,
                                                                      "i_dont_exist"]}}})
-    assert json_response(conn, 422) == %{"error" => %{"not_found" => %{"users" => ["i_dont_exist"]}}}
+    assert json_response(conn, 422) == %{"errors" => %{"not_found" => %{"users" => ["i_dont_exist"]}}}
 
     assert [] == Repo.preload(group, :direct_user_members).direct_user_members
   end
@@ -233,7 +233,7 @@ defmodule Cog.V1.GroupMembershipController.Test do
     conn = api_request(requestor, :post, "/v1/groups/#{group.id}/membership",
                        body: %{"members" => %{"groups" => %{"add" => [existing_group.name,
                                                                      "i_dont_exist"]}}})
-    assert json_response(conn, 422) == %{"error" => %{"not_found" => %{"groups" => ["i_dont_exist"]}}}
+    assert json_response(conn, 422) == %{"errors" => %{"not_found" => %{"groups" => ["i_dont_exist"]}}}
 
     assert [] == Repo.preload(group, :direct_user_members).direct_user_members
   end
@@ -305,7 +305,7 @@ defmodule Cog.V1.GroupMembershipController.Test do
                        body: %{"members" => %{"users" => %{"remove" => [user.username,
                                                                         "i_dont_exist"]}}})
 
-    assert json_response(conn, 422) == %{"error" => %{"not_found" => %{"users" => ["i_dont_exist"]}}}
+    assert json_response(conn, 422) == %{"errors" => %{"not_found" => %{"users" => ["i_dont_exist"]}}}
 
     assert [user] == Repo.preload(group, :direct_user_members).direct_user_members
   end
@@ -385,7 +385,7 @@ defmodule Cog.V1.GroupMembershipController.Test do
                        body: %{"members" => %{"groups" => %{"remove" => [group.name,
                                                                         "i_dont_exist"]}}})
 
-    assert json_response(conn, 422) == %{"error" => %{"not_found" => %{"groups" => ["i_dont_exist"]}}}
+    assert json_response(conn, 422) == %{"errors" => %{"not_found" => %{"groups" => ["i_dont_exist"]}}}
 
     assert [member] == Repo.preload(group, :direct_group_members).direct_group_members
   end

--- a/test/controllers/v1/permission_grant_controller_test.exs
+++ b/test/controllers/v1/permission_grant_controller_test.exs
@@ -151,7 +151,7 @@ defmodule Cog.V1.PermissionGrantController.Test do
         conn = api_request(requestor, :post, path,
                            body: %{"permissions" => %{"grant" => ["site:first",
                                                                   "site:does_not_exist"]}})
-        assert json_response(conn, 422) == %{"error" => %{"not_found" => %{"permissions" => ["site:does_not_exist"]}}}
+        assert json_response(conn, 422) == %{"errors" => %{"not_found" => %{"permissions" => ["site:does_not_exist"]}}}
 
         refute_permission_is_granted(target, existing)
       end
@@ -259,7 +259,7 @@ defmodule Cog.V1.PermissionGrantController.Test do
         conn = api_request(requestor, :post, path,
                            body: %{"permissions" => %{"revoke" => ["site:first",
                                                                    "site:does_not_exist"]}})
-        assert json_response(conn, 422) == %{"error" => %{"not_found" => %{"permissions" => ["site:does_not_exist"]}}}
+        assert json_response(conn, 422) == %{"errors" => %{"not_found" => %{"permissions" => ["site:does_not_exist"]}}}
 
         # Still got it
         assert_permission_is_granted(target, existing)

--- a/test/controllers/v1/role_grant_controller_test.exs
+++ b/test/controllers/v1/role_grant_controller_test.exs
@@ -147,7 +147,7 @@ defmodule Cog.V1.RoleGrantController.Test do
         conn = api_request(requestor, :post, path,
                            body: %{"roles" => %{"grant" => [existing.name,
                                                             "does_not_exist"]}})
-        assert json_response(conn, 422) == %{"error" => %{"not_found" => %{"roles" => ["does_not_exist"]}}}
+        assert json_response(conn, 422) == %{"errors" => %{"not_found" => %{"roles" => ["does_not_exist"]}}}
 
         refute_role_is_granted(target, existing)
       end
@@ -253,7 +253,7 @@ defmodule Cog.V1.RoleGrantController.Test do
         conn = api_request(requestor, :post, path,
                            body: %{"roles" => %{"revoke" => [existing.name,
                                                              "does_not_exist"]}})
-        assert json_response(conn, 422) == %{"error" => %{"not_found" => %{"roles" => ["does_not_exist"]}}}
+        assert json_response(conn, 422) == %{"errors" => %{"not_found" => %{"roles" => ["does_not_exist"]}}}
 
         # Still got it
         assert_role_is_granted(target, existing)

--- a/web/controllers/v1/group_membership_controller.ex
+++ b/web/controllers/v1/group_membership_controller.ex
@@ -74,11 +74,11 @@ defmodule Cog.V1.GroupMembershipController do
       {:error, {:not_found, {"users", names}}} ->
         conn
         |> put_status(:unprocessable_entity)
-        |> json(%{"error" => %{"not_found" => %{"users" => names}}})
+        |> json(%{"errors" => %{"not_found" => %{"users" => names}}})
       {:error, {:not_found, {"groups", names}}} ->
         conn
         |> put_status(:unprocessable_entity)
-        |> json(%{"error" => %{"not_found" => %{"groups" => names}}})
+        |> json(%{"errors" => %{"not_found" => %{"groups" => names}}})
     end
   end
 

--- a/web/controllers/v1/permission_controller.ex
+++ b/web/controllers/v1/permission_controller.ex
@@ -71,7 +71,7 @@ defmodule Cog.V1.PermissionController do
       _ ->
         conn
         |> put_status(:forbidden)
-        |> json(%{error: "Modifying permissions outside of the #{@site} namespace is forbidden."})
+        |> json(%{errors: "Modifying permissions outside of the #{@site} namespace is forbidden."})
     end
   end
 
@@ -91,7 +91,7 @@ defmodule Cog.V1.PermissionController do
       _ ->
         conn
         |> put_status(:forbidden)
-        |> json(%{error: "Deleting permissions outside of the #{@site} namespace is forbidden."})
+        |> json(%{errors: "Deleting permissions outside of the #{@site} namespace is forbidden."})
     end
   end
 

--- a/web/controllers/v1/permission_grant_controller.ex
+++ b/web/controllers/v1/permission_grant_controller.ex
@@ -48,7 +48,7 @@ defmodule Cog.V1.PermissionGrantController do
       {:error, {:not_found, {"permissions", names}}} ->
         conn
         |> put_status(:unprocessable_entity)
-        |> json(%{"error" => %{"not_found" => %{"permissions" => names}}})
+        |> json(%{"errors" => %{"not_found" => %{"permissions" => names}}})
     end
   end
 

--- a/web/controllers/v1/role_grant_controller.ex
+++ b/web/controllers/v1/role_grant_controller.ex
@@ -42,7 +42,7 @@ defmodule Cog.V1.RoleGrantController do
       {:error, {:not_found, {"roles", names}}} ->
         conn
         |> put_status(:unprocessable_entity)
-        |> json(%{"error" => %{"not_found" => %{"roles" => names}}})
+        |> json(%{"errors" => %{"not_found" => %{"roles" => names}}})
     end
   end
 

--- a/web/controllers/v1/token_controller.ex
+++ b/web/controllers/v1/token_controller.ex
@@ -15,7 +15,7 @@ defmodule Cog.V1.TokenController do
         Passwords.matches?(nil, "")
         conn
         |> put_status(:forbidden)
-        |> json(%{error: "Invalid username/password"})
+        |> json(%{errors: "Invalid username/password"})
     end
   end
 
@@ -31,7 +31,7 @@ defmodule Cog.V1.TokenController do
           false ->
             conn
             |> put_status(:forbidden)
-            |> json(%{error: "Invalid username/password"})
+            |> json(%{errors: "Invalid username/password"})
         end
     end
   end

--- a/web/views/bootstrap_view.ex
+++ b/web/views/bootstrap_view.ex
@@ -6,7 +6,7 @@ defmodule Cog.V1.BootstrapView do
   end
 
   def render("bootstrapped.json", _) do
-    %{bootstrap: %{errors: "Already bootstrapped"}}
+    %{errors: %{bootstrap: "Already bootstrapped"}}
   end
 
   def render("bootstrap.json", %{user: user}) do

--- a/web/views/bootstrap_view.ex
+++ b/web/views/bootstrap_view.ex
@@ -6,7 +6,7 @@ defmodule Cog.V1.BootstrapView do
   end
 
   def render("bootstrapped.json", _) do
-    %{bootstrap: %{error: "Already bootstrapped"}}
+    %{bootstrap: %{errors: "Already bootstrapped"}}
   end
 
   def render("bootstrap.json", %{user: user}) do

--- a/web/views/error_view.ex
+++ b/web/views/error_view.ex
@@ -14,7 +14,7 @@ defmodule Cog.ErrorView do
   end
 
   def render("422.json", %{error: msg}) do
-    %{error: msg}
+    %{errors: msg}
   end
 
   # In case no render clause matches or no


### PR DESCRIPTION
Before this change there was an inconsistent struct usage for errors. Some changesets used `:errors`, while others used `:error`. This PR changes things such that Cog uses `:errors`, which is consistent with the Ecto.changeset.

Fixes #442