### PR TITLE
Pipeline ID can be passed into the executor

### DIFF
--- a/lib/cog/adapter.ex
+++ b/lib/cog/adapter.ex
@@ -45,7 +45,8 @@ defmodule Cog.Adapter do
       end
 
       defp payload(sender, room, text) do
-        %{sender: sender,
+        %{id: UUID.uuid4(:hex),
+          sender: sender,
           room: room,
           text: text,
           adapter: name(),

--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -90,9 +90,8 @@ defmodule Cog.Command.Pipeline.Executor do
   def init([request]) when is_map(request) do
     request = sanitize_request(request)
     {:ok, conn} = Connection.connect()
-    id = UUID.uuid4(:hex)
+    id = Map.fetch!(request, "id")
     topic = "/bot/pipelines/#{id}"
-
     Connection.subscribe(conn, topic <> "/+")
 
     adapter = request["adapter"]

--- a/lib/cog/command/pipeline/executor_sup.ex
+++ b/lib/cog/command/pipeline/executor_sup.ex
@@ -1,17 +1,15 @@
 defmodule Cog.Command.Pipeline.ExecutorSup do
   use Supervisor
 
-  def start_link() do
-    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
-  end
+  def start_link,
+    do: Supervisor.start_link(__MODULE__, [], name: __MODULE__)
 
   def init(_) do
     children = [worker(Cog.Command.Pipeline.Executor, [], restart: :temporary)]
     supervise(children, strategy: :simple_one_for_one, max_restarts: 0, max_seconds: 1)
   end
 
-  def run(payload) do
-    Supervisor.start_child(__MODULE__, [payload])
-  end
+  def run(payload),
+    do: Supervisor.start_child(__MODULE__, [payload])
 
 end

--- a/lib/cog/command/pipeline/initializer.ex
+++ b/lib/cog/command/pipeline/initializer.ex
@@ -5,9 +5,8 @@ defmodule Cog.Command.Pipeline.Initializer do
 
   use GenServer
 
-  def start_link() do
-    GenServer.start_link(__MODULE__, [], name: __MODULE__)
-  end
+  def start_link,
+    do: GenServer.start_link(__MODULE__, [], name: __MODULE__)
 
   def init(_) do
     cp = Application.get_env(:cog, :command_prefix)
@@ -33,9 +32,8 @@ defmodule Cog.Command.Pipeline.Initializer do
     end
   end
 
-  def handle_info(_, state) do
-    {:noreply, state}
-  end
+  def handle_info(_, state),
+    do: {:noreply, state}
 
   defp check_history(payload, state) when is_map(payload) do
     uid = get_in(payload, ["sender", "id"])
@@ -47,9 +45,8 @@ defmodule Cog.Command.Pipeline.Initializer do
     end
   end
 
-  defp put_in_history(uid, text, %__MODULE__{history: history}=state) do
-    %{state | history: Map.put(history, uid, text)}
-  end
+  defp put_in_history(uid, text, %__MODULE__{history: history}=state),
+    do: %{state | history: Map.put(history, uid, text)}
 
   defp retrieve_last(uid, payload, %__MODULE__{history: history}=state) do
     case Map.get(history, uid) do

--- a/lib/cog/command/pipeline/initializer.ex
+++ b/lib/cog/command/pipeline/initializer.ex
@@ -1,4 +1,13 @@
 defmodule Cog.Command.Pipeline.Initializer do
+  @moduledoc """
+  Listens for pipeline requests, triggering the execution of those
+  pipelines.
+
+  Additionalaly, tracks the history of requests being made, thus
+  providing a "history" function, whereby a user may re-run the last
+  request they made.
+  """
+
   require Logger
 
   defstruct mq_conn: nil, history: %{}, history_token: ""

--- a/test/support/adapters/test/helpers.ex
+++ b/test/support/adapters/test/helpers.ex
@@ -7,7 +7,8 @@ defmodule Cog.Adapters.Test.Helpers do
   def send_message(%User{username: username}, "@bot: " <> message) do
     {:ok, mq_conn} = Connection.connect
     reply_topic = "/bot/adapters/test/#{:erlang.unique_integer([:positive, :monotonic])}"
-    payload = %{sender: %{id: username, handle: username},
+    payload = %{id: UUID.uuid4(:hex),
+                sender: %{id: username, handle: username},
                 room: %{id: "general", name: "general"},
                 text: message,
                 adapter: "test",


### PR DESCRIPTION
Previously the executor itself would create a unique ID for the pipeline
being executed. In order to facilitate better tracking for pipelines
that are initiated from external events (e.g., webhooks), we'll need to
externalize this ID generation. (this will allow us to correlate HTTP
request processing with the resulting pipeline).

Now the pipeline initializer creates the ID and passes it as an argument
to the new executor process.

Fixes #417