### PR TITLE
Make Token controller use errors instead of error

### DIFF
--- a/test/controllers/v1/token_controller_test.exs
+++ b/test/controllers/v1/token_controller_test.exs
@@ -22,26 +22,26 @@ defmodule Cog.V1.TokenControllerTest do
     user("tester")
     conn = post(conn, "/v1/token",
                 %{"username" => "not_tester", "password" => "tester"})
-    assert json_response(conn, 403)["error"] == "Invalid username/password"
+    assert json_response(conn, 403)["errors"] == "Invalid username/password"
   end
 
   test "does not create resource and renders errors when password is invalid", %{conn: conn} do
     user("tester")
     conn = post(conn, "/v1/token",
                 %{"username" => "tester", "password" => "wrong_password"})
-    assert json_response(conn, 403)["error"] == "Invalid username/password"
+    assert json_response(conn, 403)["errors"] == "Invalid username/password"
   end
 
   test "fails to provide token if username is not provided", %{conn: conn} do
     conn = post(conn, "/v1/token",
                 %{"password" => "not_even_close"})
-    assert json_response(conn, 401)["error"] == "Must supply both a username and password"
+    assert json_response(conn, 401)["errors"] == "Must supply both a username and password"
   end
 
   test "fails to provide token if password is not provided", %{conn: conn} do
     conn = post(conn, "/v1/token",
                 %{"username" => "little_bobby_tables"})
-    assert json_response(conn, 401)["error"] == "Must supply both a username and password"
+    assert json_response(conn, 401)["errors"] == "Must supply both a username and password"
   end
 
 end

--- a/web/controllers/v1/token_controller.ex
+++ b/web/controllers/v1/token_controller.ex
@@ -22,7 +22,7 @@ defmodule Cog.V1.TokenController do
   def create(conn, _params) do
     conn
     |> put_status(:unauthorized)
-    |> json(%{error: "Must supply both a username and password"})
+    |> json(%{errors: "Must supply both a username and password"})
   end
 
   defp verify_password(user, conn, password) do


### PR DESCRIPTION
This fixes the tests that are failing on master. The errors are stored using ":errors" instead 'f ":error".