### PR TITLE
Add COG_ENV to pipeline "command_dispatched" events

### DIFF
--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -482,8 +482,10 @@ defmodule Cog.Command.Pipeline.Executor do
     |> Probe.notify
   end
 
-  defp dispatch_event(%__MODULE__{id: id, current_plan: current_plan}=state, relay) do
-    PipelineEvent.dispatched(id, elapsed(state), current_plan.invocation_text, relay)
+  defp dispatch_event(%__MODULE__{id: id, current_plan: plan}=state, relay) do
+    PipelineEvent.dispatched(id, elapsed(state),
+                             plan.invocation_text,
+                             relay, plan.cog_env)
     |> Probe.notify
   end
 

--- a/lib/cog/events/pipeline_event.ex
+++ b/lib/cog/events/pipeline_event.ex
@@ -101,9 +101,10 @@ defmodule Cog.Events.PipelineEvent do
   @doc """
   Create a `command_dispatched` event
   """
-  def dispatched(pipeline_id, elapsed, command, relay) do
+  def dispatched(pipeline_id, elapsed, command, relay, cog_env) do
     new(pipeline_id, :command_dispatched, elapsed, %{command_text: command,
-                                                     relay: relay})
+                                                     relay: relay,
+                                                     cog_env: cog_env})
   end
 
   @doc """


### PR DESCRIPTION
This will give a more complete picture of exactly what each command
invocation is operating on.

Example output taken from our test runs, formatted for readability
(notice that `multiple`-execution commands receive a single map, while
`once` commands receive a list):

```json
{
    "data": {
        "cog_env": {
            "foo": {
                "bar": {
                    "baz": "stuff"
                }
            }
        },
        "command_text": "operable:filter --path=foo.bar.baz --matches=me",
        "relay": "396bf701-fef6-4628-a39b-22cf5c8cbfa5"
    },
    "elapsed_microseconds": 31390,
    "event": "command_dispatched",
    "pipeline_id": "8efa3ee7adec4af098e22bcb45667548",
    "timestamp": "2016-03-22T01:01:38Z"
}
```

```json
{
    "data": {
        "cog_env": [
            {
                "command": "operable:rules",
                "id": "9ec8b7a1-b00b-4166-9f99-444a3252b23a",
                "rule": "when command is operable:rules must have operable:manage_commands"
            },
            {
                "command": "operable:rules",
                "id": "392c09e6-dcd9-454b-9951-2277e51e7702",
                "rule": "when command is operable:rules with option[user] == /.*/ must have operable:manage_users"
            },
            {
                "command": "operable:rules",
                "id": "3cbe3406-9e71-43ac-a11a-fb5b30db261e",
                "rule": "when command is operable:rules with option[role] == /.*/ must have operable:manage_roles"
            },
            {
                "command": "operable:rules",
                "id": "a96f17c3-3ce9-4e1c-a26e-a9ac6417c874",
                "rule": "when command is operable:rules with option[group] == /.*/ must have operable:manage_groups"
            }
        ],
        "command_text": "operable:sort --field=rule",
        "relay": "396bf701-fef6-4628-a39b-22cf5c8cbfa5"
    },
    "elapsed_microseconds": 64546,
    "event": "command_dispatched",
    "pipeline_id": "68620495130346e6a1f44c3ff76a5c22",
    "timestamp": "2016-03-22T01:01:53Z"
}
```

Fixes #419