### PR TITLE
Include user in command request

### DIFF
--- a/lib/cog/command/command_sup.ex
+++ b/lib/cog/command/command_sup.ex
@@ -8,7 +8,7 @@ defmodule Cog.Command.CommandSup do
   end
 
   def init(_) do
-    children = [worker(Command.UserPermissionsCache, []),
+    children = [worker(Command.PermissionsCache, []),
                 supervisor(Command.Pipeline.ExecutorSup, []),
                 worker(Command.Pipeline.Initializer, [])]
     supervise(children, strategy: :one_for_one)

--- a/lib/cog/command/permissions_cache.ex
+++ b/lib/cog/command/permissions_cache.ex
@@ -1,9 +1,9 @@
-defmodule Cog.Command.UserPermissionsCache do
+defmodule Cog.Command.PermissionsCache do
   defstruct [:ttl, :tref]
   use GenServer
   require Logger
 
-  @ets_table :cog_userperms_cache
+  @ets_table :cog_perms_cache
 
   def start_link() do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)

--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -77,7 +77,7 @@ defmodule Cog.Command.Pipeline.Executor do
 
   alias Carrier.Messaging.Connection
   alias Cog.Command.CommandResolver
-  alias Cog.Command.UserPermissionsCache
+  alias Cog.Command.PermissionsCache
   alias Cog.Events.PipelineEvent
   alias Cog.Queries
   alias Cog.Repo
@@ -102,7 +102,7 @@ defmodule Cog.Command.Pipeline.Executor do
       {:ok, initial_context} ->
         case fetch_user_from_request(request) do
           {:ok, user} ->
-            {:ok, perms} = UserPermissionsCache.fetch(user)
+            {:ok, perms} = PermissionsCache.fetch(user)
             loop_data = %__MODULE__{id: id, topic: topic, request: request,
                                     mq_conn: conn,
                                     user: user,

--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -94,18 +94,13 @@ defmodule Cog.Command.Pipeline.Executor do
     {:ok, conn} = Connection.connect()
     id = Map.fetch!(request, "id")
     topic = "/bot/pipelines/#{id}"
-
     Connection.subscribe(conn, topic <> "/+")
+
     case create_initial_context(request) do
       {:ok, initial_context} ->
-        adapter = request["adapter"]
-        handle = request["sender"]["handle"]
-        # We resolve users and permissions at this stage so that we can
-        # include the Cog user (and not just their adapter-specific
-        # handle) in event logs (and also to prevent us doing unnecessary
-        # work for users that don't have Cog accounts)
-        case UserPermissionsCache.fetch(username: handle, adapter: adapter) do
-          {:ok, {user, perms}} ->
+        case fetch_user_from_request(request) do
+          {:ok, user} ->
+            {:ok, perms} = UserPermissionsCache.fetch(user)
             loop_data = %__MODULE__{id: id, topic: topic, request: request,
                                     mq_conn: conn,
                                     user: user,
@@ -217,7 +212,7 @@ defmodule Cog.Command.Pipeline.Executor do
   def plan_next_invocation(:timeout, %__MODULE__{invocations: []}=state),
     do: respond(state)
 
-  def execute_plan(:timeout, %__MODULE__{plans: [current_plan|remaining_plans], request: request}=state) do
+  def execute_plan(:timeout, %__MODULE__{plans: [current_plan|remaining_plans], request: request, user: user}=state) do
     bundle = current_plan.command.bundle
     name   = current_plan.command.name
 
@@ -230,19 +225,12 @@ defmodule Cog.Command.Pipeline.Executor do
         relay ->
           topic = "/bot/commands/#{relay}/#{bundle.name}/#{name}"
           reply_to_topic = "#{state.topic}/reply"
-
-          req = request_for_plan(current_plan,
-                                       # TODO: Just send the request in?
-                                       request["sender"],
-                                       request["room"],
-                                       request["adapter"],
-                                       reply_to_topic)
-
+          req = request_for_plan(current_plan, request, user, reply_to_topic)
           updated_state =  %{state | current_plan: current_plan, plans: remaining_plans}
 
           dispatch_event(updated_state, relay)
-
           Connection.publish(updated_state.mq_conn, Spanner.Command.Request.encode!(req), routed_by: topic)
+
           {:next_state, :wait_for_command, updated_state, @command_timeout}
       end
     else
@@ -709,15 +697,20 @@ defmodule Cog.Command.Pipeline.Executor do
   ########################################################################
   # Miscellaneous Functions
 
-  defp request_for_plan(plan, requestor, room, provider, reply_to) do
+  defp request_for_plan(plan, request, user, reply_to) do
     # TODO: stuffing the provider into requestor here is a bit
     # code-smelly; investigate and fix
-    requestor = Map.put_new(requestor, "provider", provider)
+    provider  = request["adapter"]
+    requestor = request["sender"] |> Map.put_new("provider", provider)
+    room      = request["room"]
+    user      = Cog.Models.EctoJson.render(user)
+
     %Spanner.Command.Request{command: Cog.Models.Command.full_name(plan.command),
                              options: plan.options,
                              args: plan.args,
                              cog_env: plan.cog_env,
                              requestor: requestor,
+                             user: user,
                              room: room,
                              reply_to: reply_to}
   end
@@ -741,4 +734,18 @@ defmodule Cog.Command.Pipeline.Executor do
     Map.put(request, "text", text)
   end
 
+  def fetch_user_from_request(request) do
+    adapter   = request["adapter"]
+    sender_id = request["sender"]["id"]
+
+    user = Cog.Queries.User.for_chat_provider_user_id(sender_id, adapter)
+    |> Cog.Repo.one
+
+    case user do
+      nil ->
+        {:error, :not_found}
+      user ->
+        {:ok, user}
+    end
+  end
 end

--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -79,6 +79,8 @@ defmodule Cog.Command.Pipeline.Executor do
   alias Cog.Command.CommandResolver
   alias Cog.Command.UserPermissionsCache
   alias Cog.Events.PipelineEvent
+  alias Cog.Queries
+  alias Cog.Repo
   alias Cog.TemplateCache
   alias Piper.Command.Ast
   alias Piper.Command.Parser
@@ -738,8 +740,8 @@ defmodule Cog.Command.Pipeline.Executor do
     adapter   = request["adapter"]
     sender_id = request["sender"]["id"]
 
-    user = Cog.Queries.User.for_chat_provider_user_id(sender_id, adapter)
-    |> Cog.Repo.one
+    user = Queries.User.for_chat_provider_user_id(sender_id, adapter)
+    |> Repo.one
 
     case user do
       nil ->

--- a/lib/cog/commands/alias/new.ex
+++ b/lib/cog/commands/alias/new.ex
@@ -21,8 +21,8 @@ defmodule Cog.Commands.Alias.New do
   def create_new_user_command_alias(req, arg_list) do
     case Helpers.get_args(arg_list, 2) do
       {:ok, [alias_name, pipeline]} ->
-        user = Helpers.get_user(req.requestor)
-        changeset = UserCommandAlias.changeset(%UserCommandAlias{}, %{name: alias_name, pipeline: pipeline, user_id: user.id})
+        params = %{name: alias_name, pipeline: pipeline, user_id: req.user["id"]}
+        changeset = UserCommandAlias.changeset(%UserCommandAlias{}, params)
 
         case Repo.insert(changeset) do
           {:ok, command_alias} ->

--- a/lib/cog/commands/alias/rm.ex
+++ b/lib/cog/commands/alias/rm.ex
@@ -22,10 +22,11 @@ defmodule Cog.Commands.Alias.Rm do
   Returns {:ok, <msg>} on success and {:error, <err>} on failure.
   """
   def rm_command_alias(req, arg_list) do
+    user_id = req.user["id"]
+
     case Helpers.get_args(arg_list, 1) do
       {:ok, [alias]} ->
-        user = Helpers.get_user(req.requestor)
-        case Helpers.get_command_alias(user, alias) do
+        case Helpers.get_command_alias(user_id, alias) do
           nil ->
             {:error, {:alias_not_found, alias}}
           command_alias ->

--- a/lib/cog/commands/helpers.ex
+++ b/lib/cog/commands/helpers.ex
@@ -1,6 +1,5 @@
 defmodule Cog.Commands.Helpers do
   alias Cog.Repo
-  alias Cog.Queries
   alias Cog.Models.UserCommandAlias
   alias Cog.Models.SiteCommandAlias
   alias Cog.Models.EctoJson
@@ -8,14 +7,6 @@ defmodule Cog.Commands.Helpers do
   @moduledoc """
   A collection of helper functions for working with commands.
   """
-
-  @doc """
-  Gets the current user based on the handle and provider.
-  """
-  def get_user(%{"id" => id, "provider" => provider}) do
-    Queries.User.for_chat_provider_user_id(id, provider)
-    |> Repo.one!
-  end
 
   @doc """
   Returns a list of args based on the count in the form of {:ok, <arg_list>}.
@@ -81,14 +72,14 @@ defmodule Cog.Commands.Helpers do
   Returns an alias. If the visibility isn't passed we first search for a user
   alias and if that isn't found we search for a site alias.
   """
-  def get_command_alias(user, "user:" <> user_alias),
-    do: Repo.get_by(UserCommandAlias, name: user_alias, user_id: user.id)
+  def get_command_alias(user_id, "user:" <> user_alias),
+    do: Repo.get_by(UserCommandAlias, name: user_alias, user_id: user_id)
   def get_command_alias(_, "site:" <> site_alias),
     do: Repo.get_by(SiteCommandAlias, name: site_alias)
-  def get_command_alias(user, alias) do
-    case get_command_alias(user, "user:#{alias}") do
+  def get_command_alias(user_id, alias) do
+    case get_command_alias(user_id, "user:#{alias}") do
       nil ->
-        get_command_alias(user, "site:#{alias}")
+        get_command_alias(user_id, "site:#{alias}")
       src_alias ->
         src_alias
     end

--- a/lib/cog/commands/permissions.ex
+++ b/lib/cog/commands/permissions.ex
@@ -80,11 +80,11 @@ defmodule Cog.Commands.Permissions do
               {:delete, result.permission}
             :grant ->
               Permittable.grant_to(result.permittable, result.permission)
-              Cog.Command.UserPermissionsCache.reset_cache
+              Cog.Command.PermissionsCache.reset_cache
               {:grant, result.permittable, req.options["permission"]}
             :revoke ->
               Permittable.revoke_from(result.permittable, result.permission)
-              Cog.Command.UserPermissionsCache.reset_cache
+              Cog.Command.PermissionsCache.reset_cache
               {:revoke, result.permittable, req.options["permission"]}
           end
         %__MODULE__{errors: errors} ->

--- a/lib/cog/commands/which.ex
+++ b/lib/cog/commands/which.ex
@@ -29,9 +29,9 @@ defmodule Cog.Commands.Which do
   """
 
   def handle_message(req, state) do
-    results = with {:ok, user} <- get_user(req.requestor),
-                   {:ok, [arg]} <- Helpers.get_args(req.args, count: 1),
-                     do: which(user, arg)
+    results = with {:ok, [arg]} <- Helpers.get_args(req.args, count: 1),
+                   user_id = req.user["id"],
+                   do: which(user_id, arg)
 
     case results do
       {:ok, data} ->
@@ -45,8 +45,8 @@ defmodule Cog.Commands.Which do
   # immediately. If it isn't we check to see if the input is a command.
   # Note: If an alias shadows a command the alias will be returned, not the
   # command.
-  defp which(user, arg) do
-    case Helpers.get_command_alias(user, arg) do
+  defp which(user_id, arg) do
+    case Helpers.get_command_alias(user_id, arg) do
       nil ->
         case Repo.get_by(Command, name: arg) do
           nil ->
@@ -60,17 +60,6 @@ defmodule Cog.Commands.Which do
         {:ok, %{type: "alias", scope: "user", name: arg, pipeline: pipeline}}
       %SiteCommandAlias{pipeline: pipeline} ->
         {:ok, %{type: "alias", scope: "site", name: arg, pipeline: pipeline}}
-    end
-  end
-
-  # A simple wrapper around Helpers.get_user/1. So we can get output like we
-  # want it.
-  defp get_user(requestor) do
-    case Helpers.get_user(requestor) do
-      nil ->
-        {:error, {:no_user, requestor["handle"], requestor["provider"]}}
-      user ->
-        {:ok, user}
     end
   end
 end

--- a/test/support/adapter_case.ex
+++ b/test/support/adapter_case.ex
@@ -29,7 +29,7 @@ defmodule Cog.AdapterCase do
       setup do
         Ecto.Adapters.SQL.restart_test_transaction(Repo, [])
         bootstrap
-        Cog.Command.UserPermissionsCache.reset_cache
+        Cog.Command.PermissionsCache.reset_cache
         :ok
       end
 


### PR DESCRIPTION
We now lookup the user (from chat provider id) in the executor which is then passed on to the user permissions cache and further on to commands. All commands now pull user info out of the request struct they are given.

Closes https://github.com/operable/cog/issues/451