### PR TITLE
Add null chat provider

### DIFF
--- a/lib/cog/adapters/null.ex
+++ b/lib/cog/adapters/null.ex
@@ -22,6 +22,10 @@ defmodule Cog.Adapters.Null do
     true
   end
 
+  def lookup_user(handle: "admininator") do
+    {:ok, %{id: "admininator", handle: "admininator"}}
+  end
+
   def lookup_user(_opts) do
     {:error, :not_implemented}
   end

--- a/priv/repo/migrations/20160322222933_add_null_chat_provider.exs
+++ b/priv/repo/migrations/20160322222933_add_null_chat_provider.exs
@@ -1,0 +1,15 @@
+defmodule Cog.Repo.Migrations.AddNullChatProvider do
+  use Ecto.Migration
+  use Cog.Queries
+  alias Cog.Repo
+  alias Cog.Models.ChatProvider
+
+  def up do
+    Repo.insert!(%ChatProvider{name: "null"})
+  end
+
+  def down do
+    Repo.delete_all(from p in ChatProvider, where: p.name == "null")
+  end
+
+end


### PR DESCRIPTION
This PR fixes the cogctl chat-handler creation test by adding the null chat adapter and stubbing a lookup_user function.

Fixes https://github.com/operable/cog/issues/456