### PR TITLE
Render different formatting for permissions in the Role and Permissio…

### DIFF
--- a/lib/cog/models/ecto_json.ex
+++ b/lib/cog/models/ecto_json.ex
@@ -89,5 +89,4 @@ defmodule Cog.Models.EctoJson do
     non_struct
   end
 
-
 end

--- a/lib/cog/models/role.ex
+++ b/lib/cog/models/role.ex
@@ -12,8 +12,8 @@ defmodule Cog.Models.Role do
     has_many :permissions, through: [:permission_grants, :permission]
   end
 
-  summary_fields [:id, :name]
-  detail_fields [:id, :name]
+  summary_fields [:id, :name, :permissions]
+  detail_fields [:id, :name, :permissions]
 
   @required_fields ~w(name)
   @optional_fields ~w()

--- a/test/controllers/v1/permission_grant_controller_test.exs
+++ b/test/controllers/v1/permission_grant_controller_test.exs
@@ -84,7 +84,7 @@ defmodule Cog.V1.PermissionGrantController.Test do
                            body: %{"permissions" => %{"grant" => ["site:do_stuff"]}})
 
         %{id: id, name: name} = permission
-        assert %{"permissions" => [%{"id" => ^id, "name" => ^name}]} = json_response(conn, 200)
+        assert %{"permissions" => [%{"namespace" => "site", "id" => ^id, "name" => ^name}]} = json_response(conn, 200)
 
         assert_permission_is_granted(target, permission)
       end
@@ -167,7 +167,7 @@ defmodule Cog.V1.PermissionGrantController.Test do
                            body: %{"permissions" => %{"grant" => ["site:do_stuff"]}})
 
         %{id: id, name: name} = permission
-        assert %{"permissions" => [%{"id" => ^id, "name" => ^name}]} = json_response(conn, 200)
+        assert %{"permissions" => [%{"namespace" => "site", "id" => ^id, "name" => ^name}]} = json_response(conn, 200)
 
         # Still got it!
         assert_permission_is_granted(target, permission)
@@ -243,7 +243,7 @@ defmodule Cog.V1.PermissionGrantController.Test do
         %{id: id, name: name} = remaining_permission
 
         # only the revoked permission is, um, revoked
-        assert %{"permissions" => [%{"id" => ^id, "name" => ^name}]} = json_response(conn, 200)
+        assert %{"permissions" => [%{"namespace" => "site", "id" => ^id, "name" => ^name}]} = json_response(conn, 200)
 
         assert_permission_is_granted(target, remaining_permission)
         refute_permission_is_granted(target, to_be_revoked_permission)

--- a/test/controllers/v1/role_controller_test.exs
+++ b/test/controllers/v1/role_controller_test.exs
@@ -32,7 +32,8 @@ defmodule Cog.V1.RoleController.Test do
     role = role("monkey")
     conn = api_request(user, :get, "/v1/roles")
     assert %{"roles" => [%{"id" => role.id,
-                           "name" => "monkey"}]} == json_response(conn, 200)
+                           "name" => "monkey",
+                           "permissions" => []}]} == json_response(conn, 200)
   end
 
   test "index returns multiple roles when multiple exist", %{authed: user} do
@@ -41,9 +42,11 @@ defmodule Cog.V1.RoleController.Test do
 
     conn = api_request(user, :get, "/v1/roles")
     assert [%{"id" => first.id,
-              "name" => "first"},
+              "name" => "first",
+              "permissions" => []},
             %{"id" => second.id,
-              "name" => "second"}] == json_response(conn, 200)["roles"] |> sort_by("name")
+              "name" => "second",
+              "permissions" => []}] == json_response(conn, 200)["roles"] |> sort_by("name")
   end
 
   test "create works on the happy path", %{authed: user} do
@@ -76,7 +79,8 @@ defmodule Cog.V1.RoleController.Test do
     role = role("admin")
     conn = api_request(user, :get, "/v1/roles/#{role.id}")
     assert %{"role" => %{"id" => role.id,
-                         "name" => "admin"}} == json_response(conn, 200)
+                         "name" => "admin",
+                         "permissions" => []}} == json_response(conn, 200)
   end
 
   test "show fails when the role doesn't exist", %{authed: user} do
@@ -94,7 +98,8 @@ defmodule Cog.V1.RoleController.Test do
     conn = api_request(user, :put, "/v1/roles/#{role.id}",
                        body: %{"role" => %{"name" => "other"}})
     assert %{"role" => %{"id" => role.id,
-                         "name" => "other"}} == json_response(conn, 200)
+                         "name" => "other",
+                         "permissions" => []}} == json_response(conn, 200)
 
   end
 

--- a/test/controllers/v1/role_grant_controller_test.exs
+++ b/test/controllers/v1/role_grant_controller_test.exs
@@ -81,7 +81,8 @@ defmodule Cog.V1.RoleGrantController.Test do
                            body: %{"roles" => %{"grant" => ["admin"]}})
 
         assert %{"roles" => [%{"id" => role.id,
-                               "name" => role.name}]} == json_response(conn, 200)
+                               "name" => role.name,
+                               "permissions" => []}]} == json_response(conn, 200)
 
         assert_role_is_granted(target, role)
       end
@@ -103,11 +104,14 @@ defmodule Cog.V1.RoleGrantController.Test do
         # Verify the response body
         [admin, dev, ops] = roles
         assert [%{"id" => admin.id,
-                  "name" => admin.name},
+                  "name" => admin.name,
+                  "permissions" => []},
                 %{"id" => dev.id,
-                  "name" => dev.name},
+                  "name" => dev.name,
+                  "permissions" => []},
                 %{"id" => ops.id,
-                  "name" => ops.name}] == granted_roles |> sort_by("name")
+                  "name" => ops.name,
+                  "permissions" => []}] == granted_roles |> sort_by("name")
 
         # Ensure grants are persisted in the database
         assert_role_is_granted(target, roles)
@@ -129,9 +133,11 @@ defmodule Cog.V1.RoleGrantController.Test do
 
         # You should see both roles in the response body
         assert [%{"id" => pre_existing.id,
-                  "name" => pre_existing.name},
+                  "name" => pre_existing.name,
+                  "permissions" => []},
                 %{"id" => new_role.id,
-                  "name" => new_role.name}] == granted_roles |> sort_by("name")
+                  "name" => new_role.name,
+                  "permissions" => []}] == granted_roles |> sort_by("name")
 
         # Verify they're both in the database
         assert_role_is_granted(target, [pre_existing, new_role])
@@ -163,7 +169,8 @@ defmodule Cog.V1.RoleGrantController.Test do
                            body: %{"roles" => %{"grant" => [role.name]}})
 
         assert %{"roles" => [%{"id" => role.id,
-                               "name" => role.name}]} == json_response(conn, 200)
+                               "name" => role.name,
+                               "permissions" => []}]} == json_response(conn, 200)
 
         # Still got it!
         assert_role_is_granted(target, role)
@@ -237,7 +244,8 @@ defmodule Cog.V1.RoleGrantController.Test do
 
         # only the revoked role is, um, revoked
         assert %{"roles" => [%{"id" => remaining_role.id,
-                               "name" => remaining_role.name}]} == json_response(conn, 200)
+                               "name" => remaining_role.name,
+                               "permissions" => []}]} == json_response(conn, 200)
 
         assert_role_is_granted(target, remaining_role)
         refute_role_is_granted(target, to_be_revoked_role)

--- a/web/controllers/v1/permission_controller.ex
+++ b/web/controllers/v1/permission_controller.ex
@@ -1,7 +1,6 @@
 defmodule Cog.V1.PermissionController do
   use Cog.Web, :controller
 
-  alias Cog.Models.EctoJson
   alias Cog.Models.Permission
   alias Cog.Models.Permission.Namespace
   alias Cog.Queries
@@ -18,7 +17,7 @@ defmodule Cog.V1.PermissionController do
     |> Repo.all
     |> Repo.preload(:namespace)
 
-    json(conn, EctoJson.render(permissions, envelope: :permissions, policy: :summary))
+    render(conn, "index.json", permissions: permissions)
   end
 
   @doc """
@@ -37,7 +36,7 @@ defmodule Cog.V1.PermissionController do
         conn
         |> put_status(:created)
         |> put_resp_header("location", permission_path(conn, :show, permission))
-        |> json(EctoJson.render(permission, envelope: :permission, policy: :detail))
+        |> render("show.json", permission: permission)
      {:error, changeset} ->
         conn
         |> put_status(:unprocessable_entity)
@@ -53,7 +52,7 @@ defmodule Cog.V1.PermissionController do
     |> Repo.get!(id)
     |> Repo.preload(:namespace)
 
-    json(conn, EctoJson.render(permission, envelope: :permission, policy: :detail))
+    render(conn, "show.json", permission: permission)
   end
 
   @doc """
@@ -107,7 +106,7 @@ defmodule Cog.V1.PermissionController do
   defp update_permission(conn, changeset) do
     case Repo.update(changeset) do
       {:ok, permission} ->
-        json(conn, EctoJson.render(permission, envelope: :permission, policy: :detail))
+        render(conn, "show.json", permission: permission)
       {:error, changeset} ->
         conn
         |> put_status(:unprocessable_entity)

--- a/web/controllers/v1/permission_grant_controller.ex
+++ b/web/controllers/v1/permission_grant_controller.ex
@@ -1,7 +1,6 @@
 defmodule Cog.V1.PermissionGrantController do
   use Cog.Web, :controller
 
-  alias Cog.Models.EctoJson
   alias Cog.Models.User
   alias Cog.Models.Permission
   alias Cog.Models.Role
@@ -12,6 +11,8 @@ defmodule Cog.V1.PermissionGrantController do
   plug Cog.Plug.Authorization, [permission: "#{Cog.embedded_bundle}:manage_users"] when action == :manage_user_permissions
   plug Cog.Plug.Authorization, [permission: "#{Cog.embedded_bundle}:manage_roles"] when action == :manage_role_permissions
   plug Cog.Plug.Authorization, [permission: "#{Cog.embedded_bundle}:manage_groups"] when action == :manage_group_permissions
+
+  plug :put_view, Cog.V1.PermissionView
 
   def manage_role_permissions(conn, params),
     do: manage_permissions(conn, Role, params)
@@ -44,7 +45,7 @@ defmodule Cog.V1.PermissionGrantController do
     case result do
       {:ok, permittable} ->
         conn
-        |> json(EctoJson.render(permittable.permissions, envelope: :permissions, policy: :detail))
+        |> render("index.json", permissions: permittable.permissions)
       {:error, {:not_found, {"permissions", names}}} ->
         conn
         |> put_status(:unprocessable_entity)

--- a/web/views/permissions_view.ex
+++ b/web/views/permissions_view.ex
@@ -1,0 +1,18 @@
+defmodule Cog.V1.PermissionView do
+  use Cog.Web, :view
+
+  def render("permission.json", %{permission: permission}) do
+    %{id: permission.id,
+      name: permission.name,
+      namespace: permission.namespace.name}
+  end
+
+  def render("index.json", %{permissions: permissions}) do
+    %{permissions: render_many(permissions, __MODULE__, "permission.json")}
+  end
+
+  def render("show.json", %{permission: permission}) do
+    %{permission: render_one(permission, __MODULE__, "permission.json")}
+  end
+
+end

--- a/web/views/roles_view.ex
+++ b/web/views/roles_view.ex
@@ -1,0 +1,26 @@
+defmodule Cog.V1.RoleView do
+  use Cog.Web, :view
+
+  def render("role.json", %{role: role}) do
+    %{id: role.id,
+      name: role.name,
+      permissions: render_permissions(role.permissions)}
+  end
+
+  def render("index.json", %{roles: roles}) do
+    %{roles: render_many(roles, __MODULE__, "role.json")}
+  end
+
+  def render("show.json", %{role: role}) do
+    %{role: render_one(role, __MODULE__, "role.json")}
+  end
+
+  defp render_permissions(permissions) do
+    Enum.map(permissions, fn(permission) ->
+        %{id: permission.id,
+          name: permission.name,
+          namespace: permission.namespace.name}
+    end)
+  end
+
+end


### PR DESCRIPTION
This PR
* adds the show api to the Role controller
* a new permission format
```
%{permissions: [%{namespace: "namespace1",
                               id: "some id",
                               name: "some permission"},
                              %{namespace: "namespace2",
                                  id: "some other id",
                                  name:"some other permission"}]
}
```
* adds permissions to the Role model

Fixes https://github.com/operable/cog/issues/382