### PR TITLE
Fixes "user not found" functionality

### DIFF
--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -564,7 +564,7 @@ defmodule Cog.Command.Pipeline.Executor do
     |> Cog.Queries.Permission.from_full_name
     |> Cog.Repo.one!
     |> Cog.Queries.User.with_permission
-    |> Cog.Queries.User.with_chat_handle_for(adapter)
+    |> Cog.Queries.User.for_chat_provider(adapter)
     |> Cog.Repo.all
     |> Enum.flat_map(&(&1.chat_handles))
     |> Enum.map(&(adapter_module.mention_name(&1.handle)))

--- a/lib/cog/queries/user.ex
+++ b/lib/cog/queries/user.ex
@@ -46,7 +46,8 @@ defmodule Cog.Queries.User do
     from u in queryable,
     join: ch in assoc(u, :chat_handles),
     join: cp in assoc(ch, :chat_provider),
-    where: cp.name == ^chat_provider_name
+    where: cp.name == ^chat_provider_name,
+    preload: [chat_handles: ch]
   end
 
   def for_chat_provider_user_id(chat_provider_user_id, chat_provider_name) do


### PR DESCRIPTION
A recent refactoring around chat handle management inadvertently broke
the "user not found" functionality in the executor.

This commit uses the correct query name, and adds the chat handle
preload back to the query.