### PR TITLE
add assert_message helper

### DIFF
--- a/test/integration/alias_execution_test.exs
+++ b/test/integration/alias_execution_test.exs
@@ -10,45 +10,40 @@ defmodule Integration.AliasExecutionTest do
 
   test "alias executes properly", %{user: user} do
     send_message(user, "@bot: operable:alias new my-alias \"echo my alias\"")
-    response = send_message(user, "@bot: my-alias") |> Map.fetch!("response")
-
-    assert response == "my alias"
+    send_message(user, "@bot: my-alias")
+    |> assert_message("my alias")
   end
 
   test "alias executes properly in the site namespace", %{user: user} do
     send_message(user, "@bot: operable:alias new my-alias \"echo my alias\"")
     send_message(user, "@bot: operable:alias mv my-alias site")
-    response = send_message(user, "@bot: my-alias") |> Map.fetch!("response")
-
-    assert response == "my alias"
+    send_message(user, "@bot: my-alias")
+    |> assert_message("my alias")
   end
 
   test "alias executes properly in pipelines", %{user: user} do
     send_message(user, "@bot: operable:alias new my-alias \"echo my alias\"")
-    response = send_message(user, "@bot: my-alias | echo $body") |> Map.fetch!("response")
-
-    assert response == "my alias"
+    send_message(user, "@bot: my-alias | echo $body")
+    |> assert_message("my alias")
   end
 
   test "alias executes properly in mid pipeline", %{user: user} do
     send_message(user, "@bot: operable:alias new my-alias \"echo $body\"")
-    response = send_message(user, "@bot: echo \"foo\" | my-alias") |> Map.fetch!("response")
-
-    assert response == "foo"
+    send_message(user, "@bot: echo \"foo\" | my-alias")
+    |> assert_message("foo")
   end
 
   test "alias nested expansion works properly", %{user: user} do
     send_message(user, "@bot: operable:alias new my-alias \"echo my alias\"")
     send_message(user, "@bot: operable:alias new my-other-alias \"my-alias\"")
-    response = send_message(user, "@bot: my-other-alias") |> Map.fetch!("response")
-
-    assert response == "my alias"
+    send_message(user, "@bot: my-other-alias")
+    |> assert_message("my alias")
   end
 
   test "alias expansion fails on infinite expansion", %{user: user} do
     send_message(user, "@bot: operable:alias new my-alias \"my-alias\"")
-    response = send_message(user, "@bot: my-alias") |> Map.fetch!("response")
-    assert "@vanstee Alias expansion limit (5) exceeded starting with alias 'my-alias'." = response
+    send_message(user, "@bot: my-alias")
+    |> assert_message("@vanstee Alias expansion limit (5) exceeded starting with alias 'my-alias'.")
   end
 
   test "alias using slack emoji works", %{user: user} do

--- a/test/integration/command_test.exs
+++ b/test/integration/command_test.exs
@@ -9,88 +9,88 @@ defmodule Integration.CommandTest do
   end
 
   test "running a command with a required option", %{user: user} do
-    response = send_message(user, "@bot: operable:req-opt --req=\"foo\"") |> Map.fetch!("response")
-    assert response == "req-opt response"
+    send_message(user, "@bot: operable:req-opt --req=\"foo\"")
+    |> assert_message("req-opt response")
   end
 
   test "running a command with a bad template", %{user: user} do
-    response = send_message(user, "@bot: operable:bad-template") |> Map.fetch!("response")
-    assert response == "@vanstee Whoops! An error occurred. There was an error rendering the template 'badtemplate' for the adapter 'test': %Protocol.UndefinedError{description: nil, protocol: String.Chars, value: %{\"bad\" => %{\"foo\" => \"bar\"}}}"
+    send_message(user, "@bot: operable:bad-template")
+    |> assert_message("@vanstee Whoops! An error occurred. There was an error rendering the template 'badtemplate' for the adapter 'test': %Protocol.UndefinedError{description: nil, protocol: String.Chars, value: %{\"bad\" => %{\"foo\" => \"bar\"}}}")
   end
 
   test "running a command with a required option missing", %{user: user} do
-    response = send_message(user, "@bot: operable:req-opt") |> Map.fetch!("response")
-    assert response == "@vanstee Whoops! An error occurred. Looks like you forgot to include some required options: 'req'"
+    send_message(user, "@bot: operable:req-opt")
+    |> assert_message("@vanstee Whoops! An error occurred. Looks like you forgot to include some required options: 'req'")
   end
 
   test "running a command with a 'string' option", %{user: user} do
-    response = send_message(user, "@bot: operable:type-test --string=\"a string\"") |> Map.fetch!("response")
-    assert response == "type-test response"
+    send_message(user, "@bot: operable:type-test --string=\"a string\"")
+    |> assert_message("type-test response")
   end
 
   test "running a command with a 'bool' option", %{user: user} do
-    response = send_message(user, "@bot: operable:type-test --bool=true") |> Map.fetch!("response")
-    assert response == "type-test response"
+    send_message(user, "@bot: operable:type-test --bool=true")
+    |> assert_message("type-test response")
 
-    response = send_message(user, "@bot: operable:type-test --bool=t") |> Map.fetch!("response")
-    assert response == "type-test response"
+    send_message(user, "@bot: operable:type-test --bool=t")
+    |> assert_message("type-test response")
 
-    response = send_message(user, "@bot: operable:type-test --bool=1") |> Map.fetch!("response")
-    assert response == "type-test response"
+    send_message(user, "@bot: operable:type-test --bool=1")
+    |> assert_message("type-test response")
 
-    response = send_message(user, "@bot: operable:type-test --bool=y") |> Map.fetch!("response")
-    assert response == "type-test response"
+    send_message(user, "@bot: operable:type-test --bool=y")
+    |> assert_message("type-test response")
 
-    response = send_message(user, "@bot: operable:type-test --bool=yes") |> Map.fetch!("response")
-    assert response == "type-test response"
+    send_message(user, "@bot: operable:type-test --bool=yes")
+    |> assert_message("type-test response")
 
-    response = send_message(user, "@bot: operable:type-test --bool=on") |> Map.fetch!("response")
-    assert response == "type-test response"
+    send_message(user, "@bot: operable:type-test --bool=on")
+    |> assert_message("type-test response")
 
-    response = send_message(user, "@bot: operable:type-test --bool") |> Map.fetch!("response")
-    assert response == "type-test response"
+    send_message(user, "@bot: operable:type-test --bool")
+    |> assert_message("type-test response")
   end
 
   test "running a command with an 'int' option", %{user: user} do
-    response = send_message(user, "@bot: operable:type-test --int=1") |> Map.fetch!("response")
-    assert response == "type-test response"
+    send_message(user, "@bot: operable:type-test --int=1")
+    |> assert_message("type-test response")
   end
 
   test "running a command with an invalid 'int' option", %{user: user} do
-    response = send_message(user, "@bot: operable:type-test --int=\"this is a string\"") |> Map.fetch!("response")
-    assert response == "@vanstee Whoops! An error occurred. Type Error: `\"this is a string\"` is not of type `int`"
+    send_message(user, "@bot: operable:type-test --int=\"this is a string\"")
+    |> assert_message("@vanstee Whoops! An error occurred. Type Error: `\"this is a string\"` is not of type `int`")
   end
 
   test "running a command with a 'float' option", %{user: user} do
-    response = send_message(user, "@bot: operable:type-test --float=1.0") |> Map.fetch!("response")
-    assert response == "type-test response"
+    send_message(user, "@bot: operable:type-test --float=1.0")
+    |> assert_message("type-test response")
   end
 
   test "running a command with an invalid 'float' option", %{user: user} do
-    response = send_message(user, "@bot: operable:type-test --float=\"This is a string\"") |> Map.fetch!("response")
-    assert response == "@vanstee Whoops! An error occurred. Type Error: `\"This is a string\"` is not of type `float`"
+    send_message(user, "@bot: operable:type-test --float=\"This is a string\"")
+    |> assert_message("@vanstee Whoops! An error occurred. Type Error: `\"This is a string\"` is not of type `float`")
   end
 
   test "running a command with an 'incr' option", %{user: user} do
-    response = send_message(user, "@bot: operable:type-test --incr") |> Map.fetch!("response")
-    assert response == "type-test response"
+    send_message(user, "@bot: operable:type-test --incr")
+    |> assert_message("type-test response")
   end
 
   test "running the st-echo command with permission", %{user: user} do
     user |> with_permission("operable:st-echo")
 
-    response = send_message(user, "@bot: operable:st-echo test") |> Map.fetch!("response")
-    assert response == "test"
+    send_message(user, "@bot: operable:st-echo test")
+    |> assert_message("test")
   end
 
   test "running the st-echo command without permission", %{user: user} do
-    response = send_message(user, "@bot: operable:st-echo test") |> Map.fetch!("response")
-    assert response == "@vanstee Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command."
+    send_message(user, "@bot: operable:st-echo test")
+    |> assert_message("@vanstee Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command.")
   end
 
   test "running the un-enforced t-echo command without permission", %{user: user} do
-    response = send_message(user, "@bot: operable:t-echo test") |> Map.fetch!("response")
-    assert response == "test"
+    send_message(user, "@bot: operable:t-echo test")
+    |> assert_message("test")
   end
 
   test "running commands in a pipeline", %{user: user} do
@@ -98,74 +98,74 @@ defmodule Integration.CommandTest do
     |> with_permission("operable:echo")
     |> with_permission("operable:thorn")
 
-    response = send_message(user, ~s(@bot: operable:echo "this is a test" | operable:thorn $body)) |> Map.fetch!("response")
-    assert response == "þis is a test"
+    send_message(user, ~s(@bot: operable:echo "this is a test" | operable:thorn $body))
+    |> assert_message("þis is a test")
   end
 
   test "running commands in a pipeline without permission", %{user: user} do
     user |> with_permission("operable:st-echo")
 
-    response = send_message(user, ~s(@bot: operable:st-echo "this is a test" | operable:st-thorn $body)) |> Map.fetch!("response")
-    assert response == "@vanstee Sorry, you aren't allowed to execute 'operable:st-thorn $body' :(\n You will need the 'operable:st-thorn' permission to run this command."
+    send_message(user, ~s(@bot: operable:st-echo "this is a test" | operable:st-thorn $body))
+    |> assert_message("@vanstee Sorry, you aren't allowed to execute 'operable:st-thorn $body' :(\n You will need the 'operable:st-thorn' permission to run this command.")
   end
 
   test "running unknown commands", %{user: user} do
-    response = send_message(user, "@bot: operable:weirdo test") |> Map.fetch!("response")
-    assert response == "@vanstee Command 'weirdo' not found in any installed bundle."
+    send_message(user, "@bot: operable:weirdo test")
+    |> assert_message("@vanstee Command 'weirdo' not found in any installed bundle.")
   end
 
   test "running a command in a pipeline with nil output", %{user: user} do
-    response = send_message(user, ~s(@bot: seed '[{"a": "1", "b": "2"}, {"a": "3"}]' | filter --path=b | echo $a)) |> Map.fetch!("response")
-    assert response == "1"
+    send_message(user, ~s(@bot: seed '[{"a": "1", "b": "2"}, {"a": "3"}]' | filter --path=b | echo $a))
+    |> assert_message("1")
   end
 
   test "running a pipeline with a variable that resolves to a command fails with a parse error", %{user: user} do
-    response = send_message(user, ~s(@bot: echo "echo" | $body[0] foo)) |> Map.fetch!("response")
-    assert response == "@vanstee (Line: 1, Col: 15) syntax error before: \"body\"."
+    send_message(user, ~s(@bot: echo "echo" | $body[0] foo))
+    |> assert_message("@vanstee (Line: 1, Col: 15) syntax error before: \"body\".")
   end
 
   test "reading the path to filter a certain path", %{user: user} do
-    response = send_message(user, ~s(@bot: seed '[{"foo":{"bar":{"baz":"stuff"}}}, {"foo": {"bar":{"baz":"me"}}}]' | operable:filter --path="foo.bar")) |> Map.fetch!("response")
-    assert response == "{\n  \"foo\": {\n    \"bar\": {\n      \"baz\": \"stuff\"\n    }\n  }\n}\n{\n  \"foo\": {\n    \"bar\": {\n      \"baz\": \"me\"\n    }\n  }\n}"
+    send_message(user, ~s(@bot: seed '[{"foo":{"bar":{"baz":"stuff"}}}, {"foo": {"bar":{"baz":"me"}}}]' | operable:filter --path="foo.bar"))
+    |> assert_message("{\n  \"foo\": {\n    \"bar\": {\n      \"baz\": \"stuff\"\n    }\n  }\n}\n{\n  \"foo\": {\n    \"bar\": {\n      \"baz\": \"me\"\n    }\n  }\n}")
   end
 
   test "reading the path to allow quoted path if supplied", %{user: user} do
-    response = send_message(user, ~s(@bot: seed '[{"foo":{"bar.qux":{"baz":"stuff"}}}, {"foo": {"bar":{"baz":"me"}}}]' | operable:filter --path='foo."bar.qux".baz')) |> Map.fetch!("response")
-    assert response == "{\n  \"foo\": {\n    \"bar.qux\": {\n      \"baz\": \"stuff\"\n    }\n  }\n}"
+    send_message(user, ~s(@bot: seed '[{"foo":{"bar.qux":{"baz":"stuff"}}}, {"foo": {"bar":{"baz":"me"}}}]' | operable:filter --path='foo."bar.qux".baz'))
+    |> assert_message("{\n  \"foo\": {\n    \"bar.qux\": {\n      \"baz\": \"stuff\"\n    }\n  }\n}")
   end
 
   test "returning the path that contains the matching value", %{user: user} do
-    response = send_message(user, ~s(@bot: seed '[{"foo":{"bar":{"baz":"stuff"}}}, {"foo": {"bar":{"baz":"me"}}}]' | operable:filter --path="foo.bar.baz" --matches=me)) |> Map.fetch!("response")
-    assert response == "{\n  \"foo\": {\n    \"bar\": {\n      \"baz\": \"me\"\n    }\n  }\n}"
+    send_message(user, ~s(@bot: seed '[{"foo":{"bar":{"baz":"stuff"}}}, {"foo": {"bar":{"baz":"me"}}}]' | operable:filter --path="foo.bar.baz" --matches=me))
+    |> assert_message("{\n  \"foo\": {\n    \"bar\": {\n      \"baz\": \"me\"\n    }\n  }\n}")
   end
 
   test "returning an error if matches is not a valid string", %{user: user} do
-    response = send_message(user, ~s(@bot: seed '{"foo":{"bar":{"baz":"stuff"}}}' | operable:filter --path="foo.bar.baz" --matches="st[uff")) |> Map.fetch!("response")
-    assert response == "@vanstee Whoops! An error occurred. \n* The regular expression in `--matches` does not compile correctly.\n\n"
+    send_message(user, ~s(@bot: seed '{"foo":{"bar":{"baz":"stuff"}}}' | operable:filter --path="foo.bar.baz" --matches="st[uff"))
+     |> assert_message("@vanstee Whoops! An error occurred. \n* The regular expression in `--matches` does not compile correctly.\n\n")
   end
 
   test "returning an error if matches is used without a path", %{user: user} do
-    response = send_message(user, ~s(@bot: seed '{"foo":{"bar":{"baz":"stuff"}}}' | operable:filter --matches="stuff")) |> Map.fetch!("response")
-    assert response == "@vanstee Whoops! An error occurred. \n* Must specify `--path` with the `--matches` option.\n\n"
+    send_message(user, ~s(@bot: seed '{"foo":{"bar":{"baz":"stuff"}}}' | operable:filter --matches="stuff"))
+    |> assert_message("@vanstee Whoops! An error occurred. \n* Must specify `--path` with the `--matches` option.\n\n")
   end
 
   test "an empty response from the filter command single input item", %{user: user} do
-    response = send_message(user, ~s(@bot: seed '[{ "foo": { "one": { "name": "asdf" }, "two": { "name": "fdsa" } } }]' | operable:filter --path="foo.one.name" --matches="/blurp/")) |> Map.fetch!("response")
-    assert response == "Pipeline executed successfully, but no output was returned"
+    send_message(user, ~s(@bot: seed '[{ "foo": { "one": { "name": "asdf" }, "two": { "name": "fdsa" } } }]' | operable:filter --path="foo.one.name" --matches="/blurp/"))
+    |> assert_message("Pipeline executed successfully, but no output was returned")
   end
 
   test "filter matching using regular expression", %{user: user} do
-    response = send_message(user, ~s(@bot: seed '[ {"key": "Name", "value": "test1"}, {"key": "Name", "value": "test2"} ]' | operable:filter --path="value" --matches="test[0-9]")) |> Map.fetch!("response")
-    assert response == "{\n  \"value\": \"test1\",\n  \"key\": \"Name\"\n}\n{\n  \"value\": \"test2\",\n  \"key\": \"Name\"\n}"
+    send_message(user, ~s(@bot: seed '[ {"key": "Name", "value": "test1"}, {"key": "Name", "value": "test2"} ]' | operable:filter --path="value" --matches="test[0-9]"))
+    |> assert_message("{\n  \"value\": \"test1\",\n  \"key\": \"Name\"\n}\n{\n  \"value\": \"test2\",\n  \"key\": \"Name\"\n}")
   end
 
   test "filter where the path has no matching value but the matches value is in the input list", %{user: user} do
-    response = send_message(user, ~s(@bot: seed '[ {"key": "Name", "value": "test1"}, {"key": "Name", "value": "test2"} ]' | operable:filter --path="value" --matches="Name")) |> Map.fetch!("response")
-    assert response == "Pipeline executed successfully, but no output was returned"
+    send_message(user, ~s(@bot: seed '[ {"key": "Name", "value": "test1"}, {"key": "Name", "value": "test2"} ]' | operable:filter --path="value" --matches="Name"))
+    |> assert_message("Pipeline executed successfully, but no output was returned")
   end
 
   test "filter where execution further down the pipeline only executes how many times the output is generated from the filter command", %{user: user} do
-    response = send_message(user, ~s(@bot: seed '[{"key": "foo"}, {"key": "bar"}, {"key": "baz"}]' | operable:filter --path "key" --matches "bar" | operable:echo "do-something-dangerous --option=" $key)) |> Map.fetch!("response")
-    assert response == "do-something-dangerous --option= bar"
+    send_message(user, ~s(@bot: seed '[{"key": "foo"}, {"key": "bar"}, {"key": "baz"}]' | operable:filter --path "key" --matches "bar" | operable:echo "do-something-dangerous --option=" $key))
+    |> assert_message("do-something-dangerous --option= bar")
   end
 end

--- a/test/integration/commands/alias_test.exs
+++ b/test/integration/commands/alias_test.exs
@@ -13,9 +13,10 @@ defmodule Integration.Commands.AliasTest do
   test "creating a new alias", %{user: user} do
     expected_map = %{"name" => "my-new-alias", "pipeline" => "echo My New Alias", "visibility" => "user"}
 
-    response = send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"") |> Map.fetch!("response")
     expected_response = Helpers.render_template("alias-new", expected_map)
-    assert response == expected_response
+
+    send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
+    |> assert_message(expected_response)
 
     new_alias = Repo.get_by(Cog.Models.UserCommandAlias, name: "my-new-alias", user_id: user.id)
     assert new_alias.name == expected_map["name"]
@@ -26,24 +27,25 @@ defmodule Integration.Commands.AliasTest do
   test "creating a new alias with an existing name", %{user: user} do
     send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
 
-    response = send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"") |> Map.fetch!("response")
-    assert response == "@vanstee Whoops! An error occurred. name: The alias name is already in use."
+    send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
+    |> assert_message("@vanstee Whoops! An error occurred. name: The alias name is already in use.")
   end
 
   test "removing an alias", %{user: user} do
     expected_map = %{"name" => "my-new-alias", "pipeline" => "echo My New Alias", "visibility" => "user"}
     send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
 
-    response = send_message(user, "@bot: operable:alias rm my-new-alias") |> Map.fetch!("response")
     expected_response = Helpers.render_template("alias-rm", expected_map)
-    assert response == expected_response
+
+    send_message(user, "@bot: operable:alias rm my-new-alias")
+    |> assert_message(expected_response)
 
     assert Repo.get_by(Cog.Models.UserCommandAlias, name: "my-new-alias", user_id: user.id) == nil
   end
 
   test "removing an alias that does not exist", %{user: user} do
-    response = send_message(user, "@bot: operable:alias rm my-new-alias") |> Map.fetch!("response")
-    assert response == "@vanstee Whoops! An error occurred. I can't find 'my-new-alias'. Please try again"
+    send_message(user, "@bot: operable:alias rm my-new-alias")
+    |> assert_message("@vanstee Whoops! An error occurred. I can't find 'my-new-alias'. Please try again")
   end
 
   test "moving an alias to site using full visibility syntax", %{user: user} do
@@ -56,9 +58,9 @@ defmodule Integration.Commands.AliasTest do
 
     send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
 
-    response = send_message(user, "@bot: operable:alias mv user:my-new-alias site") |> Map.fetch!("response")
     expected_response = Helpers.render_template("alias-mv", expected_map)
-    assert response == expected_response
+    send_message(user, "@bot: operable:alias mv user:my-new-alias site")
+    |> assert_message(expected_response)
 
     command_alias = Repo.get_by(Cog.Models.SiteCommandAlias, name: "my-new-alias")
     assert command_alias.name == "my-new-alias"
@@ -74,9 +76,9 @@ defmodule Integration.Commands.AliasTest do
 
     send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
 
-    response = send_message(user, "@bot: operable:alias mv user:my-new-alias site:my-renamed-alias") |> Map.fetch!("response")
     expected_response = Helpers.render_template("alias-mv", expected_map)
-    assert response == expected_response
+    send_message(user, "@bot: operable:alias mv user:my-new-alias site:my-renamed-alias")
+    |> assert_message(expected_response)
 
     command_alias = Repo.get_by(Cog.Models.SiteCommandAlias, name: "my-renamed-alias")
     assert command_alias.name == "my-renamed-alias"
@@ -92,9 +94,9 @@ defmodule Integration.Commands.AliasTest do
 
     send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
 
-    response = send_message(user, "@bot: operable:alias mv my-new-alias site") |> Map.fetch!("response")
     expected_response = Helpers.render_template("alias-mv", expected_map)
-    assert response == expected_response
+    send_message(user, "@bot: operable:alias mv my-new-alias site")
+    |> assert_message(expected_response)
 
     command_alias = Repo.get_by(Cog.Models.SiteCommandAlias, name: "my-new-alias")
     assert command_alias.name == "my-new-alias"
@@ -110,9 +112,9 @@ defmodule Integration.Commands.AliasTest do
 
     send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
 
-    response = send_message(user, "@bot: operable:alias mv my-new-alias site:my-renamed-alias") |> Map.fetch!("response")
     expected_response = Helpers.render_template("alias-mv", expected_map)
-    assert response == expected_response
+    send_message(user, "@bot: operable:alias mv my-new-alias site:my-renamed-alias")
+    |> assert_message(expected_response)
 
     command_alias = Repo.get_by(Cog.Models.SiteCommandAlias, name: "my-renamed-alias")
     assert command_alias.name == "my-renamed-alias"
@@ -129,9 +131,9 @@ defmodule Integration.Commands.AliasTest do
     send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
     send_message(user, "@bot: operable:alias mv my-new-alias site")
 
-    response = send_message(user, "@bot: operable:alias mv site:my-new-alias user") |> Map.fetch!("response")
     expected_response = Helpers.render_template("alias-mv", expected_map)
-    assert response == expected_response
+    send_message(user, "@bot: operable:alias mv site:my-new-alias user")
+    |> assert_message(expected_response)
 
     command_alias = Repo.get_by(Cog.Models.UserCommandAlias, name: "my-new-alias")
     assert command_alias.name == "my-new-alias"
@@ -148,9 +150,9 @@ defmodule Integration.Commands.AliasTest do
     send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
     send_message(user, "@bot: operable:alias mv my-new-alias site")
 
-    response = send_message(user, "@bot: operable:alias mv site:my-new-alias user:my-renamed-alias") |> Map.fetch!("response")
     expected_response = Helpers.render_template("alias-mv", expected_map)
-    assert response == expected_response
+    send_message(user, "@bot: operable:alias mv site:my-new-alias user:my-renamed-alias")
+    |> assert_message(expected_response)
 
     command_alias = Repo.get_by(Cog.Models.UserCommandAlias, name: "my-renamed-alias")
     assert command_alias.name == "my-renamed-alias"
@@ -167,9 +169,9 @@ defmodule Integration.Commands.AliasTest do
     send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
     send_message(user, "@bot: operable:alias mv my-new-alias site")
 
-    response = send_message(user, "@bot: operable:alias mv my-new-alias user") |> Map.fetch!("response")
     expected_response = Helpers.render_template("alias-mv", expected_map)
-    assert response == expected_response
+    send_message(user, "@bot: operable:alias mv my-new-alias user")
+    |> assert_message(expected_response)
 
     command_alias = Repo.get_by(Cog.Models.UserCommandAlias, name: "my-new-alias")
     assert command_alias.name == "my-new-alias"
@@ -186,9 +188,9 @@ defmodule Integration.Commands.AliasTest do
     send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
     send_message(user, "@bot: operable:alias mv my-new-alias site")
 
-    response = send_message(user, "@bot: operable:alias mv my-new-alias user:my-renamed-alias") |> Map.fetch!("response")
     expected_response = Helpers.render_template("alias-mv", expected_map)
-    assert response == expected_response
+    send_message(user, "@bot: operable:alias mv my-new-alias user:my-renamed-alias")
+    |> assert_message(expected_response)
 
     command_alias = Repo.get_by(Cog.Models.UserCommandAlias, name: "my-renamed-alias")
     assert command_alias.name == "my-renamed-alias"
@@ -204,9 +206,9 @@ defmodule Integration.Commands.AliasTest do
 
     send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
 
-    response = send_message(user, "@bot: operable:alias mv my-new-alias my-renamed-alias") |> Map.fetch!("response")
     expected_response = Helpers.render_template("alias-mv", expected_map)
-    assert response == expected_response
+    send_message(user, "@bot: operable:alias mv my-new-alias my-renamed-alias")
+    |> assert_message(expected_response)
 
     command_alias = Repo.get_by(Cog.Models.UserCommandAlias, name: "my-renamed-alias")
     assert command_alias.name == "my-renamed-alias"
@@ -223,9 +225,9 @@ defmodule Integration.Commands.AliasTest do
     send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
     send_message(user, "@bot: operable:alias mv my-new-alias site")
 
-    response = send_message(user, "@bot: operable:alias mv my-new-alias my-renamed-alias") |> Map.fetch!("response")
     expected_response = Helpers.render_template("alias-mv", expected_map)
-    assert response == expected_response
+    send_message(user, "@bot: operable:alias mv my-new-alias my-renamed-alias")
+    |> assert_message(expected_response)
 
     command_alias = Repo.get_by(Cog.Models.SiteCommandAlias, name: "my-renamed-alias")
     assert command_alias.name == "my-renamed-alias"
@@ -236,8 +238,8 @@ defmodule Integration.Commands.AliasTest do
     send_message(user, "@bot: operable:alias mv my-new-alias site")
     send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
 
-    response = send_message(user, "@bot: operable:alias mv user:my-new-alias site") |> Map.fetch!("response")
-    assert response == "@vanstee Whoops! An error occurred. name: The alias name is already in use."
+    send_message(user, "@bot: operable:alias mv user:my-new-alias site")
+    |> assert_message("@vanstee Whoops! An error occurred. name: The alias name is already in use.")
   end
 
   test "moving an alias to user when an alias with that name already exists in user", %{user: user} do
@@ -245,8 +247,8 @@ defmodule Integration.Commands.AliasTest do
     send_message(user, "@bot: operable:alias mv my-new-alias site")
     send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
 
-    response = send_message(user, "@bot: operable:alias mv site:my-new-alias user") |> Map.fetch!("response")
-    assert response == "@vanstee Whoops! An error occurred. name: The alias name is already in use."
+    send_message(user, "@bot: operable:alias mv site:my-new-alias user")
+    |> assert_message("@vanstee Whoops! An error occurred. name: The alias name is already in use.")
   end
 
   test "list all aliases", %{user: user} do
@@ -269,9 +271,9 @@ defmodule Integration.Commands.AliasTest do
                     "pipeline" => "echo My New Alias",
                     "name" => "my-new-alias"}]
 
-    response = send_message(user, "@bot: operable:alias ls") |> Map.fetch!("response")
     expected_response = Helpers.render_template("alias-ls", Enum.sort(alias_list))
-    assert response == expected_response
+    send_message(user, "@bot: operable:alias ls")
+    |> assert_message(expected_response)
   end
 
   test "list all aliases matching a pattern", %{user: user} do
@@ -288,54 +290,54 @@ defmodule Integration.Commands.AliasTest do
                     "pipeline" => "echo My New Alias",
                     "name" => "my-new-alias1"}]
 
-    response = send_message(user, "@bot: operable:alias ls \"my-*\"") |> Map.fetch!("response")
     expected_response = Helpers.render_template("alias-ls", Enum.sort(alias_list))
-    assert response == expected_response
+    send_message(user, "@bot: operable:alias ls \"my-*\"")
+    |> assert_message(expected_response)
   end
 
   test "list all aliases with no matching aliases", %{user: user} do
-    response = send_message(user, "@bot: operable:alias ls \"my-*\"") |> Map.fetch!("response")
-    assert response == "Pipeline executed successfully, but no output was returned"
+    send_message(user, "@bot: operable:alias ls \"my-*\"")
+    |> assert_message("Pipeline executed successfully, but no output was returned")
   end
 
   test "list all aliases with no aliases", %{user: user} do
-    response = send_message(user, "@bot: operable:alias ls") |> Map.fetch!("response")
-    assert response == "Pipeline executed successfully, but no output was returned"
+    send_message(user, "@bot: operable:alias ls")
+    |> assert_message("Pipeline executed successfully, but no output was returned")
   end
 
   test "list aliases with an invalid pattern", %{user: user} do
-    response = send_message(user, "@bot: operable:alias ls \"% &my#-*\"") |> Map.fetch!("response")
-    assert response == "@vanstee Whoops! An error occurred. Invalid alias name. Only emoji, letters, numbers, and the following special characters are allowed: *, -, _"
+    send_message(user, "@bot: operable:alias ls \"% &my#-*\"")
+    |> assert_message("@vanstee Whoops! An error occurred. Invalid alias name. Only emoji, letters, numbers, and the following special characters are allowed: *, -, _")
   end
 
   test "list aliases with too many wildcards", %{user: user} do
-    response = send_message(user, "@bot: operable:alias ls \"*my-*\"") |> Map.fetch!("response")
-    assert response == "@vanstee Whoops! An error occurred. Too many wildcards. You can only include one wildcard in a query"
+    send_message(user, "@bot: operable:alias ls \"*my-*\"")
+    |> assert_message("@vanstee Whoops! An error occurred. Too many wildcards. You can only include one wildcard in a query")
   end
 
   test "list aliases with a bad pattern and too many wildcards", %{user: user} do
-    response = send_message(user, "@bot: operable:alias ls \"*m++%y-*\"") |> Map.fetch!("response")
-    assert response == "@vanstee Whoops! An error occurred. Too many wildcards. You can only include one wildcard in a query\nInvalid alias name. Only emoji, letters, numbers, and the following special characters are allowed: *, -, _"
+    send_message(user, "@bot: operable:alias ls \"*m++%y-*\"")
+    |> assert_message("@vanstee Whoops! An error occurred. Too many wildcards. You can only include one wildcard in a query\nInvalid alias name. Only emoji, letters, numbers, and the following special characters are allowed: *, -, _")
   end
 
   test "passing too many args", %{user: user} do
-    response = send_message(user, "@bot: operable:alias new my-invalid-alias \"echo foo\" invalid-arg") |> Map.fetch!("response")
-    assert response == "@vanstee Whoops! An error occurred. Too many args. Arguments required: exactly 2."
+    send_message(user, "@bot: operable:alias new my-invalid-alias \"echo foo\" invalid-arg")
+    |> assert_message("@vanstee Whoops! An error occurred. Too many args. Arguments required: exactly 2.")
   end
 
   test "passing too few args", %{user: user} do
-    response = send_message(user, "@bot: operable:alias new my-invalid-alias") |> Map.fetch!("response")
-    assert response == "@vanstee Whoops! An error occurred. Not enough args. Arguments required: exactly 2."
+    send_message(user, "@bot: operable:alias new my-invalid-alias")
+    |> assert_message("@vanstee Whoops! An error occurred. Not enough args. Arguments required: exactly 2.")
   end
 
   test "passing an unknown subcommand", %{user: user} do
-    response = send_message(user, "@bot: operable:alias foo") |> Map.fetch!("response")
-    assert response == "@vanstee Whoops! An error occurred. Unknown subcommand 'foo'"
+    send_message(user, "@bot: operable:alias foo")
+    |> assert_message("@vanstee Whoops! An error occurred. Unknown subcommand 'foo'")
   end
 
   test "passing now subcommand", %{user: user} do
-    response = send_message(user, "@bot: operable:alias") |> Map.fetch!("response")
-    assert response == "@vanstee Whoops! An error occurred. I don't what to do, please specify a subcommand"
+    send_message(user, "@bot: operable:alias")
+    |> assert_message("@vanstee Whoops! An error occurred. I don't what to do, please specify a subcommand")
   end
 
 end

--- a/test/integration/commands/table_test.exs
+++ b/test/integration/commands/table_test.exs
@@ -10,11 +10,11 @@ defmodule Integration.Commands.TableTest do
 
   # TODO: Figure out a better way of testing this without a template
   test "displaying data in a table", %{user: user} do
-    response = send_message(user, ~s<@bot: seed '[{"foo": "foo1", "bar": "bar1", "baz": "baz1"}, {"foo": "foo2", "bar": "bar2", "baz": "baz2"}]' | table --fields "foo,bar,baz">) |> Map.fetch!("response")
-    assert response == """
+    send_message(user, ~s<@bot: seed '[{"foo": "foo1", "bar": "bar1", "baz": "baz1"}, {"foo": "foo2", "bar": "bar2", "baz": "baz2"}]' | table --fields "foo,bar,baz">)
+    |> assert_message(String.rstrip("""
     {
       "table": "foo   bar   baz \\nfoo1  bar1  baz1\\nfoo2  bar2  baz2"
     }
-    """ |> String.rstrip
+    """))
   end
 end

--- a/test/integration/commands/which_test.exs
+++ b/test/integration/commands/which_test.exs
@@ -14,9 +14,9 @@ defmodule Integration.Commands.WhichTest do
 
     send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
 
-    response = send_message(user, "@bot: operable:which my-new-alias") |> Map.fetch!("response")
     expected_response = Helpers.render_template("which", expected_map)
-    assert response == expected_response
+    send_message(user, "@bot: operable:which my-new-alias")
+    |> assert_message(expected_response)
   end
 
   test "an alias in the 'site' visibility", %{user: user} do
@@ -25,25 +25,25 @@ defmodule Integration.Commands.WhichTest do
     send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
     send_message(user, "@bot: operable:alias mv my-new-alias site")
 
-    response = send_message(user, "@bot: operable:which my-new-alias") |> Map.fetch!("response")
     expected_response = Helpers.render_template("which", expected_map)
-    assert response == expected_response
+    send_message(user, "@bot: operable:which my-new-alias")
+    |> assert_message(expected_response)
   end
 
   test "a command", %{user: user} do
     expected_map = %{type: "command", scope: "operable", name: "alias"}
 
-    response = send_message(user, "@bot: operable:which alias") |> Map.fetch!("response")
     expected_response = Helpers.render_template("which", expected_map)
-    assert response == expected_response
+    send_message(user, "@bot: operable:which alias")
+    |> assert_message(expected_response)
   end
 
   test "an unknown", %{user: user} do
     expected_map = %{not_found: true}
 
-    response = send_message(user, "@bot: operable:which foo") |> Map.fetch!("response")
     expected_response = Helpers.render_template("which", expected_map)
-    assert response == expected_response
+    send_message(user, "@bot: operable:which foo")
+    |> assert_message(expected_response)
   end
 
 end

--- a/test/integration/group_test.exs
+++ b/test/integration/group_test.exs
@@ -11,97 +11,97 @@ defmodule Integration.GroupTest do
   end
 
   test "adding a user to a group", %{user: user} do
-    response = send_message(user, "@bot: operable:group --add --user=#{user.username} elves") |> Map.fetch!("response")
-    assert response == "@belf Whoops! An error occurred. ERROR! Could not find group `elves`"
+    send_message(user, "@bot: operable:group --add --user=#{user.username} elves")
+    |> assert_message("@belf Whoops! An error occurred. ERROR! Could not find group `elves`")
 
-    response = send_message(user, "@bot: operable:group --create elves") |> Map.fetch!("response")
-    assert response == "The group `elves` has been created."
+    send_message(user, "@bot: operable:group --create elves")
+    |> assert_message("The group `elves` has been created.")
 
-    response = send_message(user, "@bot: operable:group --add --user=papa_elf elves") |> Map.fetch!("response")
-    assert response == "@belf Whoops! An error occurred. ERROR! Could not find user `papa_elf`"
+    send_message(user, "@bot: operable:group --add --user=papa_elf elves")
+    |> assert_message("@belf Whoops! An error occurred. ERROR! Could not find user `papa_elf`")
 
-    response = send_message(user, "@bot: operable:group --add elves") |> Map.fetch!("response")
-    assert response == "@belf Whoops! An error occurred. ERROR! Must specify a target to act upon. See `operable:help operable:group` for more details."
+    send_message(user, "@bot: operable:group --add elves")
+    |> assert_message("@belf Whoops! An error occurred. ERROR! Must specify a target to act upon. See `operable:help operable:group` for more details.")
 
-    response = send_message(user, "@bot: operable:group --add --user=belf elves") |> Map.fetch!("response")
-    assert response == "Added the user `belf` to the group `elves`"
+    send_message(user, "@bot: operable:group --add --user=belf elves")
+    |> assert_message("Added the user `belf` to the group `elves`")
   end
 
   test "creating a group", %{user: user} do
-    response = send_message(user, "@bot: operable:group --create test") |> Map.fetch!("response")
-    assert response == "The group `test` has been created."
+    send_message(user, "@bot: operable:group --create test")
+    |> assert_message("The group `test` has been created.")
 
-    response = send_message(user, "@bot: operable:group --create test") |> Map.fetch!("response")
-    assert response == "@belf Whoops! An error occurred. ERROR! The group `test` already exists."
+    send_message(user, "@bot: operable:group --create test")
+    |> assert_message("@belf Whoops! An error occurred. ERROR! The group `test` already exists.")
   end
 
   test "adding a group to a group", %{user: user} do
     group = group("elves")
 
-    response = send_message(user, "@bot: operable:group --add --group=#{group.name} cheer") |> Map.fetch!("response")
-    assert response == "@belf Whoops! An error occurred. ERROR! Could not find group `cheer`"
+    send_message(user, "@bot: operable:group --add --group=#{group.name} cheer")
+    |> assert_message("@belf Whoops! An error occurred. ERROR! Could not find group `cheer`")
 
-    response = send_message(user, "@bot: operable:group --create cheer") |> Map.fetch!("response")
-    assert response == "The group `cheer` has been created."
+    send_message(user, "@bot: operable:group --create cheer")
+    |> assert_message("The group `cheer` has been created.")
 
-    response = send_message(user, "@bot: operable:group --add --group=humbug cheer") |> Map.fetch!("response")
-    assert response == "@belf Whoops! An error occurred. ERROR! Could not find group `humbug`"
+    send_message(user, "@bot: operable:group --add --group=humbug cheer")
+    |> assert_message("@belf Whoops! An error occurred. ERROR! Could not find group `humbug`")
 
-    response = send_message(user, "@bot: operable:group --add --group=#{group.name} cheer") |> Map.fetch!("response")
-    assert response == "Added the group `elves` to the group `cheer`"
+    send_message(user, "@bot: operable:group --add --group=#{group.name} cheer")
+    |> assert_message("Added the group `elves` to the group `cheer`")
   end
 
   test "errors using the group command", %{user: user} do
-    response = send_message(user, "@bot: operable:group --create ") |> Map.fetch!("response")
-    assert response == "@belf Whoops! An error occurred. ERROR! Unable to create ``:\nMissing name"
+    send_message(user, "@bot: operable:group --create ")
+    |> assert_message("@belf Whoops! An error occurred. ERROR! Unable to create ``:\nMissing name")
 
-    response = send_message(user, "@bot: operable:group --add --user=belf") |> Map.fetch!("response")
-    assert response == "@belf Whoops! An error occurred. ERROR! Must specify a group to modify."
+    send_message(user, "@bot: operable:group --add --user=belf")
+    |> assert_message("@belf Whoops! An error occurred. ERROR! Must specify a group to modify.")
   end
 
   test "dropping a group", %{user: user} do
     group("cheer")
-    response = send_message(user, "@bot: operable:group --add --user=belf cheer") |> Map.fetch!("response")
-    assert response == "Added the user `belf` to the group `cheer`"
+    send_message(user, "@bot: operable:group --add --user=belf cheer")
+    |> assert_message("Added the user `belf` to the group `cheer`")
 
-    response = send_message(user, "@bot: operable:group --drop cheer") |> Map.fetch!("response")
-    assert response == "The group `cheer` has been deleted."
+    send_message(user, "@bot: operable:group --drop cheer")
+    |> assert_message("The group `cheer` has been deleted.")
 
-    response = send_message(user, "@bot: operable:group --remove --user=belf cheer") |> Map.fetch!("response")
-    assert response == "@belf Whoops! An error occurred. ERROR! Could not find group `cheer`"
+    send_message(user, "@bot: operable:group --remove --user=belf cheer")
+    |> assert_message("@belf Whoops! An error occurred. ERROR! Could not find group `cheer`")
   end
 
   test "removing a group", %{user: user} do
     group("elves")
 
-    response = send_message(user, "@bot: operable:group --add --group=elves cheer") |> Map.fetch!("response")
-    assert response == "@belf Whoops! An error occurred. ERROR! Could not find group `cheer`"
+    send_message(user, "@bot: operable:group --add --group=elves cheer")
+    |> assert_message("@belf Whoops! An error occurred. ERROR! Could not find group `cheer`")
 
     group("cheer")
-    response = send_message(user, "@bot: operable:group --add --group=elves cheer") |> Map.fetch!("response")
-    assert response == "Added the group `elves` to the group `cheer`"
+    send_message(user, "@bot: operable:group --add --group=elves cheer")
+    |> assert_message("Added the group `elves` to the group `cheer`")
 
-    response = send_message(user, "@bot: operable:group --remove --group=elves cheer") |> Map.fetch!("response")
-    assert response == "Removed the group `elves` from the group `cheer`"
+    send_message(user, "@bot: operable:group --remove --group=elves cheer")
+    |> assert_message("Removed the group `elves` from the group `cheer`")
   end
 
   test "listing group", %{user: user} do
     group("elves")
     group("cheer")
 
-    response = send_message(user, "@bot: operable:group --add --group=elves cheer") |> Map.fetch!("response")
-    assert response == "Added the group `elves` to the group `cheer`"
+    send_message(user, "@bot: operable:group --add --group=elves cheer")
+    |> assert_message("Added the group `elves` to the group `cheer`")
 
-    response = send_message(user, "@bot: operable:group --add --user=belf cheer") |> Map.fetch!("response")
-    assert response == "Added the user `belf` to the group `cheer`"
+    send_message(user, "@bot: operable:group --add --user=belf cheer")
+    |> assert_message("Added the user `belf` to the group `cheer`")
 
-    response = send_message(user, "@bot: operable:group --list") |> Map.fetch!("response")
-    assert response == "The following are the available groups: \n* cheer\n* elves\n"
+    send_message(user, "@bot: operable:group --list")
+    |> assert_message("The following are the available groups: \n* cheer\n* elves\n")
 
-    response = send_message(user, "@bot: operable:group --drop cheer") |> Map.fetch!("response")
-    assert response == "The group `cheer` has been deleted."
+    send_message(user, "@bot: operable:group --drop cheer")
+    |> assert_message("The group `cheer` has been deleted.")
 
-    response = send_message(user, "@bot: operable:group --list") |> Map.fetch!("response")
-    assert response == "The following are the available groups: \n* elves\n"
+    send_message(user, "@bot: operable:group --list")
+    |> assert_message("The following are the available groups: \n* elves\n")
   end
 end

--- a/test/integration/permission_test.exs
+++ b/test/integration/permission_test.exs
@@ -18,85 +18,85 @@ defmodule Integration.PermissionTest do
   end
 
   test "granting a permission to a user", %{user: user} do
-    response = send_message(user, "@bot: operable:st-echo test") |> Map.fetch!("response")
-    assert response == "@vanstee Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command."
+    send_message(user, "@bot: operable:st-echo test")
+    |> assert_message("@vanstee Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command.")
 
-    response = send_message(user, "@bot: operable:permissions --grant --user=vanstee --permission=operable:st-echo") |> Map.fetch!("response")
-    assert response == "Granted permission `operable:st-echo` to user `vanstee`"
+    send_message(user, "@bot: operable:permissions --grant --user=vanstee --permission=operable:st-echo")
+    |> assert_message("Granted permission `operable:st-echo` to user `vanstee`")
 
-    response = send_message(user, "@bot: operable:st-echo test") |> Map.fetch!("response")
-    assert response == "test"
+    send_message(user, "@bot: operable:st-echo test")
+    |> assert_message("test")
   end
 
   test "granting a permission to a group", %{user: user} do
-    response = send_message(user, "@bot: operable:st-echo test") |> Map.fetch!("response")
-    assert response == "@vanstee Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command."
+    send_message(user, "@bot: operable:st-echo test")
+    |> assert_message("@vanstee Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command.")
 
-    response = send_message(user, "@bot: operable:permissions --grant --group=ops --permission=operable:st-echo") |> Map.fetch!("response")
-    assert response == "Granted permission `operable:st-echo` to group `ops`"
+    send_message(user, "@bot: operable:permissions --grant --group=ops --permission=operable:st-echo")
+    |> assert_message("Granted permission `operable:st-echo` to group `ops`")
 
-    response = send_message(user, "@bot: operable:st-echo test") |> Map.fetch!("response")
-    assert response == "test"
+    send_message(user, "@bot: operable:st-echo test")
+    |> assert_message("test")
   end
 
   test "granting a permission to a role", %{user: user} do
-    response = send_message(user, "@bot: operable:st-echo test") |> Map.fetch!("response")
-    assert response == "@vanstee Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command."
+    send_message(user, "@bot: operable:st-echo test")
+    |> assert_message("@vanstee Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command.")
 
-    response = send_message(user, "@bot: operable:permissions --grant --role=admin --permission=operable:st-echo") |> Map.fetch!("response")
-    assert response == "Granted permission `operable:st-echo` to role `admin`"
+    send_message(user, "@bot: operable:permissions --grant --role=admin --permission=operable:st-echo")
+    |> assert_message("Granted permission `operable:st-echo` to role `admin`")
 
-    response = send_message(user, "@bot: operable:st-echo test") |> Map.fetch!("response")
-    assert response == "test"
+    send_message(user, "@bot: operable:st-echo test")
+    |> assert_message("test")
   end
 
   test "granting a permission to a user without the grant permission" do
     mctesterson = user("mctesterson", first_name: "Testy", last_name: "McTesterson")
     |> with_chat_handle_for("test")
 
-    response = send_message(mctesterson, "@bot: operable:permissions --grant --user=mctesterson --permission=operable:st-echo") |> Map.fetch!("response")
-    assert response == "@mctesterson Sorry, you aren't allowed to execute 'operable:permissions --grant --user=mctesterson --permission=operable:st-echo' :(\n You will need the 'operable:manage_users' permission to run this command."
+    send_message(mctesterson, "@bot: operable:permissions --grant --user=mctesterson --permission=operable:st-echo")
+    |> assert_message("@mctesterson Sorry, you aren't allowed to execute 'operable:permissions --grant --user=mctesterson --permission=operable:st-echo' :(\n You will need the 'operable:manage_users' permission to run this command.")
   end
 
   test "revoking a permission from a user", %{user: user} do
-    response = send_message(user, "@bot: operable:permissions --grant --user=vanstee --permission=operable:st-echo") |> Map.fetch!("response")
-    assert response == "Granted permission `operable:st-echo` to user `vanstee`"
+    send_message(user, "@bot: operable:permissions --grant --user=vanstee --permission=operable:st-echo")
+    |> assert_message("Granted permission `operable:st-echo` to user `vanstee`")
 
-    response = send_message(user, "@bot: operable:st-echo good_test") |> Map.fetch!("response")
-    assert response == "good_test"
+    send_message(user, "@bot: operable:st-echo good_test")
+    |> assert_message("good_test")
 
-    response = send_message(user, "@bot: operable:permissions --revoke --user=vanstee --permission=operable:st-echo") |> Map.fetch!("response")
-    assert response == "Revoked permission `operable:st-echo` from user `vanstee`"
+    send_message(user, "@bot: operable:permissions --revoke --user=vanstee --permission=operable:st-echo")
+    |> assert_message("Revoked permission `operable:st-echo` from user `vanstee`")
 
-    response = send_message(user, "@bot: operable:st-echo fail_test") |> Map.fetch!("response")
-    assert response == "@vanstee Sorry, you aren't allowed to execute 'operable:st-echo fail_test' :(\n You will need the 'operable:st-echo' permission to run this command."
+    send_message(user, "@bot: operable:st-echo fail_test")
+    |> assert_message("@vanstee Sorry, you aren't allowed to execute 'operable:st-echo fail_test' :(\n You will need the 'operable:st-echo' permission to run this command.")
   end
 
   test "revoking a permission from a group", %{user: user} do
-    response = send_message(user, "@bot: operable:permissions --grant --group=ops --permission=operable:st-echo") |> Map.fetch!("response")
-    assert response == "Granted permission `operable:st-echo` to group `ops`"
+    send_message(user, "@bot: operable:permissions --grant --group=ops --permission=operable:st-echo")
+    |> assert_message("Granted permission `operable:st-echo` to group `ops`")
 
-    response = send_message(user, "@bot: operable:st-echo test") |> Map.fetch!("response")
-    assert response == "test"
+    send_message(user, "@bot: operable:st-echo test")
+    |> assert_message("test")
 
-    response = send_message(user, "@bot: operable:permissions --revoke --group=ops --permission=operable:st-echo") |> Map.fetch!("response")
-    assert response == "Revoked permission `operable:st-echo` from group `ops`"
+    send_message(user, "@bot: operable:permissions --revoke --group=ops --permission=operable:st-echo")
+    |> assert_message("Revoked permission `operable:st-echo` from group `ops`")
 
-    response = send_message(user, "@bot: operable:st-echo test") |> Map.fetch!("response")
-    assert response == "@vanstee Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command."
+    send_message(user, "@bot: operable:st-echo test")
+    |> assert_message("@vanstee Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command.")
   end
 
   test "revoking a permission from a role", %{user: user} do
-    response = send_message(user, "@bot: operable:permissions --grant --role=admin --permission=operable:st-echo") |> Map.fetch!("response")
-    assert response == "Granted permission `operable:st-echo` to role `admin`"
+    send_message(user, "@bot: operable:permissions --grant --role=admin --permission=operable:st-echo")
+    |> assert_message("Granted permission `operable:st-echo` to role `admin`")
 
-    response = send_message(user, "@bot: operable:st-echo test") |> Map.fetch!("response")
-    assert response == "test"
+    send_message(user, "@bot: operable:st-echo test")
+    |> assert_message("test")
 
-    response = send_message(user, "@bot: operable:permissions --revoke --role=admin --permission=operable:st-echo") |> Map.fetch!("response")
-    assert response == "Revoked permission `operable:st-echo` from role `admin`"
+    send_message(user, "@bot: operable:permissions --revoke --role=admin --permission=operable:st-echo")
+    |> assert_message("Revoked permission `operable:st-echo` from role `admin`")
 
-    response = send_message(user, "@bot: operable:st-echo test") |> Map.fetch!("response")
-    assert response == "@vanstee Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command."
+    send_message(user, "@bot: operable:st-echo test")
+    |> assert_message("@vanstee Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command.")
   end
 end

--- a/test/integration/role_test.exs
+++ b/test/integration/role_test.exs
@@ -12,97 +12,97 @@ defmodule Integration.RoleTest do
   end
 
   test "granting a role to a user", %{user: user} do
-    response = send_message(user, "@bot: operable:role --grant --user=#{user.username} cheer") |> Map.fetch!("response")
-    assert response == "@belf Whoops! An error occurred. ERROR! Could not find role `cheer`"
+    send_message(user, "@bot: operable:role --grant --user=#{user.username} cheer")
+    |> assert_message("@belf Whoops! An error occurred. ERROR! Could not find role `cheer`")
 
-    response = send_message(user, "@bot: operable:role --create cheer") |> Map.fetch!("response")
-    assert response == "The role `cheer` has been created."
+    send_message(user, "@bot: operable:role --create cheer")
+    |> assert_message("The role `cheer` has been created.")
 
-    response = send_message(user, "@bot: operable:role --grant --user=papa_elf cheer") |> Map.fetch!("response")
-    assert response == "@belf Whoops! An error occurred. ERROR! Could not find user `papa_elf`"
+    send_message(user, "@bot: operable:role --grant --user=papa_elf cheer")
+    |> assert_message("@belf Whoops! An error occurred. ERROR! Could not find user `papa_elf`")
 
-    response = send_message(user, "@bot: operable:role --grant cheer") |> Map.fetch!("response")
-    assert response == "@belf Whoops! An error occurred. ERROR! Must specify a target to act upon. See `operable:help operable:role` for more details."
+    send_message(user, "@bot: operable:role --grant cheer")
+    |> assert_message("@belf Whoops! An error occurred. ERROR! Must specify a target to act upon. See `operable:help operable:role` for more details.")
 
-    response = send_message(user, "@bot: operable:role --grant --user=belf cheer") |> Map.fetch!("response")
-    assert response == "Granted role `cheer` to user `belf`"
+    send_message(user, "@bot: operable:role --grant --user=belf cheer")
+    |> assert_message("Granted role `cheer` to user `belf`")
   end
 
   test "creating a role", %{user: user} do
-    response = send_message(user, "@bot: operable:role --create test") |> Map.fetch!("response")
-    assert response == "The role `test` has been created."
+    send_message(user, "@bot: operable:role --create test")
+    |> assert_message("The role `test` has been created.")
 
-    response = send_message(user, "@bot: operable:role --create test") |> Map.fetch!("response")
-    assert response == "@belf Whoops! An error occurred. ERROR! The role `test` already exists."
+    send_message(user, "@bot: operable:role --create test")
+    |> assert_message("@belf Whoops! An error occurred. ERROR! The role `test` already exists.")
   end
 
   test "granting a role to a group", %{user: user} do
     group = group("elves")
 
-    response = send_message(user, "@bot: operable:role --grant --group=#{group.name} cheer") |> Map.fetch!("response")
-    assert response == "@belf Whoops! An error occurred. ERROR! Could not find role `cheer`"
+    send_message(user, "@bot: operable:role --grant --group=#{group.name} cheer")
+    |> assert_message("@belf Whoops! An error occurred. ERROR! Could not find role `cheer`")
 
-    response = send_message(user, "@bot: operable:role --create cheer") |> Map.fetch!("response")
-    assert response == "The role `cheer` has been created."
+    send_message(user, "@bot: operable:role --create cheer")
+    |> assert_message("The role `cheer` has been created.")
 
-    response = send_message(user, "@bot: operable:role --grant --group=humbug cheer") |> Map.fetch!("response")
-    assert response == "@belf Whoops! An error occurred. ERROR! Could not find group `humbug`"
+    send_message(user, "@bot: operable:role --grant --group=humbug cheer")
+    |> assert_message("@belf Whoops! An error occurred. ERROR! Could not find group `humbug`")
 
-    response = send_message(user, "@bot: operable:role --grant --group=#{group.name} cheer") |> Map.fetch!("response")
-    assert response == "Granted role `cheer` to group `elves`"
+    send_message(user, "@bot: operable:role --grant --group=#{group.name} cheer")
+    |> assert_message("Granted role `cheer` to group `elves`")
   end
 
   test "errors using the role command", %{user: user} do
-    response = send_message(user, "@bot: operable:role --create ") |> Map.fetch!("response")
-    assert response == "@belf Whoops! An error occurred. ERROR! Unable to create ``:\nMissing name"
+    send_message(user, "@bot: operable:role --create ")
+    |> assert_message("@belf Whoops! An error occurred. ERROR! Unable to create ``:\nMissing name")
 
-    response = send_message(user, "@bot: operable:role --grant --user=belf") |> Map.fetch!("response")
-    assert response == "@belf Whoops! An error occurred. ERROR! Must specify a role to modify."
+    send_message(user, "@bot: operable:role --grant --user=belf")
+    |> assert_message("@belf Whoops! An error occurred. ERROR! Must specify a role to modify.")
   end
 
   test "dropping a role", %{user: user} do
     role("cheer")
-    response = send_message(user, "@bot: operable:role --grant --user=belf cheer") |> Map.fetch!("response")
-    assert response == "Granted role `cheer` to user `belf`"
+    send_message(user, "@bot: operable:role --grant --user=belf cheer")
+    |> assert_message("Granted role `cheer` to user `belf`")
 
-    response = send_message(user, "@bot: operable:role --drop cheer") |> Map.fetch!("response")
-    assert response == "@belf Whoops! An error occurred. ERROR! Unable to delete role `cheer`. There are assignments to this role: \n* user: belf\n"
+    send_message(user, "@bot: operable:role --drop cheer")
+    |> assert_message("@belf Whoops! An error occurred. ERROR! Unable to delete role `cheer`. There are assignments to this role: \n* user: belf\n")
 
-    response = send_message(user, "@bot: operable:role --revoke --user=belf cheer") |> Map.fetch!("response")
-    assert response == "Revoked role `cheer` from user `belf`"
+    send_message(user, "@bot: operable:role --revoke --user=belf cheer")
+    |> assert_message("Revoked role `cheer` from user `belf`")
 
-    response = send_message(user, "@bot: operable:role --drop cheer") |> Map.fetch!("response")
-    assert response == "The role `cheer` has been deleted."
+    send_message(user, "@bot: operable:role --drop cheer")
+    |> assert_message("The role `cheer` has been deleted.")
 
-    response = send_message(user, "@bot: operable:role --drop cheer") |> Map.fetch!("response")
-    assert response == "@belf Whoops! An error occurred. ERROR! The role `cheer` does not exist."
+    send_message(user, "@bot: operable:role --drop cheer")
+    |> assert_message("@belf Whoops! An error occurred. ERROR! The role `cheer` does not exist.")
   end
 
   test "revoking a role", %{user: user} do
     group("elves")
     role("cheer")
 
-    response = send_message(user, "@bot: operable:role --grant --group=elves cheer") |> Map.fetch!("response")
-    assert response == "Granted role `cheer` to group `elves`"
+    send_message(user, "@bot: operable:role --grant --group=elves cheer")
+    |> assert_message("Granted role `cheer` to group `elves`")
 
-    response = send_message(user, "@bot: operable:role --revoke --group=elves cheer") |> Map.fetch!("response")
-    assert response == "Revoked role `cheer` from group `elves`"
+    send_message(user, "@bot: operable:role --revoke --group=elves cheer")
+    |> assert_message("Revoked role `cheer` from group `elves`")
   end
 
   test "listing roles", %{user: user} do
     group("elves")
     role("cheer")
 
-    response = send_message(user, "@bot: operable:role --grant --group=elves cheer") |> Map.fetch!("response")
-    assert response == "Granted role `cheer` to group `elves`"
+    send_message(user, "@bot: operable:role --grant --group=elves cheer")
+    |> assert_message("Granted role `cheer` to group `elves`")
 
-    response = send_message(user, "@bot: operable:role --grant --user=belf cheer") |> Map.fetch!("response")
-    assert response == "Granted role `cheer` to user `belf`"
+    send_message(user, "@bot: operable:role --grant --user=belf cheer")
+    |> assert_message("Granted role `cheer` to user `belf`")
 
-    response = send_message(user, "@bot: operable:role --list") |> Map.fetch!("response")
-    assert response == "The following are the available roles: \n* cheer\n"
+    send_message(user, "@bot: operable:role --list")
+    |> assert_message("The following are the available roles: \n* cheer\n")
 
-    response = send_message(user, "@bot: operable:role --drop cheer") |> Map.fetch!("response")
-    assert response == "@belf Whoops! An error occurred. ERROR! Unable to delete role `cheer`. There are assignments to this role: \n* user: belf\n* group: elves\n"
+    send_message(user, "@bot: operable:role --drop cheer")
+    |> assert_message("@belf Whoops! An error occurred. ERROR! Unable to delete role `cheer`. There are assignments to this role: \n* user: belf\n* group: elves\n")
   end
 end

--- a/test/integration/sort_test.exs
+++ b/test/integration/sort_test.exs
@@ -11,22 +11,22 @@ defmodule Integration.SortTest do
   end
 
   test "sorting numbers", %{user: user} do
-    response = send_message(user, "@bot: operable:sort 7 3 6 4 5 9") |> Map.fetch!("response")
-    assert response == "3\n4\n5\n6\n7\n9"
+    send_message(user, "@bot: operable:sort 7 3 6 4 5 9")
+    |> assert_message("3\n4\n5\n6\n7\n9")
 
-    response = send_message(user, "@bot: operable:sort -desc 7 3 6 4 5 9") |> Map.fetch!("response")
-    assert response == "9\n7\n6\n5\n4\n3"
+    send_message(user, "@bot: operable:sort -desc 7 3 6 4 5 9")
+    |> assert_message("9\n7\n6\n5\n4\n3")
 
-    response = send_message(user, "@bot: operable:sort --asc 7 3 6 4 5 9") |> Map.fetch!("response")
-    assert response == "3\n4\n5\n6\n7\n9"
+    send_message(user, "@bot: operable:sort --asc 7 3 6 4 5 9")
+    |> assert_message("3\n4\n5\n6\n7\n9")
   end
 
   test "sorting strings", %{user: user} do
-    response = send_message(user, "@bot: operable:sort --desc Life goes on") |> Map.fetch!("response")
-    assert response == "on\ngoes\nLife"
+    send_message(user, "@bot: operable:sort --desc Life goes on")
+    |> assert_message("on\ngoes\nLife")
 
-    response = send_message(user, "@bot: operable:sort Life is 10 percent what happens to us and 90% how we react to it") |> Map.fetch!("response")
-    assert response == "10\n90%\nLife\nand\nhappens\nhow\nis\nit\npercent\nreact\nto\nto\nus\nwe\nwhat"
+    send_message(user, "@bot: operable:sort Life is 10 percent what happens to us and 90% how we react to it")
+    |> assert_message("10\n90%\nLife\nand\nhappens\nhow\nis\nit\npercent\nreact\nto\nto\nus\nwe\nwhat")
   end
 
   test "sorting in a pipeline", %{user: user} do

--- a/test/support/adapter_case.ex
+++ b/test/support/adapter_case.ex
@@ -32,6 +32,10 @@ defmodule Cog.AdapterCase do
         Cog.Command.UserPermissionsCache.reset_cache
         :ok
       end
+
+      defp assert_message(%{"response" => response}, expected_message) do
+        assert response == expected_message
+      end
     end
   end
 


### PR DESCRIPTION
Adds an `assert_message/2` helper to the tests. Should make writing and modifying tests a bit easier.