### PR TITLE
remove calling convention

### DIFF
--- a/lib/cog/bundle/install.ex
+++ b/lib/cog/bundle/install.ex
@@ -16,8 +16,7 @@ defmodule Cog.Bundle.Install do
   require Logger
 
   @command_attrs ["name", "options", "enforcing",
-                  "calling_convention", "execution",
-                  "documentation"]
+                  "execution", "documentation"]
 
   @doc """
   Given a map of bundle parameters, fully installs the bundle into the
@@ -80,7 +79,6 @@ defmodule Cog.Bundle.Install do
   #
   #     create_command(bundle, %{"name" => "ec2-tag",
   #                              "enforcing" => true,
-  #                              "calling_convention" => "bound",
   #                              "execution" => "multiple",
   #                              "options": [%{"name" => "instance-id", "type" => "string", "required" => true}],
   #                              "module" => "Cog.Commands.EC2Tag"})

--- a/lib/cog/commands/filter.ex
+++ b/lib/cog/commands/filter.ex
@@ -1,5 +1,5 @@
 defmodule Cog.Commands.Filter do
-  use Spanner.GenCommand.Base, bundle: Cog.embedded_bundle, enforcing: false, calling_convention: :all
+  use Spanner.GenCommand.Base, bundle: Cog.embedded_bundle, enforcing: false
 
   @moduledoc """
   Filters a collection where the `path` equals the `matches`.

--- a/lib/cog/commands/raw.ex
+++ b/lib/cog/commands/raw.ex
@@ -1,7 +1,6 @@
 defmodule Cog.Command.Raw do
   use Spanner.GenCommand.Base, bundle: Cog.embedded_bundle,
-                               enforcing: false,
-                               calling_convention: :all
+                               enforcing: false
 
   alias Spanner.Command.Request
 

--- a/lib/cog/commands/sort.ex
+++ b/lib/cog/commands/sort.ex
@@ -1,5 +1,5 @@
 defmodule Cog.Commands.Sort do
-  use Spanner.GenCommand.Base, bundle: Cog.embedded_bundle, enforcing: false, execution: :once, calling_convention: :all
+  use Spanner.GenCommand.Base, bundle: Cog.embedded_bundle, enforcing: false, execution: :once
 
   @moduledoc """
   Sorts the given inputs.

--- a/lib/cog/commands/table.ex
+++ b/lib/cog/commands/table.ex
@@ -1,5 +1,5 @@
 defmodule Cog.Commands.Table do
-  use Spanner.GenCommand.Base, bundle: Cog.embedded_bundle, enforcing: false, execution: :once, calling_convention: :all
+  use Spanner.GenCommand.Base, bundle: Cog.embedded_bundle, enforcing: false, execution: :once
   alias Cog.Formatters.Table
 
   @moduledoc """

--- a/lib/cog/commands/unique.ex
+++ b/lib/cog/commands/unique.ex
@@ -6,7 +6,7 @@ defmodule Cog.Commands.Unique do
   > @bot operable:unique 49.3 9 2 2 42 49.3
   > @bot operable:unique "apple" "apple" "ball" "car" "car" "zebra"
   """
-  use Spanner.GenCommand.Base, bundle: Cog.embedded_bundle, enforcing: false, calling_convention: :all, execution: :once
+  use Spanner.GenCommand.Base, bundle: Cog.embedded_bundle, enforcing: false, execution: :once
 
   def handle_message(req, state) do
     entries = get_entries(req)

--- a/lib/cog/models/command.ex
+++ b/lib/cog/models/command.ex
@@ -8,7 +8,6 @@ defmodule Cog.Models.Command do
     field :name, :string
     field :documentation, :string
     field :enforcing, :boolean, default: true
-    field :calling_convention, :string, default: "bound"
     field :execution, :string, default: "multiple"
 
     belongs_to :bundle, Bundle
@@ -18,7 +17,7 @@ defmodule Cog.Models.Command do
   end
 
   @required_fields ~w(name bundle_id)
-  @optional_fields ~w(documentation enforcing calling_convention execution)
+  @optional_fields ~w(documentation enforcing execution)
 
   summary_fields [:id, :name]
   detail_fields [:id, :name, :documentation]

--- a/priv/repo/migrations/20160325211544_drop_command_calling_convention.exs
+++ b/priv/repo/migrations/20160325211544_drop_command_calling_convention.exs
@@ -1,0 +1,9 @@
+defmodule Cog.Repo.Migrations.DropCommandCallingConvention do
+  use Ecto.Migration
+
+  def change do
+    alter table(:commands) do
+      remove :calling_convention
+    end
+  end
+end


### PR DESCRIPTION
Removes references to command calling convention.

partially resolves https://github.com/operable/cog/issues/421