### PR TITLE
Overhaul executor error-handling

### DIFF
--- a/lib/cog/events/util.ex
+++ b/lib/cog/events/util.ex
@@ -19,8 +19,21 @@ defmodule Cog.Events.Util do
 
   """
   @spec now_iso8601_utc() :: binary()
-  def now_iso8601_utc do
-    {{year, month, day}, {hour, min, sec}} = :calendar.universal_time
+  def now_iso8601_utc,
+    do: ts_iso8601_utc(now)
+
+  @doc """
+  Formats a given timestamp as an ISO-8601 formatted string.
+
+  Example:
+
+      iex> Cog.Events.Util.ts_iso8691_utc(:os.timestamp())
+      "2016-01-15T01:48:20Z"
+
+  """
+  @spec ts_iso8601_utc(:erlang.timestamp) :: binary()
+  def ts_iso8601_utc(ts) do
+    {{year, month, day}, {hour, min, sec}} = :calendar.now_to_universal_time(ts)
     :io_lib.format(@date_format, [year, month, day, hour, min, sec])
     |> IO.iodata_to_binary
   end

--- a/test/integration/alias_execution_test.exs
+++ b/test/integration/alias_execution_test.exs
@@ -43,7 +43,7 @@ defmodule Integration.AliasExecutionTest do
   test "alias expansion fails on infinite expansion", %{user: user} do
     send_message(user, "@bot: operable:alias new my-alias \"my-alias\"")
     send_message(user, "@bot: my-alias")
-    |> assert_message("@vanstee Alias expansion limit (5) exceeded starting with alias 'my-alias'.")
+    |> assert_error_message_contains("An error occurred. Alias expansion limit (5) exceeded starting with alias 'my-alias'.")
   end
 
   test "alias using slack emoji works", %{user: user} do

--- a/test/integration/command_test.exs
+++ b/test/integration/command_test.exs
@@ -15,12 +15,12 @@ defmodule Integration.CommandTest do
 
   test "running a command with a bad template", %{user: user} do
     send_message(user, "@bot: operable:bad-template")
-    |> assert_message("@vanstee Whoops! An error occurred. There was an error rendering the template 'badtemplate' for the adapter 'test': %Protocol.UndefinedError{description: nil, protocol: String.Chars, value: %{\"bad\" => %{\"foo\" => \"bar\"}}}")
+    |> assert_error_message_contains("Whoops! An error occurred. There was an error rendering the template 'badtemplate' for the adapter 'test': %Protocol.UndefinedError{description: nil, protocol: String.Chars, value: %{\"bad\" => %{\"foo\" => \"bar\"}}}")
   end
 
   test "running a command with a required option missing", %{user: user} do
     send_message(user, "@bot: operable:req-opt")
-    |> assert_message("@vanstee Whoops! An error occurred. Looks like you forgot to include some required options: 'req'")
+    |> assert_error_message_contains("Whoops! An error occurred. Looks like you forgot to include some required options: 'req'")
   end
 
   test "running a command with a 'string' option", %{user: user} do
@@ -58,7 +58,7 @@ defmodule Integration.CommandTest do
 
   test "running a command with an invalid 'int' option", %{user: user} do
     send_message(user, "@bot: operable:type-test --int=\"this is a string\"")
-    |> assert_message("@vanstee Whoops! An error occurred. Type Error: `\"this is a string\"` is not of type `int`")
+    |> assert_error_message_contains("Whoops! An error occurred. Type Error: `\"this is a string\"` is not of type `int`")
   end
 
   test "running a command with a 'float' option", %{user: user} do
@@ -68,7 +68,7 @@ defmodule Integration.CommandTest do
 
   test "running a command with an invalid 'float' option", %{user: user} do
     send_message(user, "@bot: operable:type-test --float=\"This is a string\"")
-    |> assert_message("@vanstee Whoops! An error occurred. Type Error: `\"This is a string\"` is not of type `float`")
+    |> assert_error_message_contains("Whoops! An error occurred. Type Error: `\"This is a string\"` is not of type `float`")
   end
 
   test "running a command with an 'incr' option", %{user: user} do
@@ -85,7 +85,7 @@ defmodule Integration.CommandTest do
 
   test "running the st-echo command without permission", %{user: user} do
     send_message(user, "@bot: operable:st-echo test")
-    |> assert_message("@vanstee Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command.")
+    |> assert_error_message_contains("Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command.")
   end
 
   test "running the un-enforced t-echo command without permission", %{user: user} do
@@ -106,12 +106,12 @@ defmodule Integration.CommandTest do
     user |> with_permission("operable:st-echo")
 
     send_message(user, ~s(@bot: operable:st-echo "this is a test" | operable:st-thorn $body))
-    |> assert_message("@vanstee Sorry, you aren't allowed to execute 'operable:st-thorn $body' :(\n You will need the 'operable:st-thorn' permission to run this command.")
+    |> assert_error_message_contains("Sorry, you aren't allowed to execute 'operable:st-thorn $body' :(\n You will need the 'operable:st-thorn' permission to run this command.")
   end
 
   test "running unknown commands", %{user: user} do
     send_message(user, "@bot: operable:weirdo test")
-    |> assert_message("@vanstee Command 'weirdo' not found in any installed bundle.")
+    |> assert_error_message_contains("Command 'weirdo' not found in any installed bundle.")
   end
 
   test "running a command in a pipeline with nil output", %{user: user} do
@@ -121,7 +121,7 @@ defmodule Integration.CommandTest do
 
   test "running a pipeline with a variable that resolves to a command fails with a parse error", %{user: user} do
     send_message(user, ~s(@bot: echo "echo" | $body[0] foo))
-    |> assert_message("@vanstee (Line: 1, Col: 15) syntax error before: \"body\".")
+    |> assert_error_message_contains("(Line: 1, Col: 15) syntax error before: \"body\".")
   end
 
   test "reading the path to filter a certain path", %{user: user} do
@@ -141,12 +141,12 @@ defmodule Integration.CommandTest do
 
   test "returning an error if matches is not a valid string", %{user: user} do
     send_message(user, ~s(@bot: seed '{"foo":{"bar":{"baz":"stuff"}}}' | operable:filter --path="foo.bar.baz" --matches="st[uff"))
-     |> assert_message("@vanstee Whoops! An error occurred. \n* The regular expression in `--matches` does not compile correctly.\n\n")
+     |> assert_error_message_contains("Whoops! An error occurred. \n* The regular expression in `--matches` does not compile correctly.\n\n")
   end
 
   test "returning an error if matches is used without a path", %{user: user} do
     send_message(user, ~s(@bot: seed '{"foo":{"bar":{"baz":"stuff"}}}' | operable:filter --matches="stuff"))
-    |> assert_message("@vanstee Whoops! An error occurred. \n* Must specify `--path` with the `--matches` option.\n\n")
+    |> assert_error_message_contains("Whoops! An error occurred. \n* Must specify `--path` with the `--matches` option.\n\n")
   end
 
   test "an empty response from the filter command single input item", %{user: user} do

--- a/test/integration/commands/alias_test.exs
+++ b/test/integration/commands/alias_test.exs
@@ -28,7 +28,7 @@ defmodule Integration.Commands.AliasTest do
     send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
 
     send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
-    |> assert_message("@vanstee Whoops! An error occurred. name: The alias name is already in use.")
+    |> assert_error_message_contains("Whoops! An error occurred. name: The alias name is already in use.")
   end
 
   test "removing an alias", %{user: user} do
@@ -45,7 +45,7 @@ defmodule Integration.Commands.AliasTest do
 
   test "removing an alias that does not exist", %{user: user} do
     send_message(user, "@bot: operable:alias rm my-new-alias")
-    |> assert_message("@vanstee Whoops! An error occurred. I can't find 'my-new-alias'. Please try again")
+    |> assert_error_message_contains("Whoops! An error occurred. I can't find 'my-new-alias'. Please try again")
   end
 
   test "moving an alias to site using full visibility syntax", %{user: user} do
@@ -239,7 +239,7 @@ defmodule Integration.Commands.AliasTest do
     send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
 
     send_message(user, "@bot: operable:alias mv user:my-new-alias site")
-    |> assert_message("@vanstee Whoops! An error occurred. name: The alias name is already in use.")
+    |> assert_error_message_contains("Whoops! An error occurred. name: The alias name is already in use.")
   end
 
   test "moving an alias to user when an alias with that name already exists in user", %{user: user} do
@@ -248,7 +248,7 @@ defmodule Integration.Commands.AliasTest do
     send_message(user, "@bot: operable:alias new my-new-alias \"echo My New Alias\"")
 
     send_message(user, "@bot: operable:alias mv site:my-new-alias user")
-    |> assert_message("@vanstee Whoops! An error occurred. name: The alias name is already in use.")
+    |> assert_error_message_contains("Whoops! An error occurred. name: The alias name is already in use.")
   end
 
   test "list all aliases", %{user: user} do
@@ -307,37 +307,37 @@ defmodule Integration.Commands.AliasTest do
 
   test "list aliases with an invalid pattern", %{user: user} do
     send_message(user, "@bot: operable:alias ls \"% &my#-*\"")
-    |> assert_message("@vanstee Whoops! An error occurred. Invalid alias name. Only emoji, letters, numbers, and the following special characters are allowed: *, -, _")
+    |> assert_error_message_contains("Whoops! An error occurred. Invalid alias name. Only emoji, letters, numbers, and the following special characters are allowed: *, -, _")
   end
 
   test "list aliases with too many wildcards", %{user: user} do
     send_message(user, "@bot: operable:alias ls \"*my-*\"")
-    |> assert_message("@vanstee Whoops! An error occurred. Too many wildcards. You can only include one wildcard in a query")
+    |> assert_error_message_contains("Whoops! An error occurred. Too many wildcards. You can only include one wildcard in a query")
   end
 
   test "list aliases with a bad pattern and too many wildcards", %{user: user} do
     send_message(user, "@bot: operable:alias ls \"*m++%y-*\"")
-    |> assert_message("@vanstee Whoops! An error occurred. Too many wildcards. You can only include one wildcard in a query\nInvalid alias name. Only emoji, letters, numbers, and the following special characters are allowed: *, -, _")
+    |> assert_error_message_contains("Whoops! An error occurred. Too many wildcards. You can only include one wildcard in a query\nInvalid alias name. Only emoji, letters, numbers, and the following special characters are allowed: *, -, _")
   end
 
   test "passing too many args", %{user: user} do
     send_message(user, "@bot: operable:alias new my-invalid-alias \"echo foo\" invalid-arg")
-    |> assert_message("@vanstee Whoops! An error occurred. Too many args. Arguments required: exactly 2.")
+    |> assert_error_message_contains("Whoops! An error occurred. Too many args. Arguments required: exactly 2.")
   end
 
   test "passing too few args", %{user: user} do
     send_message(user, "@bot: operable:alias new my-invalid-alias")
-    |> assert_message("@vanstee Whoops! An error occurred. Not enough args. Arguments required: exactly 2.")
+    |> assert_error_message_contains("Whoops! An error occurred. Not enough args. Arguments required: exactly 2.")
   end
 
   test "passing an unknown subcommand", %{user: user} do
     send_message(user, "@bot: operable:alias foo")
-    |> assert_message("@vanstee Whoops! An error occurred. Unknown subcommand 'foo'")
+    |> assert_error_message_contains("Whoops! An error occurred. Unknown subcommand 'foo'")
   end
 
   test "passing now subcommand", %{user: user} do
     send_message(user, "@bot: operable:alias")
-    |> assert_message("@vanstee Whoops! An error occurred. I don't what to do, please specify a subcommand")
+    |> assert_error_message_contains("Whoops! An error occurred. I don't what to do, please specify a subcommand")
   end
 
 end

--- a/test/integration/group_test.exs
+++ b/test/integration/group_test.exs
@@ -12,16 +12,16 @@ defmodule Integration.GroupTest do
 
   test "adding a user to a group", %{user: user} do
     send_message(user, "@bot: operable:group --add --user=#{user.username} elves")
-    |> assert_message("@belf Whoops! An error occurred. ERROR! Could not find group `elves`")
+    |> assert_error_message_contains("Whoops! An error occurred. ERROR! Could not find group `elves`")
 
     send_message(user, "@bot: operable:group --create elves")
     |> assert_message("The group `elves` has been created.")
 
     send_message(user, "@bot: operable:group --add --user=papa_elf elves")
-    |> assert_message("@belf Whoops! An error occurred. ERROR! Could not find user `papa_elf`")
+    |> assert_error_message_contains("Whoops! An error occurred. ERROR! Could not find user `papa_elf`")
 
     send_message(user, "@bot: operable:group --add elves")
-    |> assert_message("@belf Whoops! An error occurred. ERROR! Must specify a target to act upon. See `operable:help operable:group` for more details.")
+    |> assert_error_message_contains("Whoops! An error occurred. ERROR! Must specify a target to act upon. See `operable:help operable:group` for more details.")
 
     send_message(user, "@bot: operable:group --add --user=belf elves")
     |> assert_message("Added the user `belf` to the group `elves`")
@@ -32,20 +32,20 @@ defmodule Integration.GroupTest do
     |> assert_message("The group `test` has been created.")
 
     send_message(user, "@bot: operable:group --create test")
-    |> assert_message("@belf Whoops! An error occurred. ERROR! The group `test` already exists.")
+    |> assert_error_message_contains("Whoops! An error occurred. ERROR! The group `test` already exists.")
   end
 
   test "adding a group to a group", %{user: user} do
     group = group("elves")
 
     send_message(user, "@bot: operable:group --add --group=#{group.name} cheer")
-    |> assert_message("@belf Whoops! An error occurred. ERROR! Could not find group `cheer`")
+    |> assert_error_message_contains("Whoops! An error occurred. ERROR! Could not find group `cheer`")
 
     send_message(user, "@bot: operable:group --create cheer")
     |> assert_message("The group `cheer` has been created.")
 
     send_message(user, "@bot: operable:group --add --group=humbug cheer")
-    |> assert_message("@belf Whoops! An error occurred. ERROR! Could not find group `humbug`")
+    |> assert_error_message_contains("Whoops! An error occurred. ERROR! Could not find group `humbug`")
 
     send_message(user, "@bot: operable:group --add --group=#{group.name} cheer")
     |> assert_message("Added the group `elves` to the group `cheer`")
@@ -53,10 +53,10 @@ defmodule Integration.GroupTest do
 
   test "errors using the group command", %{user: user} do
     send_message(user, "@bot: operable:group --create ")
-    |> assert_message("@belf Whoops! An error occurred. ERROR! Unable to create ``:\nMissing name")
+    |> assert_error_message_contains("Whoops! An error occurred. ERROR! Unable to create ``:\nMissing name")
 
     send_message(user, "@bot: operable:group --add --user=belf")
-    |> assert_message("@belf Whoops! An error occurred. ERROR! Must specify a group to modify.")
+    |> assert_error_message_contains("Whoops! An error occurred. ERROR! Must specify a group to modify.")
   end
 
   test "dropping a group", %{user: user} do
@@ -68,14 +68,14 @@ defmodule Integration.GroupTest do
     |> assert_message("The group `cheer` has been deleted.")
 
     send_message(user, "@bot: operable:group --remove --user=belf cheer")
-    |> assert_message("@belf Whoops! An error occurred. ERROR! Could not find group `cheer`")
+    |> assert_error_message_contains("Whoops! An error occurred. ERROR! Could not find group `cheer`")
   end
 
   test "removing a group", %{user: user} do
     group("elves")
 
     send_message(user, "@bot: operable:group --add --group=elves cheer")
-    |> assert_message("@belf Whoops! An error occurred. ERROR! Could not find group `cheer`")
+    |> assert_error_message_contains("Whoops! An error occurred. ERROR! Could not find group `cheer`")
 
     group("cheer")
     send_message(user, "@bot: operable:group --add --group=elves cheer")

--- a/test/integration/hipchat_test.exs
+++ b/test/integration/hipchat_test.exs
@@ -48,7 +48,7 @@ defmodule Integration.HipChatTest do
 
   test "running the st-echo command without permission", %{user: user} do
     message = send_message user, "@deckard operable:st-echo test"
-    assert_response "@ciuser Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command.", after: message
+    assert_response_contains "Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command.", after: message
   end
 
   test "running commands in a pipeline", %{user: user} do
@@ -64,6 +64,6 @@ defmodule Integration.HipChatTest do
     user |> with_permission("operable:st-echo")
 
     message = send_message user, ~s(@deckard operable:st-echo "this is a test" | operable:st-thorn $body)
-    assert_response "@ciuser Sorry, you aren't allowed to execute 'operable:st-thorn $body' :(\n You will need the 'operable:st-thorn' permission to run this command.", after: message
+    assert_response_contains "Sorry, you aren't allowed to execute 'operable:st-thorn $body' :(\n You will need the 'operable:st-thorn' permission to run this command.", after: message
   end
 end

--- a/test/integration/permission_test.exs
+++ b/test/integration/permission_test.exs
@@ -19,7 +19,7 @@ defmodule Integration.PermissionTest do
 
   test "granting a permission to a user", %{user: user} do
     send_message(user, "@bot: operable:st-echo test")
-    |> assert_message("@vanstee Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command.")
+    |> assert_error_message_contains("Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command.")
 
     send_message(user, "@bot: operable:permissions --grant --user=vanstee --permission=operable:st-echo")
     |> assert_message("Granted permission `operable:st-echo` to user `vanstee`")
@@ -30,7 +30,7 @@ defmodule Integration.PermissionTest do
 
   test "granting a permission to a group", %{user: user} do
     send_message(user, "@bot: operable:st-echo test")
-    |> assert_message("@vanstee Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command.")
+    |> assert_error_message_contains("Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command.")
 
     send_message(user, "@bot: operable:permissions --grant --group=ops --permission=operable:st-echo")
     |> assert_message("Granted permission `operable:st-echo` to group `ops`")
@@ -41,7 +41,7 @@ defmodule Integration.PermissionTest do
 
   test "granting a permission to a role", %{user: user} do
     send_message(user, "@bot: operable:st-echo test")
-    |> assert_message("@vanstee Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command.")
+    |> assert_error_message_contains("Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command.")
 
     send_message(user, "@bot: operable:permissions --grant --role=admin --permission=operable:st-echo")
     |> assert_message("Granted permission `operable:st-echo` to role `admin`")
@@ -55,7 +55,7 @@ defmodule Integration.PermissionTest do
     |> with_chat_handle_for("test")
 
     send_message(mctesterson, "@bot: operable:permissions --grant --user=mctesterson --permission=operable:st-echo")
-    |> assert_message("@mctesterson Sorry, you aren't allowed to execute 'operable:permissions --grant --user=mctesterson --permission=operable:st-echo' :(\n You will need the 'operable:manage_users' permission to run this command.")
+    |> assert_error_message_contains("Sorry, you aren't allowed to execute 'operable:permissions --grant --user=mctesterson --permission=operable:st-echo' :(\n You will need the 'operable:manage_users' permission to run this command.")
   end
 
   test "revoking a permission from a user", %{user: user} do
@@ -69,7 +69,7 @@ defmodule Integration.PermissionTest do
     |> assert_message("Revoked permission `operable:st-echo` from user `vanstee`")
 
     send_message(user, "@bot: operable:st-echo fail_test")
-    |> assert_message("@vanstee Sorry, you aren't allowed to execute 'operable:st-echo fail_test' :(\n You will need the 'operable:st-echo' permission to run this command.")
+    |> assert_error_message_contains("Sorry, you aren't allowed to execute 'operable:st-echo fail_test' :(\n You will need the 'operable:st-echo' permission to run this command.")
   end
 
   test "revoking a permission from a group", %{user: user} do
@@ -83,7 +83,7 @@ defmodule Integration.PermissionTest do
     |> assert_message("Revoked permission `operable:st-echo` from group `ops`")
 
     send_message(user, "@bot: operable:st-echo test")
-    |> assert_message("@vanstee Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command.")
+    |> assert_error_message_contains("Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command.")
   end
 
   test "revoking a permission from a role", %{user: user} do
@@ -97,6 +97,6 @@ defmodule Integration.PermissionTest do
     |> assert_message("Revoked permission `operable:st-echo` from role `admin`")
 
     send_message(user, "@bot: operable:st-echo test")
-    |> assert_message("@vanstee Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command.")
+    |> assert_error_message_contains("Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command.")
   end
 end

--- a/test/integration/role_test.exs
+++ b/test/integration/role_test.exs
@@ -13,16 +13,16 @@ defmodule Integration.RoleTest do
 
   test "granting a role to a user", %{user: user} do
     send_message(user, "@bot: operable:role --grant --user=#{user.username} cheer")
-    |> assert_message("@belf Whoops! An error occurred. ERROR! Could not find role `cheer`")
+    |> assert_error_message_contains("Whoops! An error occurred. ERROR! Could not find role `cheer`")
 
     send_message(user, "@bot: operable:role --create cheer")
     |> assert_message("The role `cheer` has been created.")
 
     send_message(user, "@bot: operable:role --grant --user=papa_elf cheer")
-    |> assert_message("@belf Whoops! An error occurred. ERROR! Could not find user `papa_elf`")
+    |> assert_error_message_contains("Whoops! An error occurred. ERROR! Could not find user `papa_elf`")
 
     send_message(user, "@bot: operable:role --grant cheer")
-    |> assert_message("@belf Whoops! An error occurred. ERROR! Must specify a target to act upon. See `operable:help operable:role` for more details.")
+    |> assert_error_message_contains("Whoops! An error occurred. ERROR! Must specify a target to act upon. See `operable:help operable:role` for more details.")
 
     send_message(user, "@bot: operable:role --grant --user=belf cheer")
     |> assert_message("Granted role `cheer` to user `belf`")
@@ -33,20 +33,20 @@ defmodule Integration.RoleTest do
     |> assert_message("The role `test` has been created.")
 
     send_message(user, "@bot: operable:role --create test")
-    |> assert_message("@belf Whoops! An error occurred. ERROR! The role `test` already exists.")
+    |> assert_error_message_contains("Whoops! An error occurred. ERROR! The role `test` already exists.")
   end
 
   test "granting a role to a group", %{user: user} do
     group = group("elves")
 
     send_message(user, "@bot: operable:role --grant --group=#{group.name} cheer")
-    |> assert_message("@belf Whoops! An error occurred. ERROR! Could not find role `cheer`")
+    |> assert_error_message_contains("Whoops! An error occurred. ERROR! Could not find role `cheer`")
 
     send_message(user, "@bot: operable:role --create cheer")
     |> assert_message("The role `cheer` has been created.")
 
     send_message(user, "@bot: operable:role --grant --group=humbug cheer")
-    |> assert_message("@belf Whoops! An error occurred. ERROR! Could not find group `humbug`")
+    |> assert_error_message_contains("Whoops! An error occurred. ERROR! Could not find group `humbug`")
 
     send_message(user, "@bot: operable:role --grant --group=#{group.name} cheer")
     |> assert_message("Granted role `cheer` to group `elves`")
@@ -54,10 +54,10 @@ defmodule Integration.RoleTest do
 
   test "errors using the role command", %{user: user} do
     send_message(user, "@bot: operable:role --create ")
-    |> assert_message("@belf Whoops! An error occurred. ERROR! Unable to create ``:\nMissing name")
+    |> assert_error_message_contains("Whoops! An error occurred. ERROR! Unable to create ``:\nMissing name")
 
     send_message(user, "@bot: operable:role --grant --user=belf")
-    |> assert_message("@belf Whoops! An error occurred. ERROR! Must specify a role to modify.")
+    |> assert_error_message_contains("Whoops! An error occurred. ERROR! Must specify a role to modify.")
   end
 
   test "dropping a role", %{user: user} do
@@ -66,7 +66,7 @@ defmodule Integration.RoleTest do
     |> assert_message("Granted role `cheer` to user `belf`")
 
     send_message(user, "@bot: operable:role --drop cheer")
-    |> assert_message("@belf Whoops! An error occurred. ERROR! Unable to delete role `cheer`. There are assignments to this role: \n* user: belf\n")
+    |> assert_error_message_contains("Whoops! An error occurred. ERROR! Unable to delete role `cheer`. There are assignments to this role: \n* user: belf\n")
 
     send_message(user, "@bot: operable:role --revoke --user=belf cheer")
     |> assert_message("Revoked role `cheer` from user `belf`")
@@ -75,7 +75,7 @@ defmodule Integration.RoleTest do
     |> assert_message("The role `cheer` has been deleted.")
 
     send_message(user, "@bot: operable:role --drop cheer")
-    |> assert_message("@belf Whoops! An error occurred. ERROR! The role `cheer` does not exist.")
+    |> assert_error_message_contains("Whoops! An error occurred. ERROR! The role `cheer` does not exist.")
   end
 
   test "revoking a role", %{user: user} do
@@ -103,6 +103,6 @@ defmodule Integration.RoleTest do
     |> assert_message("The following are the available roles: \n* cheer\n")
 
     send_message(user, "@bot: operable:role --drop cheer")
-    |> assert_message("@belf Whoops! An error occurred. ERROR! Unable to delete role `cheer`. There are assignments to this role: \n* user: belf\n* group: elves\n")
+    |> assert_error_message_contains("Whoops! An error occurred. ERROR! Unable to delete role `cheer`. There are assignments to this role: \n* user: belf\n* group: elves\n")
   end
 end

--- a/test/integration/rule_test.exs
+++ b/test/integration/rule_test.exs
@@ -14,17 +14,17 @@ defmodule Integration.RuleTest do
 
   test "error when unknown options for rules command", %{user: user} do
     assert_error(user, "@bot: operable:rules --doit 'when command is operable:st-echo must have operable:st-echo'",
-                 "@belf Whoops! An error occurred. \n* You must specify either an `--add`, `--drop`, or `--list` action\n\n")
+                 "Whoops! An error occurred. \n* You must specify either an `--add`, `--drop`, or `--list` action\n\n")
   end
 
   test "error when no action is specified", %{user: user} do
     assert_error(user, "@bot: operable:rules",
-                 "@belf Whoops! An error occurred. \n* You must specify either an `--add`, `--drop`, or `--list` action\n\n")
+                 "Whoops! An error occurred. \n* You must specify either an `--add`, `--drop`, or `--list` action\n\n")
   end
 
   test "error when too many actions are specified", %{user: user} do
     assert_error(user, "@bot: operable:rules --add --drop",
-                 "@belf Whoops! An error occurred. \n* You must specify only one of `--add`, `--drop`, or `--list` as an action\n\n")
+                 "Whoops! An error occurred. \n* You must specify only one of `--add`, `--drop`, or `--list` as an action\n\n")
   end
 
   ########################################################################
@@ -42,66 +42,66 @@ defmodule Integration.RuleTest do
 
   test "error when specifying too many arguments for manual rule creation", %{user: user} do
     assert_error(user, "@bot: operable:rules --add \"blah\" \"blah\"",
-                 "@belf Whoops! An error occurred. \n* The `--add` action expects 1 argument\n\n")
+                 "Whoops! An error occurred. \n* The `--add` action expects 1 argument\n\n")
   end
 
   test "error when rule argument is not a string", %{user: user} do
     assert_error(user, "@bot: operable:rules --add 123",
-                 "@belf Whoops! An error occurred. \n* The argument `<expression>` must be a string; you gave `123`\n\n")
+                 "Whoops! An error occurred. \n* The argument `<expression>` must be a string; you gave `123`\n\n")
   end
 
   test "error when creating rule for an unrecognized command", %{user: user} do
     permission("site:permission")
     assert_error(user, "@bot: operable:rules --add --for-command=\"not_really:a_command\" --permission=\"site:permission\"",
-                 "@belf Whoops! An error occurred. \n* Could not find command `not_really:a_command`\n\n")
+                 "Whoops! An error occurred. \n* Could not find command `not_really:a_command`\n\n")
   end
 
   test "error when creating rule for an unqualified command", %{user: user} do
     permission("site:permission")
     assert_error(user, "@bot: operable:rules --add --for-command=\"something\" --permission=\"site:permission\"",
-                 "@belf Whoops! An error occurred. \n* The value of the `--for-command` option must be a bundle-qualified command, like `operable:help`\n\n")
+                 "Whoops! An error occurred. \n* The value of the `--for-command` option must be a bundle-qualified command, like `operable:help`\n\n")
   end
 
   test "error when creating a rule without specifying a command", %{user: user} do
     permission("site:permission")
     assert_error(user, "@bot: operable:rules --add --permission=\"site:permission\"",
-                 "@belf Whoops! An error occurred. \n* You must specify a `--for-command` option\n\n")
+                 "Whoops! An error occurred. \n* You must specify a `--for-command` option\n\n")
   end
 
   test "error when creating a rule without specifying a permission", %{user: user} do
     assert_error(user, "@bot: operable:rules --add --for-command=\"operable:st-echo\"",
-                 "@belf Whoops! An error occurred. \n* You must specify a `--permission` option\n\n")
+                 "Whoops! An error occurred. \n* You must specify a `--permission` option\n\n")
   end
 
   test "error when creating a rule specifying a non-string permission", %{user: user} do
     assert_error(user, "@bot: operable:rules --add --for-command=\"operable:st-echo\" --permission=123",
-                 "@belf Whoops! An error occurred. Type Error: `123` is not of type `string`")
+                 "Whoops! An error occurred. Type Error: `123` is not of type `string`")
   end
 
   test "error when creating a rule specifying an unqualified permission", %{user: user} do
     assert_error(user, "@bot: operable:rules --add --for-command=\"operable:st-echo\" --permission=foo",
-                 "@belf Whoops! An error occurred. \n* The value of the `--permission` option must be a fully-qualified permission, like `site:admin`\n\n")
+                 "Whoops! An error occurred. \n* The value of the `--permission` option must be a fully-qualified permission, like `site:admin`\n\n")
   end
 
   test "error when creating rule with an unrecognized permission", %{user: user} do
     assert_error(user, "@bot: operable:rules --add --for-command=\"operable:st-echo\" --permission=\"site:permission\"",
-                 "@belf Whoops! An error occurred. \n* Could not find permission `site:permission`\n\n")
+                 "Whoops! An error occurred. \n* Could not find permission `site:permission`\n\n")
   end
 
   test "error when creating a rule specifying a permission from an unacceptable namespace", %{user: user} do
     permission("foo:bar")
     assert_error(user, "@bot: operable:rules --add --for-command=\"operable:st-echo\" --permission=\"foo:bar\"",
-                 "@belf Whoops! An error occurred. \n* The namespace of the permission must either be `site` or the bundle from which the command comes\n\n")
+                 "Whoops! An error occurred. \n* The namespace of the permission must either be `site` or the bundle from which the command comes\n\n")
   end
 
   test "error when creating a rule without specifying a command or a permission catches both errors", %{user: user} do
     assert_error(user, "@bot: operable:rules --add",
-                 "@belf Whoops! An error occurred. \n* You must specify a `--for-command` option\n* You must specify a `--permission` option\n\n")
+                 "Whoops! An error occurred. \n* You must specify a `--for-command` option\n* You must specify a `--permission` option\n\n")
   end
 
   test "error when manually creating a rule with invalid syntax", %{user: user} do
     assert_error(user, "@bot: operable:rules --add \"this is totally not a valid rule\"",
-                 "@belf Whoops! An error occurred. \n* Invalid rule: (Line: 1, Col: 0) syntax error before: \"this\".\n\n")
+                 "Whoops! An error occurred. \n* Invalid rule: (Line: 1, Col: 0) syntax error before: \"this\".\n\n")
   end
 
   ########################################################################
@@ -134,32 +134,32 @@ defmodule Integration.RuleTest do
 
   test "error when dropping rule with non-string id", %{user: user} do
     assert_error(user, "@bot: operable:rules --drop --id=123",
-                 "@belf Whoops! An error occurred. Type Error: `123` is not of type `string`")
+                 "Whoops! An error occurred. Type Error: `123` is not of type `string`")
   end
 
   test "error when dropping rule with non-UUID string id", %{user: user} do
     assert_error(user, "@bot: operable:rules --drop --id=\"not-a-uuid\"",
-                 "@belf Whoops! An error occurred. \n* The option `id` must be a UUID; you gave `\"not-a-uuid\"`\n\n")
+                 "Whoops! An error occurred. \n* The option `id` must be a UUID; you gave `\"not-a-uuid\"`\n\n")
   end
 
   test "error when dropping rule with unknown id", %{user: user} do
     assert_error(user, "@bot: operable:rules --drop --id=\"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\"",
-                 "@belf Whoops! An error occurred. \n* There are no rules with the ID `aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`\n\n")
+                 "Whoops! An error occurred. \n* There are no rules with the ID `aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`\n\n")
   end
 
   test "error when dropping rule without `--for-command` or `--id` option", %{user: user} do
     assert_error(user, "@bot: operable:rules --drop",
-                 "@belf Whoops! An error occurred. \n* The `--drop` action expects either an `--id` option or a `--for-command` option\n\n")
+                 "Whoops! An error occurred. \n* The `--drop` action expects either an `--id` option or a `--for-command` option\n\n")
   end
 
   test "error when dropping rules by command with an unrecognized command", %{user: user} do
     assert_error(user, "@bot: operable:rules --drop --for-command=\"not_really:a_command\"",
-                 "@belf Whoops! An error occurred. \n* Could not find command `not_really:a_command`\n\n")
+                 "Whoops! An error occurred. \n* Could not find command `not_really:a_command`\n\n")
   end
 
   test "error when dropping rules for an unqualified command", %{user: user} do
     assert_error(user, "@bot: operable:rules --drop --for-command=\"something\"",
-                 "@belf Whoops! An error occurred. \n* The value of the `--for-command` option must be a bundle-qualified command, like `operable:help`\n\n")
+                 "Whoops! An error occurred. \n* The value of the `--for-command` option must be a bundle-qualified command, like `operable:help`\n\n")
   end
 
   ########################################################################
@@ -174,12 +174,12 @@ defmodule Integration.RuleTest do
 
   test "error when listing rules for an unrecognized command", %{user: user} do
     assert_error(user, "@bot: operable:rules --list --for-command=\"not_really:a_command\"",
-                 "@belf Whoops! An error occurred. \n* Could not find command `not_really:a_command`\n\n")
+                 "Whoops! An error occurred. \n* Could not find command `not_really:a_command`\n\n")
   end
 
   test "error when listing rules for an unqualified command", %{user: user} do
     assert_error(user, "@bot: operable:rules --list --for-command=\"something\"",
-                 "@belf Whoops! An error occurred. \n* The value of the `--for-command` option must be a bundle-qualified command, like `operable:help`\n\n")
+                 "Whoops! An error occurred. \n* The value of the `--for-command` option must be a bundle-qualified command, like `operable:help`\n\n")
   end
 
   ########################################################################
@@ -205,6 +205,6 @@ defmodule Integration.RuleTest do
     do: send_message(user, pipeline) |> parsed_response
 
   defp assert_error(user, pipeline, expected_message) when is_binary(expected_message),
-    do: assert interact(user, pipeline) == expected_message
+    do: assert_error_message_contains(send_message(user, pipeline), expected_message)
 
 end

--- a/test/integration/slack_test.exs
+++ b/test/integration/slack_test.exs
@@ -26,7 +26,7 @@ defmodule Integration.SlackTest do
 
   test "running the st-echo command without permission", %{user: user} do
     message = send_message user, "@deckard: operable:st-echo test"
-    assert_response "@botci Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command.", after: message
+    assert_response_contains "Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command.", after: message
   end
 
   test "running commands in a pipeline", %{user: user} do
@@ -42,7 +42,7 @@ defmodule Integration.SlackTest do
     user |> with_permission("operable:st-echo")
 
     message = send_message user, ~s(@deckard: operable:st-echo "this is a test" | operable:st-thorn $body)
-    assert_response "@botci Sorry, you aren't allowed to execute 'operable:st-thorn $body' :(\n You will need the 'operable:st-thorn' permission to run this command.", after: message
+    assert_response_contains "Sorry, you aren't allowed to execute 'operable:st-thorn $body' :(\n You will need the 'operable:st-thorn' permission to run this command.", after: message
   end
 
   test "an ambiguous redirect fails", %{user: user} do
@@ -50,7 +50,7 @@ defmodule Integration.SlackTest do
                            ~s(@deckard: operable:echo foo > am_i_user_or_room))
 
     expected_response = """
-    @botci Whoops! An error occurred. 
+    Whoops! An error occurred.
     No commands were executed because the following redirects are invalid:
 
     am_i_user_or_room
@@ -63,6 +63,6 @@ defmodule Integration.SlackTest do
     am_i_user_or_room
     """
 
-    assert_response expected_response, after: message
+    assert_response_contains expected_response, after: message
   end
 end

--- a/test/support/adapter_assertions.ex
+++ b/test/support/adapter_assertions.ex
@@ -1,0 +1,35 @@
+defmodule Cog.AdapterAssertions do
+  import ExUnit.Assertions
+
+  def assert_message(%{"response" => response}, expected_message) do
+    assert response == expected_message
+  end
+
+  @doc """
+  Temporary helper assertion to compare a fragment of an error message
+  from a chat adapter to the complete textual response given.
+
+  Eventually, we'll move to error templates, which actually will allow
+  us to compare to a data structure instead of a string, and will
+  allow these tests to be more robust.
+  """
+  def assert_error_message_contains(%{"response" => actual_response}, expected_message_fragment) do
+    if String.contains?(actual_response, expected_message_fragment) do
+      :ok
+    else
+      flunk """
+
+      Expected the string
+
+          #{inspect actual_response}
+
+      to contain the string
+
+          #{inspect expected_message_fragment}
+
+      but it didn't!
+      """
+    end
+  end
+
+end

--- a/test/support/adapter_case.ex
+++ b/test/support/adapter_case.ex
@@ -13,6 +13,7 @@ defmodule Cog.AdapterCase do
       import unquote(__MODULE__)
       import Cog.Support.ModelUtilities
       import ExUnit.Assertions
+      import Cog.AdapterAssertions
 
       setup_all do
         adapter = replace_adapter(unquote(adapter))
@@ -33,9 +34,6 @@ defmodule Cog.AdapterCase do
         :ok
       end
 
-      defp assert_message(%{"response" => response}, expected_message) do
-        assert response == expected_message
-      end
     end
   end
 

--- a/test/support/adapters/hipchat/helpers.ex
+++ b/test/support/adapters/hipchat/helpers.ex
@@ -23,4 +23,16 @@ defmodule Cog.Adapters.HipChat.Helpers do
 
     Assertions.polling_assert(message, last_message_func, @interval, @timeout)
   end
+
+  def assert_response_contains(message, after: %{"id" => id}) do
+    :timer.sleep(@interval)
+
+    last_message_func = fn ->
+      {:ok, message} = HipChat.API.retrieve_last_message(@room, id)
+      message
+    end
+
+    Assertions.polling_assert_in(message, last_message_func, @interval, @timeout)
+  end
+
 end

--- a/test/support/adapters/slack/helpers.ex
+++ b/test/support/adapters/slack/helpers.ex
@@ -18,6 +18,17 @@ defmodule Cog.Adapters.Slack.Helpers do
     Assertions.polling_assert(message, last_message_func, @interval, @timeout)
   end
 
+  def assert_response_contains(message, [after: %{"ts" => ts}]) do
+    :timer.sleep(@interval)
+
+    last_message_func = fn ->
+      {:ok, last_message} = retrieve_last_message(room: @room, oldest: ts)
+      last_message
+    end
+
+    Assertions.polling_assert_in(message, last_message_func, @interval, @timeout)
+  end
+
   def assert_edited_response(message, [after: %{"ts" => ts}]) do
     :timer.sleep(@interval)
 


### PR DESCRIPTION
Previously, error messages were generated in a number of places, making
it difficult to get a grasp on the variety of responses generated.

Additionally, error messages did not contain all that much context about
the error, something we'd need to address before allowing pipelines to
be triggered by external events.

Here, (almost) all error handling is consolidated into one place in the executor,
with lots of additional context added.

(Error messages for people lacking a Cog account, as well as for bad
redirects, are still handled as they were, since these were already
complex messages. Once we have error templates, everything will be able
to be consolidated even further.)

Tests have been updated, but in an admittedly less-than-satisfying
way. They are still strongly coupled to the exact output of the error
messages, but upcoming work to template error responses will,
interestingly enough, allow us to perform comparisons on data
structures, and not text, which will make the tests more robust in the
face of future changes.

Fixes #416