### PR TITLE
Relay management API

### DIFF
--- a/lib/cog/commands/permissions.ex
+++ b/lib/cog/commands/permissions.ex
@@ -41,6 +41,7 @@ defmodule Cog.Commands.Permissions do
   permission "manage_users"
   permission "manage_roles"
   permission "manage_groups"
+  permission "manage_relays"
 
   rule "when command is #{Cog.embedded_bundle}:permissions with option[create] == true must have #{Cog.embedded_bundle}:manage_permissions"
   rule "when command is #{Cog.embedded_bundle}:permissions with option[delete] == true must have #{Cog.embedded_bundle}:manage_permissions"

--- a/lib/cog/models.ex
+++ b/lib/cog/models.ex
@@ -29,6 +29,9 @@ defmodule Cog.Models do
       alias Cog.Models.GroupPermission
       alias Cog.Models.UserGroupMembership
       alias Cog.Models.GroupGroupMembership
+      alias Cog.Models.Relay
+      alias Cog.Models.RelayGroup
+      alias Cog.Models.RelayGroupMembership
       alias Cog.Models.Role
       alias Cog.Models.UserRole
       alias Cog.Models.Command

--- a/lib/cog/models/relay.ex
+++ b/lib/cog/models/relay.ex
@@ -1,0 +1,50 @@
+defmodule Cog.Models.Relay do
+  use Cog.Model
+  alias Cog.Passwords
+
+  alias Cog.Models.RelayGroupMembership
+
+  schema "relays" do
+    field :name, :string
+    field :token, :string, virtual: true
+    field :token_digest, :string
+    field :enabled, :boolean, default: false
+    field :desc, :string
+
+    has_many :group_memberships, RelayGroupMembership, foreign_key: :relay_id
+    has_many :groups, through: [:group_memberships, :group]
+
+    timestamps
+  end
+    @required_fields ~w(name)
+    @optional_fields ~w(token enabled desc)
+
+    def changeset(model, params \\ :empty) do
+      model
+      |> cast(params, @required_fields, @optional_fields)
+      |> validate_presence_on_insert(:token)
+      |> encode_token
+      |> unique_constraint(:name)
+    end
+
+    def validate_presence_on_insert(changeset, :token) do
+      case {get_field(changeset, :id), get_field(changeset, :token)} do
+        {nil, nil} ->
+          changeset
+          |> add_error(:token, "can't be blank")
+        _ ->
+          changeset
+      end
+    end
+
+    def encode_token(changeset) do
+      case fetch_change(changeset, :token) do
+        {:ok, token} ->
+          changeset
+          |> put_change(:token_digest, Passwords.encode(token))
+        :error ->
+          changeset
+      end
+    end
+
+end

--- a/lib/cog/models/relay_group.ex
+++ b/lib/cog/models/relay_group.ex
@@ -1,0 +1,23 @@
+defmodule Cog.Models.RelayGroup do
+  use Cog.Model
+
+  alias Cog.Models.RelayGroupMembership
+
+  schema "relay_groups" do
+    field :name, :string
+    has_many :relay_membership, RelayGroupMembership, foreign_key: :group_id
+    has_many :relays, through: [:relay_membership, :relay]
+
+    timestamps
+  end
+
+  @required_fields ~w(name)
+  @optional_fields ~w()
+
+  def changeset(model, params \\ :empty) do
+    model
+    |> cast(params, @required_fields, @optional_fields)
+    |> unique_constraint(:name)
+  end
+
+end

--- a/lib/cog/models/relay_group_membership.ex
+++ b/lib/cog/models/relay_group_membership.ex
@@ -1,0 +1,19 @@
+defmodule Cog.Models.RelayGroupMembership do
+  use Cog.Model
+  @primary_key false
+
+  schema "relay_group_memberships" do
+    belongs_to :relay, Cog.Models.Relay, references: :id
+    belongs_to :group, Cog.Models.RelayGroup, references: :id
+  end
+
+  @required_fields ~w(relay_id group_id)
+  @optional_fields ~w()
+
+  def changeset(model, params) do
+    model
+    |> cast(params, @required_fields, @optional_fields)
+    |> unique_constraint(:membership, name: "relay_group_memberships_relay_id_group_id_index")
+  end
+
+end

--- a/lib/cog/queries/relay_group_queries.ex
+++ b/lib/cog/queries/relay_group_queries.ex
@@ -1,0 +1,31 @@
+defmodule Cog.Queries.RelayGroup do
+  use Cog.Queries
+
+  alias Cog.Models.RelayGroupMembership
+  alias Cog.Repo
+
+  def all() do
+    from rg in RelayGroup,
+    preload: [:relays]
+  end
+
+  def for_id(id) do
+    all
+    |> where([rg], rg.id == ^id)
+  end
+
+  def add_relays!(group_id, relay_ids) when is_list(relay_ids) do
+    Enum.reduce(relay_ids, [], fn(id, acc) ->
+      rgm = Repo.insert!(%RelayGroupMembership{relay_id: id,
+                                               group_id: group_id})
+      [rgm|acc]
+    end)
+  end
+
+  def remove_relays(group_id, relay_ids) when is_list(relay_ids) do
+    {count, _} = Repo.delete_all(from rgm in RelayGroupMembership,
+                                 where: rgm.group_id == ^group_id and rgm.relay_id in ^relay_ids)
+    count
+  end
+
+end

--- a/lib/cog/queries/relay_queries.ex
+++ b/lib/cog/queries/relay_queries.ex
@@ -1,0 +1,21 @@
+defmodule Cog.Queries.Relay do
+  use Cog.Queries
+  alias Cog.Repo
+
+  def all() do
+    from r in Relay,
+    preload: [:groups]
+  end
+
+  def for_id(id) do
+    all
+    |> where([r], r.id == ^id)
+  end
+
+  def exists?(id) do
+    Repo.one!(from r in Relay,
+              where: r.id == ^id,
+              select: count(r.id)) == 1
+  end
+
+end

--- a/lib/cog/support/model_utilities.ex
+++ b/lib/cog/support/model_utilities.ex
@@ -201,4 +201,35 @@ defmodule Cog.Support.ModelUtilities do
     Supervisor.terminate_child(Cog.Relay.RelaySup, Cog.Bundle.Embedded)
   end
 
+  @doc """
+  Creates a relay record
+  """
+  def relay(name, token, opts \\ []) do
+    relay = %Relay{}
+    |> Relay.changeset(%{name: name,
+                         token: token,
+                         desc: Keyword.get(opts, :desc, nil)})
+    |> Repo.insert!
+    %{relay | token: nil}
+  end
+
+  @doc """
+  Creates a relay group record
+  """
+  def relay_group(name, opts \\ []) do
+    %RelayGroup{}
+    |> RelayGroup.changeset(%{name: name})
+    |> Repo.insert!
+  end
+
+  @doc """
+  Adds a relay to a relay group
+  """
+  def add_relay_to_group(group_id, relay_id) do
+    %RelayGroupMembership{}
+    |> RelayGroupMembership.changeset(%{group_id: group_id,
+                                        relay_id: relay_id})
+    |> Repo.insert!
+  end
+
 end

--- a/lib/cog/support/model_utilities.ex
+++ b/lib/cog/support/model_utilities.ex
@@ -216,7 +216,7 @@ defmodule Cog.Support.ModelUtilities do
   @doc """
   Creates a relay group record
   """
-  def relay_group(name, opts \\ []) do
+  def relay_group(name) do
     %RelayGroup{}
     |> RelayGroup.changeset(%{name: name})
     |> Repo.insert!

--- a/mix.exs
+++ b/mix.exs
@@ -78,10 +78,9 @@ defmodule Cog.Mixfile do
      {:phoenix_live_reload, "~> 1.0.3", only: :dev},
      {:earmark, "~> 0.2.1", only: :dev},
      {:ex_doc, "~> 0.10", only: :dev},
-     {:mix_test_watch, "~> 0.1.1", only: :test},
+     {:mix_test_watch, "~> 0.1.1", only: [:test, :dev]},
      {:excoveralls, "~> 0.5", only: :test},
      {:exvcr, "~> 0.7", only: :test}
-
     ]
   end
 

--- a/priv/repo/migrations/20160328115654_create_relays.exs
+++ b/priv/repo/migrations/20160328115654_create_relays.exs
@@ -1,0 +1,16 @@
+defmodule Cog.Repo.Migrations.AddRelays do
+  use Ecto.Migration
+
+  def change do
+    create table(:relays, primary_key: false) do
+      add :id, :uuid, primary_key: true
+      add :name, :text, null: false
+      add :token_digest, :text, null: false
+      add :enabled, :boolean, null: false
+      add :desc, :text, null: true
+
+      timestamps
+    end
+    create unique_index(:relays, [:name])
+  end
+end

--- a/priv/repo/migrations/20160328121935_create_relay_groups.exs
+++ b/priv/repo/migrations/20160328121935_create_relay_groups.exs
@@ -1,0 +1,22 @@
+defmodule Cog.Repo.Migrations.CreateRelayGroups do
+  use Ecto.Migration
+
+  def change do
+    create table(:relay_groups, primary_key: false) do
+      add :id, :uuid, primary_key: true
+      add :name, :text, null: false
+      add :desc, :text, null: true
+
+      timestamps
+    end
+    create unique_index(:relay_groups, [:name])
+
+    create table(:relay_group_memberships, primary_key: false) do
+      add :relay_id, references(:relays, type: :uuid, on_delete: :delete_all), null: false
+      add :group_id, references(:relay_groups, type: :uuid, on_delete: :delete_all), null: false
+    end
+    create unique_index(:relay_group_memberships, [:relay_id, :group_id])
+
+  end
+
+end

--- a/test/controllers/v1/permission_controller_test.exs
+++ b/test/controllers/v1/permission_controller_test.exs
@@ -33,7 +33,7 @@ defmodule Cog.V1.PermissionControllerTest do
     # Everything currently in the embedded bundle, which is present on
     # system startup
     assert names == ["manage_commands",
-                     "manage_groups", "manage_permissions",
+                     "manage_groups", "manage_permissions", "manage_relays",
                      "manage_roles", "manage_users", "st-echo",
                      "st-thorn"]
   end

--- a/test/controllers/v1/relay_controller_test.exs
+++ b/test/controllers/v1/relay_controller_test.exs
@@ -1,0 +1,131 @@
+defmodule Cog.V1.RelayControllerTest do
+  alias Ecto.DateTime
+
+  use Cog.ModelCase
+  use Cog.ConnCase
+
+  alias Cog.Models.Relay
+  alias Cog.Queries
+
+  @create_attrs %{name: "test-1", token: "foo"}
+  @update_attrs %{enabled: true}
+
+  setup do
+    # Requests handled by the role controller require this permission
+    required_permission = permission("#{Cog.embedded_bundle}:manage_relays")
+
+    # This user will be used to test the normal operation of the controller
+    authed_user = user("cog")
+    |> with_token
+    |> with_permission(required_permission)
+
+    # This user will be used to verify that the above permission is
+    # indeed required for requests
+    unauthed_user = user("sadpanda") |> with_token
+
+    {:ok, [authed: authed_user,
+           unauthed: unauthed_user]}
+  end
+
+  test "creates and renders resource when data is valid", %{authed: requestor} do
+    conn = api_request(requestor, :post, "/v1/relays", body: %{"relay" => @create_attrs})
+    relay_json = json_response(conn, 201)["relay"]
+    assert relay_json["id"] != nil
+    assert relay_json["groups"] == []
+    refute relay_json["enabled"]
+    assert Repo.get_by(Relay, id: relay_json["id"])
+  end
+
+  test "cannot create a relay without permission", %{unauthed: requestor} do
+    conn = api_request(requestor, :post, "/v1/relays", body: %{"relay" => @create_attrs})
+    assert conn.halted
+    assert conn.status == 403
+  end
+
+  test "shows chosen resource", %{authed: requestor} do
+    relay = relay("test-1", "foobar")
+    conn = api_request(requestor, :get, "/v1/relays/#{relay.id}")
+    assert %{"relay" => %{"id" => relay.id,
+                          "name" => relay.name,
+                          "enabled" => relay.enabled,
+                          "groups" => [],
+                          "inserted_at" => "#{DateTime.to_iso8601(relay.inserted_at)}",
+                          "updated_at" => "#{DateTime.to_iso8601(relay.updated_at)}"}} == json_response(conn, 200)
+  end
+
+  test "cannot view relay without permission", %{unauthed: requestor} do
+    relay = relay("test-1", "foobar")
+    conn = api_request(requestor, :get, "/v1/relays/#{relay.id}")
+    assert conn.halted
+    assert conn.status == 403
+  end
+
+  test "deletes chosen resource", %{authed: requestor} do
+    relay = relay("test-1", "foobar")
+    conn = api_request(requestor, :delete, "/v1/relays/#{relay.id}")
+    assert response(conn, 204)
+    refute Repo.get(Relay, relay.id)
+  end
+
+  test "cannot delete relay without permission", %{unauthed: requestor} do
+    relay = relay("test-1", "foobar")
+    conn = api_request(requestor, :delete, "/v1/relays/#{relay.id}")
+    assert conn.halted
+    assert conn.status == 403
+  end
+
+  test "enable relay", %{authed: requestor} do
+    relay = relay("test-1", "foobar")
+    conn = api_request(requestor, :put, "/v1/relays/#{relay.id}",
+                       body: %{"relay" => @update_attrs})
+    updated = json_response(conn, 200)["relay"]
+    assert updated["id"] == relay.id
+    assert updated["name"] == relay.name
+    assert updated["enabled"] == @update_attrs.enabled
+  end
+
+  test "updated token changes token digest", %{authed: requestor} do
+    relay = relay("test-1", "foobar")
+    conn = api_request(requestor, :put, "/v1/relays/#{relay.id}",
+                       body: %{"relay" => %{token: "barbaz"}})
+    assert conn.status == 200
+    updated = Repo.one!(Queries.Relay.for_id(relay.id))
+    refute relay.token_digest == updated.token_digest
+  end
+
+  test "cannot enable relay without permission", %{unauthed: requestor} do
+    relay = relay("test-1", "foobar")
+    conn = api_request(requestor, :put, "/v1/relays/#{relay.id}",
+                       body: %{"relay" => @update_attrs})
+    assert conn.halted
+    assert conn.status == 403
+  end
+
+  test "cannot change relay token without permission", %{unauthed: requestor} do
+    relay = relay("test-1", "foobar")
+    conn = api_request(requestor, :put, "/v1/relays/#{relay.id}",
+                       body: %{"relay" => %{token: "blah"}})
+    assert conn.halted
+    assert conn.status == 403
+  end
+
+  test "fetching all resources", %{authed: requestor} do
+    inserted = for {name, token} <- [{"test-1", "abc"}, {"test-2", "def"}] do
+      relay(name, token)
+    end
+    conn = api_request(requestor, :get, "/v1/relays")
+    relays = json_response(conn, 200)["relays"]
+    assert length(relays) == 2
+    inserted = Enum.sort(Enum.map(inserted, &(Map.get(&1, :id))))
+    fetched = Enum.sort(Enum.map(relays, &(Map.get(&1, "id"))))
+    assert inserted == fetched
+  end
+
+  test "inserting duplicate relay name fails", %{authed: requestor} do
+    relay("test-1", "foobar")
+    conn = api_request(requestor, :post, "/v1/relays", body: %{"relay" => @create_attrs})
+    errors = json_response(conn, 422)["errors"]
+    assert errors["name"] == ["has already been taken"]
+  end
+
+end

--- a/test/controllers/v1/relay_group_controller_test.exs
+++ b/test/controllers/v1/relay_group_controller_test.exs
@@ -1,0 +1,111 @@
+defmodule Cog.V1.RelayGroupControllerTest do
+  alias Ecto.DateTime
+
+  use Cog.ModelCase
+  use Cog.ConnCase
+
+  alias Cog.Models.RelayGroup
+  alias Cog.Repo
+
+  @create_attrs %{name: "test-1"}
+
+  setup do
+    # Requests handled by the role controller require this permission
+    required_permission = permission("#{Cog.embedded_bundle}:manage_relays")
+
+    # This user will be used to test the normal operation of the controller
+    authed_user = user("cog")
+    |> with_token
+    |> with_permission(required_permission)
+
+    # This user will be used to verify that the above permission is
+    # indeed required for requests
+    unauthed_user = user("sadpanda") |> with_token
+
+    {:ok, [authed: authed_user,
+           unauthed: unauthed_user]}
+  end
+
+  test "creates and renders resource when data is valid", %{authed: requestor} do
+    conn = api_request(requestor, :post, "/v1/relay_groups", body: %{"relay_group" => @create_attrs})
+    relay_group = json_response(conn, 201)["relay_group"]
+    assert relay_group["id"] != nil
+    assert relay_group["relays"] == []
+    assert Repo.get_by(RelayGroup, id: relay_group["id"])
+  end
+
+  test "cannot create a relay_group without permission", %{unauthed: requestor} do
+    conn = api_request(requestor, :post, "/v1/relay_groups", body: %{"relay" => @create_attrs})
+    assert conn.halted
+    assert conn.status == 403
+  end
+
+  test "shows chosen resource", %{authed: requestor} do
+    relay_group = relay_group("test-group-1")
+    conn = api_request(requestor, :get, "/v1/relay_groups/#{relay_group.id}")
+    assert %{"relay_group" => %{"id" => relay_group.id,
+                                "name" => relay_group.name,
+                                "relays" => [],
+                                "inserted_at" => "#{DateTime.to_iso8601(relay_group.inserted_at)}",
+                                "updated_at" => "#{DateTime.to_iso8601(relay_group.updated_at)}"}} == json_response(conn, 200)
+  end
+
+  test "cannot view relay_group without permission", %{unauthed: requestor} do
+    relay_group = relay_group("test-group-1")
+    conn = api_request(requestor, :get, "/v1/relay_groups/#{relay_group.id}")
+    assert conn.halted
+    assert conn.status == 403
+  end
+
+  test "deletes chosen resource", %{authed: requestor} do
+    relay_group = relay_group("test-group-1")
+    conn = api_request(requestor, :delete, "/v1/relay_groups/#{relay_group.id}")
+    assert response(conn, 204)
+    refute Repo.get(RelayGroup, relay_group.id)
+  end
+
+  test "cannot delete relay_group without permission", %{unauthed: requestor} do
+    relay_group = relay_group("test-group-1")
+    conn = api_request(requestor, :delete, "/v1/relay_groups/#{relay_group.id}")
+    assert conn.halted
+    assert conn.status == 403
+  end
+
+  test "update relay_group name", %{authed: requestor} do
+    relay_group = relay_group("test-group-1")
+    conn = api_request(requestor, :put, "/v1/relay_groups/#{relay_group.id}",
+                       body: %{"relay_group" => %{"name" => "prod-group-2"}})
+    updated = json_response(conn, 200)["relay_group"]
+    assert updated["id"] == relay_group.id
+    refute updated["name"] == relay_group.name
+    assert updated["name"] == "prod-group-2"
+  end
+
+  test "cannot update relay_group without permission", %{unauthed: requestor} do
+    relay_group = relay_group("test-group-1")
+    conn = api_request(requestor, :put, "/v1/relay_groups/#{relay_group.id}",
+                       body: %{"relay_group" => %{"name" => "prod-group-2"}})
+    assert conn.halted
+    assert conn.status == 403
+  end
+
+  test "fetching all resources", %{authed: requestor} do
+    inserted = for name <- ["test-group-1", "test-group-2", "test-group-3"] do
+      relay_group(name)
+    end
+    conn = api_request(requestor, :get, "/v1/relay_groups")
+    relay_groups = json_response(conn, 200)["relay_groups"]
+    assert length(relay_groups) == 3
+    inserted = Enum.sort(Enum.map(inserted, &(Map.get(&1, :id))))
+    fetched = Enum.sort(Enum.map(relay_groups, &(Map.get(&1, "id"))))
+    assert inserted == fetched
+  end
+
+  test "inserting duplicate relay_group name fails", %{authed: requestor} do
+    relay_group("test-1")
+    conn = api_request(requestor, :post, "/v1/relay_groups", body: %{"relay_group" => @create_attrs})
+    errors = json_response(conn, 422)["errors"]
+    assert errors["name"] == ["has already been taken"]
+  end
+
+end

--- a/test/controllers/v1/relay_group_membership_controller_test.exs
+++ b/test/controllers/v1/relay_group_membership_controller_test.exs
@@ -1,0 +1,105 @@
+defmodule Cog.V1.RelayGroupMembershipControllerTest do
+
+  use Cog.ModelCase
+  use Cog.ConnCase
+
+  @relay_create_attrs %{name: "test-relay-1", token: "foo"}
+  @relay_group_create_attrs %{name: "test-relay-group-1"}
+
+  setup do
+    # Requests handled by the role controller require this permission
+    required_permission = permission("#{Cog.embedded_bundle}:manage_relays")
+
+    # This user will be used to test the normal operation of the controller
+    authed_user = user("cog")
+    |> with_token
+    |> with_permission(required_permission)
+
+    # This user will be used to verify that the above permission is
+    # indeed required for requests
+    unauthed_user = user("sadpanda") |> with_token
+
+    {:ok, [authed: authed_user,
+           unauthed: unauthed_user]}
+  end
+
+  test "shows chosen resource", %{authed: requestor} do
+    relay = relay("test-relay-1", "foo")
+    relay_group = relay_group("test-relay-group-1")
+    add_relay_to_group(relay_group.id, relay.id)
+    conn = api_request(requestor, :get, "/v1/relay_groups/#{relay_group.id}/relays")
+    relays = json_response(conn, 200)["relays"]
+    assert length(relays) == 1
+    assert relays == [%{"id" => relay.id,
+                        "name" => relay.name}]
+  end
+
+  test "relay group includes member relays", %{authed: requestor} do
+    relay = relay("test-relay-1", "foo")
+    relay_group = relay_group("test-relay-group-1")
+    add_relay_to_group(relay_group.id, relay.id)
+    conn = api_request(requestor, :get, "/v1/relay_groups/#{relay_group.id}")
+    fetched = json_response(conn, 200)["relay_group"]
+    assert relay_group.id == fetched["id"]
+    assert relay_group.name == fetched["name"]
+    assert length(fetched["relays"]) == 1
+    member = Enum.at(fetched["relays"], 0)
+    assert member["id"] == relay.id
+    assert member["name"] == relay.name
+  end
+
+  test "relay includes relay_group memberships", %{authed: requestor} do
+    relay = relay("test-relay-1", "foo")
+    relay_groups = (for name <- ["test-relay-group-1", "test-relay-group-2"] do
+      rg = relay_group(name)
+      add_relay_to_group(rg.id, relay.id)
+      {rg.id, rg.name}
+    end) |> Enum.sort
+
+    conn = api_request(requestor, :get, "/v1/relays/#{relay.id}")
+    fetched = json_response(conn, 200)["relay"]
+
+    assert relay.id == fetched["id"]
+    assert relay.name == fetched["name"]
+    assert length(relay_groups) == length(fetched["groups"])
+    fetched_groups = fetched["groups"]
+    |> Enum.map(&({Map.get(&1, "id"), Map.get(&1, "name")}))
+    |> Enum.sort
+    assert relay_groups == fetched_groups
+  end
+
+  test "adding relays via REST endpoint", %{authed: requestor} do
+    relay_group = relay_group("test-relay-group-3")
+    relays = for name <- ["test-relay-1", "test-relay-2", "test-relay-3"] do
+      relay(name, "foo")
+    end
+    relay_ids = Enum.sort(Enum.map(relays, &(&1.id)))
+    conn = api_request(requestor, :post, "/v1/relay_groups/#{relay_group.id}/membership",
+                       body: %{"relays" => %{"add" => relay_ids}})
+    updated = json_response(conn, 200)["relay_group"]
+    assert updated["id"] == relay_group.id
+    assert updated["name"] == relay_group.name
+    assert length(updated["relays"]) == length(relay_ids)
+    assert relay_ids == Enum.sort(Enum.map(updated["relays"], &(Map.get(&1, "id"))))
+  end
+
+  test "removing relays via REST endpoint", %{authed: requestor} do
+    relay_group = relay_group("test-relay-group-3")
+    relays = for name <- ["test-relay-1", "test-relay-2", "test-relay-3"] do
+      relay(name, "foo")
+    end
+    for relay <- relays do
+      add_relay_to_group(relay_group.id, relay.id)
+    end
+    relay_ids = Enum.sort(Enum.map(relays, &(&1.id)))
+    to_remove = tl(relay_ids)
+    conn = api_request(requestor, :post, "/v1/relay_groups/#{relay_group.id}/membership",
+                       body: %{"relays" => %{"remove" => to_remove}})
+    updated = json_response(conn, 200)["relay_group"]
+    assert length(updated["relays"]) == 1
+    [remaining] = updated["relays"]
+    assert remaining["id"] == hd(relay_ids)
+  end
+
+
+end

--- a/web/controllers/v1/group_membership_controller.ex
+++ b/web/controllers/v1/group_membership_controller.ex
@@ -167,3 +167,4 @@ defmodule Cog.V1.GroupMembershipController do
   defp unique_name_field(Group), do: :name
 
 end
+

--- a/web/controllers/v1/relay_controller.ex
+++ b/web/controllers/v1/relay_controller.ex
@@ -1,0 +1,56 @@
+defmodule Cog.V1.RelayController do
+  use Cog.Web, :controller
+
+  alias Cog.Models.Relay
+  alias Cog.Queries
+
+  plug Cog.Plug.Authentication
+  plug Cog.Plug.Authorization, permission: "#{Cog.embedded_bundle}:manage_relays"
+
+  plug :scrub_params, "relay" when action in [:create, :update]
+
+  def index(conn, _params) do
+    relays = Repo.all(Queries.Relay.all())
+    render(conn, "index.json", relays: relays)
+  end
+
+  def create(conn, %{"relay" => relay_params}) do
+    changeset = Relay.changeset(%Relay{}, relay_params)
+    case Repo.insert(changeset) do
+      {:ok, relay} ->
+        conn
+        |> put_status(:created)
+        |> put_resp_header("location", relay_path(conn, :show, relay))
+        |> render("show.json", %{relay: relay})
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(Cog.ChangesetView, "error.json", changeset: changeset)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    relay = Repo.one!(Queries.Relay.for_id(id))
+    render(conn, "show.json", %{relay: relay})
+  end
+
+  def delete(conn, %{"id" => id}) do
+    relay = Repo.get!(Relay, id)
+    Repo.delete!(relay)
+    send_resp(conn, :no_content, "")
+  end
+
+  def update(conn, %{"id" => id, "relay" => relay_params}) do
+    relay = Repo.get!(Relay, id)
+    changeset = Relay.changeset(relay, relay_params)
+    case Repo.update(changeset) do
+      {:ok, relay} ->
+        render(conn, "show.json", %{relay: relay})
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(Cog.ChangesetView, "error.json", changeset: changeset)
+    end
+  end
+
+end

--- a/web/controllers/v1/relay_group_controller.ex
+++ b/web/controllers/v1/relay_group_controller.ex
@@ -1,0 +1,56 @@
+defmodule Cog.V1.RelayGroupController do
+  use Cog.Web, :controller
+
+  alias Cog.Models.RelayGroup
+  alias Cog.Queries
+
+  plug Cog.Plug.Authentication
+  plug Cog.Plug.Authorization, permission: "#{Cog.embedded_bundle}:manage_relays"
+
+  plug :scrub_params, "relay_group" when action in [:create, :update]
+
+  def index(conn, _params) do
+     groups = Repo.all(RelayGroup)
+     render(conn, "index.json", relay_groups: groups)
+  end
+
+  def create(conn, %{"relay_group" => group_params}) do
+    changeset = RelayGroup.changeset(%RelayGroup{}, group_params)
+
+    case Repo.insert(changeset) do
+      {:ok, group} ->
+        conn
+        |> put_status(:created)
+        |> put_resp_header("location", group_path(conn, :show, group))
+        |> render("show.json", relay_group: group)
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(Cog.ChangesetView, "error.json", changeset: changeset)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    group = Repo.one!(Queries.RelayGroup.for_id(id))
+    render(conn, "show.json", relay_group: group)
+  end
+
+  def delete(conn, %{"id" => id}) do
+    Repo.get!(RelayGroup, id) |> Repo.delete!
+    send_resp(conn, :no_content, "")
+  end
+
+  def update(conn, %{"id" => id, "relay_group" => group_params}) do
+    relay_group = Repo.get!(RelayGroup, id)
+    changeset = RelayGroup.changeset(relay_group, group_params)
+    case Repo.update(changeset) do
+      {:ok, relay_group} ->
+        render(conn, "show.json", relay_group: relay_group)
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(Cog.ChangesetView, "error.json", changeset: changeset)
+    end
+  end
+
+end

--- a/web/controllers/v1/relay_group_membership_controller.ex
+++ b/web/controllers/v1/relay_group_membership_controller.ex
@@ -1,0 +1,66 @@
+defmodule Cog.V1.RelayGroupMembershipController do
+  use Cog.Web, :controller
+
+  alias Cog.Models.Relay
+  alias Cog.Models.RelayGroup
+  alias Cog.Queries
+
+  plug Cog.Plug.Authentication
+  plug Cog.Plug.Authorization, permission: "#{Cog.embedded_bundle}:manage_relays"
+
+  def index(conn, %{"id" => id}) do
+    relay_group = Repo.one!(Queries.RelayGroup.for_id(id))
+    render(conn, Cog.V1.RelayGroupView, "relays.json", relay_group: relay_group)
+  end
+
+  # Manage membership of a relay group. Adds and deletes can be submitted and
+  # processed in a single request.
+  def manage_membership(conn, %{"id" => id, "relays" => member_spec}) do
+    result = Repo.transaction(fn() ->
+      group = Repo.get!(RelayGroup, id)
+
+      to_add = Enum.reduce(Map.get(member_spec, "add", []),
+                           %{found: [], not_found: []}, &lookup_or_fail/2)
+      to_remove = Enum.reduce(Map.get(member_spec, "remove", []),
+                           %{found: [], not_found: []}, &lookup_or_fail/2)
+      case to_add.not_found ++ to_remove.not_found do
+        [] ->
+          Queries.RelayGroup.add_relays!(group.id, to_add.found)
+          removed = Queries.RelayGroup.remove_relays(group.id, to_remove.found)
+          if removed != length(to_remove.found) do
+            Repo.rollback(:removing_relays_failed)
+          else
+            Repo.preload(group, :relays)
+          end
+        ids ->
+          Repo.rollback({:unknown_relays, ids})
+      end
+    end)
+
+    case result do
+      {:ok, relay_group} ->
+        render(conn, Cog.V1.RelayGroupView, "show.json", relay_group: relay_group)
+      {:error, reason} ->
+        errors = case reason do
+                   {:removing_relays_failed} ->
+                     "delete_failed"
+                   {:unknown_relays, ids} ->
+                     %{"not_found" => %{"relays" => ids}}
+                 end
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{"errors" => errors})
+    end
+  end
+
+  defp lookup_or_fail(id, acc) do
+    key = case Queries.Relay.exists?(id) do
+            false ->
+              :not_found
+            true ->
+              :found
+          end
+    Map.update(acc, key, [id], &([id|&1]))
+  end
+
+end

--- a/web/controllers/v1/relay_group_membership_controller.ex
+++ b/web/controllers/v1/relay_group_membership_controller.ex
@@ -1,7 +1,6 @@
 defmodule Cog.V1.RelayGroupMembershipController do
   use Cog.Web, :controller
 
-  alias Cog.Models.Relay
   alias Cog.Models.RelayGroup
   alias Cog.Queries
 

--- a/web/router.ex
+++ b/web/router.ex
@@ -52,6 +52,11 @@ defmodule Cog.Router do
     get "/v1/users/:id/chat_handles", V1.ChatHandleController, :index
     post "/v1/users/:id/chat_handles", V1.ChatHandleController, :create
 
+    # Relay management
+    resources "/v1/relays", V1.RelayController
+    resources "/v1/relay_groups", V1.RelayGroupController
+    get "/v1/relay_groups/:id/relays", V1.RelayGroupMembershipController, :index
+    post "/v1/relay_groups/:id/membership", V1.RelayGroupMembershipController, :manage_membership
   end
 
   scope "/", Cog do

--- a/web/views/relay_group_view.ex
+++ b/web/views/relay_group_view.ex
@@ -1,0 +1,33 @@
+defmodule Cog.V1.RelayGroupView do
+  use Cog.Web, :view
+
+  alias Ecto.Association
+
+  def render("relay_group.json", %{relay_group: relay_group}) do
+    %{id: relay_group.id,
+      name: relay_group.name,
+      relays: render_members(relay_group.relays()),
+      inserted_at: relay_group.inserted_at,
+      updated_at: relay_group.updated_at}
+  end
+  def render("index.json", %{relay_groups: relay_groups}) do
+    %{relay_groups: render_many(relay_groups, __MODULE__, "relay_group.json")}
+  end
+  def render("show.json", %{relay_group: relay_group}) do
+    %{relay_group: render_one(relay_group, __MODULE__, "relay_group.json")}
+  end
+  def render("relays.json", %{relay_group: relay_group}) do
+    %{relays: render_members(relay_group.relays())}
+  end
+
+  defp render_members(%Association.NotLoaded{}) do
+    []
+  end
+  defp render_members(relays) do
+    for relay <- relays do
+      %{id: relay.id,
+        name: relay.name}
+    end
+  end
+
+end

--- a/web/views/relay_view.ex
+++ b/web/views/relay_view.ex
@@ -1,0 +1,32 @@
+defmodule Cog.V1.RelayView do
+  use Cog.Web, :view
+
+  alias Ecto.Association
+
+  def render("relay.json", %{relay: relay}) do
+    %{id: relay.id,
+      name: relay.name,
+      enabled: relay.enabled,
+      groups: render_groups(relay.groups),
+      inserted_at: relay.inserted_at,
+      updated_at: relay.updated_at}
+  end
+  def render("index.json", %{relays: relays}) do
+    %{relays: render_many(relays, __MODULE__, "relay.json")}
+  end
+
+  def render("show.json", %{relay: relay}) do
+    %{relay: render_one(relay, __MODULE__, "relay.json")}
+  end
+
+  defp render_groups(%Association.NotLoaded{}) do
+    []
+  end
+  defp render_groups(groups) do
+    for group <- groups do
+      %{id: group.id,
+        name: group.name}
+    end
+  end
+
+end


### PR DESCRIPTION
Adds REST API w/supporting data model and migrations to manage relays and relay groups. Also lays foundation for Relay 2.0 changes.

Fixes #403.