### PR TITLE
Add groups, users, and roles to group#index and #show

### DIFF
--- a/test/controllers/v1/group_controller_test.exs
+++ b/test/controllers/v1/group_controller_test.exs
@@ -35,6 +35,9 @@ defmodule Cog.V1.GroupControllerTest do
     group = group("aliens")
     conn = api_request(user, :get, "/v1/groups/#{group.id}")
     assert json_response(conn, 200)["group"] == %{"id" => group.id,
+                                                  "members" => %{"roles" => [],
+                                                                 "groups" => [],
+                                                                 "users" => []},
                                                   "name" => group.name}
   end
 

--- a/web/views/groups_view.ex
+++ b/web/views/groups_view.ex
@@ -1,0 +1,48 @@
+defmodule Cog.V1.GroupView do
+  use Cog.Web, :view
+
+  def render("group.json", %{group: group}) do
+    %{id: group.id,
+      name: group.name,
+      members: %{roles: render_roles(group.roles),
+                 users: render_users(group.direct_user_members),
+                 groups: render_groups(group.direct_group_members)}
+    }
+  end
+
+  def render("index.json", %{groups: groups}) do
+    %{groups: render_many(groups, __MODULE__, "group.json")}
+  end
+
+  def render("show.json", %{group: group}) do
+    %{group: render_one(group, __MODULE__, "group.json")}
+  end
+
+  defp render_roles(roles) when is_list(roles) do
+    Enum.map(roles, fn(role) ->
+        %{id: role.id,
+          name: role.name}
+    end)
+  end
+  defp render_roles(_), do: []
+
+  defp render_users(users) when is_list(users) do
+    Enum.map(users, fn(user) ->
+        %{id: user.id,
+          email_address: user.email_address,
+          first_name: user.first_name,
+          last_name: user.last_name,
+          username: user.username}
+    end)
+  end
+  defp render_users(_), do: []
+
+  defp render_groups(groups) when is_list(groups) do
+    Enum.map(groups, fn(group) ->
+        %{id: group.id,
+          name: group.name}
+    end)
+  end
+  defp render_groups(_), do: []
+
+end

--- a/web/views/roles_view.ex
+++ b/web/views/roles_view.ex
@@ -7,6 +7,7 @@ defmodule Cog.V1.RoleView do
       permissions: render_permissions(role.permissions)}
   end
 
+  def render("index.json", %{roles: []}), do: %{roles: []}
   def render("index.json", %{roles: roles}) do
     %{roles: render_many(roles, __MODULE__, "role.json")}
   end
@@ -15,12 +16,13 @@ defmodule Cog.V1.RoleView do
     %{role: render_one(role, __MODULE__, "role.json")}
   end
 
-  defp render_permissions(permissions) do
+  defp render_permissions(permissions) when is_list(permissions) do
     Enum.map(permissions, fn(permission) ->
         %{id: permission.id,
           name: permission.name,
           namespace: permission.namespace.name}
     end)
   end
+  defp render_permissions(_), do: []
 
 end


### PR DESCRIPTION
This PR adds roles to the groups#show and groups#index API calls and retrieves groups, roles and users in a single call. (Instead of also needing to make a call to the group membership API).

The structure returned looks like the following:
```
%{"id" => "some-id",
  "name" => "some-group"
  "members" => %{"groups" => [[%{"id" => "group-id",
                         "name" => "some-group-name"}],
                 "roles" => [[%{"id" => "role-id",
                          "name" => "some-rolename"}],
                 "users" => [%{"id" => "user-id",
                         "username" => "some-username",
                         "email_address" => "some-email_address",
                         "first_name" => "some-firstname",
                         "last_name" => "some-lastname"}]
      }
}
```

Fixes https://github.com/operable/cog/issues/462