### PR TITLE
allow bundles to be assigned to relay groups

### DIFF
--- a/lib/cog/models.ex
+++ b/lib/cog/models.ex
@@ -31,6 +31,7 @@ defmodule Cog.Models do
       alias Cog.Models.GroupGroupMembership
       alias Cog.Models.Relay
       alias Cog.Models.RelayGroup
+      alias Cog.Models.RelayGroupAssignment
       alias Cog.Models.RelayGroupMembership
       alias Cog.Models.Role
       alias Cog.Models.UserRole

--- a/lib/cog/models/bundle.ex
+++ b/lib/cog/models/bundle.ex
@@ -12,6 +12,9 @@ defmodule Cog.Models.Bundle do
     has_many :templates, Template
     has_one :namespace, Namespace
 
+    has_many :group_assignments, RelayGroupAssignment, foreign_key: :bundle_id
+    has_many :relay_groups, through: [:group_assignments, :group]
+
     timestamps
   end
 
@@ -23,6 +26,7 @@ defmodule Cog.Models.Bundle do
 
   def changeset(model, params \\ :empty) do
     model
+    |> Repo.preload(:relay_groups)
     |> cast(params, @required_fields, @optional_fields)
     |> validate_format(:name, ~r/\A[A-Za-z0-9\_\-\.]+\z/)
     |> unique_constraint(:name, name: :bundles_name_index)

--- a/lib/cog/models/relay_group.ex
+++ b/lib/cog/models/relay_group.ex
@@ -2,11 +2,17 @@ defmodule Cog.Models.RelayGroup do
   use Cog.Model
 
   alias Cog.Models.RelayGroupMembership
+  alias Cog.Models.RelayGroupAssignment
+  alias Cog.Repo
 
   schema "relay_groups" do
     field :name, :string
+
     has_many :relay_membership, RelayGroupMembership, foreign_key: :group_id
     has_many :relays, through: [:relay_membership, :relay]
+
+    has_many :bundle_assignment, RelayGroupAssignment, foreign_key: :group_id
+    has_many :bundles, through: [:bundle_assignment, :bundle]
 
     timestamps
   end
@@ -16,8 +22,53 @@ defmodule Cog.Models.RelayGroup do
 
   def changeset(model, params \\ :empty) do
     model
+    |> Repo.preload([:bundles, :relays])
     |> cast(params, @required_fields, @optional_fields)
     |> unique_constraint(:name)
+  end
+
+  def add!(:bundle, group_id, bundle_id),
+  do: add_bundles!(group_id, bundle_id)
+
+  def add!(:relay, group_id, relay_ids),
+  do: add_relays!(group_id, relay_ids)
+
+  def remove(:bundle, group_id, bundle_ids),
+  do: remove_bundles(group_id, bundle_ids)
+
+  def remove(:relay, group_id, relay_ids),
+  do: remove_relays(group_id, relay_ids)
+
+  def add_relays!(group_id, relay_ids) when is_list(relay_ids) do
+    Enum.reduce(relay_ids, [], fn(id, acc) ->
+      rgm =
+        %RelayGroupMembership{}
+        |> RelayGroupMembership.changeset(%{relay_id: id, group_id: group_id})
+        |> Repo.insert!
+      [rgm|acc]
+    end)
+  end
+
+  def remove_relays(group_id, relay_ids) when is_list(relay_ids) do
+    {count, _} = Repo.delete_all(from rgm in RelayGroupMembership,
+                                 where: rgm.group_id == ^group_id and rgm.relay_id in ^relay_ids)
+    count
+  end
+
+  def add_bundles!(group_id, bundle_ids) when is_list(bundle_ids) do
+    Enum.reduce(bundle_ids, [], fn(id, acc) ->
+      rga =
+        %RelayGroupAssignment{}
+        |> RelayGroupAssignment.changeset(%{bundle_id: id, group_id: group_id})
+        |> Repo.insert!
+      [rga|acc]
+    end)
+  end
+
+  def remove_bundles(group_id, bundle_ids) when is_list(bundle_ids) do
+    {count, _} = Repo.delete_all(from rgm in RelayGroupAssignment,
+                                 where: rgm.group_id == ^group_id and rgm.bundle_id in ^bundle_ids)
+    count
   end
 
 end

--- a/lib/cog/models/relay_group_assignment.ex
+++ b/lib/cog/models/relay_group_assignment.ex
@@ -1,0 +1,19 @@
+defmodule Cog.Models.RelayGroupAssignment do
+  use Cog.Model
+  @primary_key false
+
+  schema "relay_group_assignments" do
+    belongs_to :bundle, Cog.Models.Bundle, references: :id
+    belongs_to :group, Cog.Models.RelayGroup, references: :id
+  end
+
+  @required_fields ~w(bundle_id group_id)
+  @optional_fields ~w()
+
+  def changeset(model, params) do
+    model
+    |> cast(params, @required_fields, @optional_fields)
+    |> unique_constraint(:bundle_id, name: :relay_group_assignments_bundle_id_group_id_index)
+  end
+
+end

--- a/lib/cog/models/relay_group_membership.ex
+++ b/lib/cog/models/relay_group_membership.ex
@@ -13,7 +13,7 @@ defmodule Cog.Models.RelayGroupMembership do
   def changeset(model, params) do
     model
     |> cast(params, @required_fields, @optional_fields)
-    |> unique_constraint(:membership, name: "relay_group_memberships_relay_id_group_id_index")
+    |> unique_constraint(:relay_id, name: :relay_group_memberships_relay_id_group_id_index)
   end
 
 end

--- a/lib/cog/queries/bundles.ex
+++ b/lib/cog/queries/bundles.ex
@@ -4,21 +4,14 @@ defmodule Cog.Queries.Bundles do
 
   alias Cog.Models.Bundle
 
-  def bundle_details(id) do
+  def all do
     from b in Bundle,
-    where: b.id == ^id,
-    preload: [:commands, :namespace]
+    preload: [:commands, :relay_groups, :namespace]
   end
 
-  def bundle_summary(id) do
-    from b in Bundle,
-    where: b.id == ^id,
-    preload: [:namespace]
-  end
-
-  def bundle_summaries() do
-    from b in Bundle,
-    preload: [:namespace]
+  def for_id(id) do
+    all
+    |> where([b], b.id == ^id)
   end
 
   def bundle_id_from_name(name) do
@@ -27,4 +20,5 @@ defmodule Cog.Queries.Bundles do
     select: b.id,
     limit: 1
   end
+
 end

--- a/lib/cog/queries/relay_group_queries.ex
+++ b/lib/cog/queries/relay_group_queries.ex
@@ -1,31 +1,14 @@
 defmodule Cog.Queries.RelayGroup do
   use Cog.Queries
 
-  alias Cog.Models.RelayGroupMembership
-  alias Cog.Repo
-
   def all() do
     from rg in RelayGroup,
-    preload: [:relays]
+    preload: [:relays, :bundles]
   end
 
   def for_id(id) do
     all
     |> where([rg], rg.id == ^id)
-  end
-
-  def add_relays!(group_id, relay_ids) when is_list(relay_ids) do
-    Enum.reduce(relay_ids, [], fn(id, acc) ->
-      rgm = Repo.insert!(%RelayGroupMembership{relay_id: id,
-                                               group_id: group_id})
-      [rgm|acc]
-    end)
-  end
-
-  def remove_relays(group_id, relay_ids) when is_list(relay_ids) do
-    {count, _} = Repo.delete_all(from rgm in RelayGroupMembership,
-                                 where: rgm.group_id == ^group_id and rgm.relay_id in ^relay_ids)
-    count
   end
 
 end

--- a/lib/cog/queries/relay_queries.ex
+++ b/lib/cog/queries/relay_queries.ex
@@ -1,6 +1,5 @@
 defmodule Cog.Queries.Relay do
   use Cog.Queries
-  alias Cog.Repo
 
   def all() do
     from r in Relay,
@@ -10,12 +9,6 @@ defmodule Cog.Queries.Relay do
   def for_id(id) do
     all
     |> where([r], r.id == ^id)
-  end
-
-  def exists?(id) do
-    Repo.one!(from r in Relay,
-              where: r.id == ^id,
-              select: count(r.id)) == 1
   end
 
 end

--- a/lib/cog/queries/repo.ex
+++ b/lib/cog/queries/repo.ex
@@ -1,0 +1,10 @@
+defmodule Cog.Queries.Repo do
+  use Cog.Queries
+
+  def count_by_id(model, id) do
+    from m in model,
+    where: m.id == ^id,
+    select: count(m.id)
+  end
+
+end

--- a/lib/cog/repo.ex
+++ b/lib/cog/repo.ex
@@ -1,3 +1,13 @@
 defmodule Cog.Repo do
   use Ecto.Repo, otp_app: :cog
+
+  alias Cog.Queries.Repo, as: Queries
+
+  def exists?(model, id) do
+    case one!(Queries.count_by_id(model, id)) do
+      1 -> true
+      _ -> false
+    end
+  end
+
 end

--- a/lib/cog/support/model_utilities.ex
+++ b/lib/cog/support/model_utilities.ex
@@ -131,11 +131,11 @@ defmodule Cog.Support.ModelUtilities do
   end
 
   @doc "Create or retrieve a permission namespace with the given `name`"
-  def namespace(name) do
+  def namespace(name, bundle_id \\ nil) do
     namespace = Repo.get_by(Namespace, name: name)
     case namespace do
       nil ->
-        Repo.insert! %Namespace{name: name}
+        Repo.insert! %Namespace{name: name, bundle_id: bundle_id}
       _ ->
         namespace
     end
@@ -188,20 +188,6 @@ defmodule Cog.Support.ModelUtilities do
   end
 
   @doc """
-  Remove everything from the database.
-
-  As this removes bundles, too, we want to terminate any running
-  bundle processes, so they won't interfere with anything you might
-  reload later.
-  """
-  def clean_db! do
-    [Bundle, User, Group, Role, Namespace]
-    |> Enum.each(&Repo.delete_all/1)
-
-    Supervisor.terminate_child(Cog.Relay.RelaySup, Cog.Bundle.Embedded)
-  end
-
-  @doc """
   Creates a relay record
   """
   def relay(name, token, opts \\ []) do
@@ -230,6 +216,30 @@ defmodule Cog.Support.ModelUtilities do
     |> RelayGroupMembership.changeset(%{group_id: group_id,
                                         relay_id: relay_id})
     |> Repo.insert!
+  end
+
+  @doc """
+  Assigns a bundle to a relay group
+  """
+  def assign_bundle_to_group(group_id, bundle_id) do
+    %RelayGroupAssignment{}
+    |> RelayGroupAssignment.changeset(%{group_id: group_id,
+                                        bundle_id: bundle_id})
+    |> Repo.insert!
+  end
+
+  @doc """
+  Remove everything from the database.
+
+  As this removes bundles, too, we want to terminate any running
+  bundle processes, so they won't interfere with anything you might
+  reload later.
+  """
+  def clean_db! do
+    [Bundle, User, Group, Relay, Role, Namespace]
+    |> Enum.each(&Repo.delete_all/1)
+
+    Supervisor.terminate_child(Cog.Relay.RelaySup, Cog.Bundle.Embedded)
   end
 
 end

--- a/priv/repo/migrations/20160329185210_add_bundle_relay_group_assignments.exs
+++ b/priv/repo/migrations/20160329185210_add_bundle_relay_group_assignments.exs
@@ -1,0 +1,11 @@
+defmodule Cog.Repo.Migrations.AddBundleRelayGroupAssignments do
+  use Ecto.Migration
+
+  def change do
+    create table(:relay_group_assignments, primary_key: false) do
+      add :bundle_id, references(:bundles, type: :uuid, on_delete: :delete_all), null: false
+      add :group_id, references(:relay_groups, type: :uuid, on_delete: :delete_all), null: false
+    end
+    create unique_index(:relay_group_assignments, [:bundle_id, :group_id])
+  end
+end

--- a/test/controllers/v1/bundles_controller_test.exs
+++ b/test/controllers/v1/bundles_controller_test.exs
@@ -1,0 +1,43 @@
+defmodule Cog.V1.BundlesControllerTest do
+  alias Ecto.DateTime
+
+  use Cog.ModelCase
+  use Cog.ConnCase
+
+  setup do
+    # Requests handled by the role controller require this permission
+    required_permission = permission("#{Cog.embedded_bundle}:manage_commands")
+
+    # This user will be used to test the normal operation of the controller
+    authed_user = user("cog")
+    |> with_token
+    |> with_permission(required_permission)
+
+    # This user will be used to verify that the above permission is
+    # indeed required for requests
+    unauthed_user = user("sadpanda") |> with_token
+
+    {:ok, [authed: authed_user,
+           unauthed: unauthed_user]}
+  end
+
+  test "shows chosen resource", %{authed: requestor} do
+    bundle = bundle("test-1")
+    conn = api_request(requestor, :get, "/v1/bundles/#{bundle.id}")
+    assert %{"bundle" => %{"id" => bundle.id,
+                           "name" => bundle.name,
+                           "enabled" => bundle.enabled,
+                           "relay_groups" => [],
+                           "commands" => [],
+                           "inserted_at" => "#{DateTime.to_iso8601(bundle.inserted_at)}",
+                           "updated_at" => "#{DateTime.to_iso8601(bundle.updated_at)}"}} == json_response(conn, 200)
+  end
+
+  test "cannot view bundle without permission", %{unauthed: requestor} do
+    bundle = bundle("test-1")
+    conn = api_request(requestor, :get, "/v1/bundles/#{bundle.id}")
+    assert conn.halted
+    assert conn.status == 403
+  end
+
+end

--- a/test/controllers/v1/relay_group_controller_test.exs
+++ b/test/controllers/v1/relay_group_controller_test.exs
@@ -46,6 +46,7 @@ defmodule Cog.V1.RelayGroupControllerTest do
     assert %{"relay_group" => %{"id" => relay_group.id,
                                 "name" => relay_group.name,
                                 "relays" => [],
+                                "bundles" => [],
                                 "inserted_at" => "#{DateTime.to_iso8601(relay_group.inserted_at)}",
                                 "updated_at" => "#{DateTime.to_iso8601(relay_group.updated_at)}"}} == json_response(conn, 200)
   end

--- a/web/controllers/v1/bundle_status_controller.ex
+++ b/web/controllers/v1/bundle_status_controller.ex
@@ -31,13 +31,13 @@ defmodule Cog.V1.BundleStatusController do
   require Logger
   alias Cog.Repo
   alias Cog.Models.Bundle
-  alias Cog.Queries.Bundles
+  alias Cog.Queries
 
   plug Cog.Plug.Authentication
   plug Cog.Plug.Authorization, permission: "#{Cog.embedded_bundle}:manage_commands"
 
   def show(conn, %{"id" => id}) do
-    case Repo.one(Bundles.bundle_details(id)) do
+    case Repo.one(Queries.Bundles.for_id(id)) do
       nil ->
         send_resp(conn, 404, Poison.encode!(%{error: "Bundle #{id} not found"}))
       bundle ->
@@ -45,7 +45,7 @@ defmodule Cog.V1.BundleStatusController do
     end
   end
   def manage_status(conn, %{"id" => id, "status" => desired_status}) when desired_status in ["enabled", "disabled"] do
-    case Repo.one(Bundles.bundle_details(id)) do
+    case Repo.one(Queries.Bundles.for_id(id)) do
       %Bundle{}=bundle ->
         case Bundle.Status.set(bundle, String.to_existing_atom(desired_status)) do
           {:ok, bundle} ->

--- a/web/controllers/v1/bundles_controller.ex
+++ b/web/controllers/v1/bundles_controller.ex
@@ -3,28 +3,28 @@ defmodule Cog.V1.BundlesController do
 
   alias Cog.Relay.Relays
   alias Cog.Models.Bundle
-  alias Cog.Models.EctoJson
-  alias Cog.Queries.Bundles
+  alias Cog.Queries
+  alias Cog.Repo
 
   plug Cog.Plug.Authentication
   plug Cog.Plug.Authorization, permission: "#{Cog.embedded_bundle}:manage_commands"
 
   def index(conn, _params) do
-    installed = Repo.all(Bundles.bundle_summaries())
-    json(conn, EctoJson.render(installed, envelope: :bundles, policy: :summary))
+    installed = Repo.all(Queries.Bundles.all)
+    render(conn, "index.json", %{bundles: installed})
   end
 
   def show(conn, %{"id" => id}) do
-    case Repo.one(Bundles.bundle_details(id)) do
+    case Repo.one(Queries.Bundles.for_id(id)) do
       nil ->
         send_resp(conn, 404, Poison.encode!(%{error: "Bundle #{id} not found"}))
       bundle ->
-        json(conn, EctoJson.render(bundle, envelope: :bundle,  policy: :detail))
+        render(conn, "show.json", %{bundle: bundle})
     end
   end
 
   def delete(conn, %{"id" => id}) do
-    case Repo.one(Bundles.bundle_summary(id)) do
+    case Repo.one(Queries.Bundles.for_id(id)) do
       nil ->
         send_resp(conn, 404, Poison.encode!(%{error: "Bundle #{id} not found"}))
       %Bundle{name: "operable"} ->

--- a/web/controllers/v1/relay_controller.ex
+++ b/web/controllers/v1/relay_controller.ex
@@ -3,6 +3,7 @@ defmodule Cog.V1.RelayController do
 
   alias Cog.Models.Relay
   alias Cog.Queries
+  alias Cog.Repo
 
   plug Cog.Plug.Authentication
   plug Cog.Plug.Authorization, permission: "#{Cog.embedded_bundle}:manage_relays"
@@ -10,7 +11,7 @@ defmodule Cog.V1.RelayController do
   plug :scrub_params, "relay" when action in [:create, :update]
 
   def index(conn, _params) do
-    relays = Repo.all(Queries.Relay.all())
+    relays = Repo.all(Queries.Relay.all)
     render(conn, "index.json", relays: relays)
   end
 
@@ -41,7 +42,7 @@ defmodule Cog.V1.RelayController do
   end
 
   def update(conn, %{"id" => id, "relay" => relay_params}) do
-    relay = Repo.get!(Relay, id)
+    relay = Repo.one!(Queries.Relay.for_id(id))
     changeset = Relay.changeset(relay, relay_params)
     case Repo.update(changeset) do
       {:ok, relay} ->

--- a/web/controllers/v1/relay_group_controller.ex
+++ b/web/controllers/v1/relay_group_controller.ex
@@ -3,6 +3,7 @@ defmodule Cog.V1.RelayGroupController do
 
   alias Cog.Models.RelayGroup
   alias Cog.Queries
+  alias Cog.Repo
 
   plug Cog.Plug.Authentication
   plug Cog.Plug.Authorization, permission: "#{Cog.embedded_bundle}:manage_relays"
@@ -10,7 +11,7 @@ defmodule Cog.V1.RelayGroupController do
   plug :scrub_params, "relay_group" when action in [:create, :update]
 
   def index(conn, _params) do
-     groups = Repo.all(RelayGroup)
+     groups = Repo.all(Queries.RelayGroup.all)
      render(conn, "index.json", relay_groups: groups)
   end
 

--- a/web/router.ex
+++ b/web/router.ex
@@ -57,6 +57,8 @@ defmodule Cog.Router do
     resources "/v1/relay_groups", V1.RelayGroupController
     get "/v1/relay_groups/:id/relays", V1.RelayGroupMembershipController, :index
     post "/v1/relay_groups/:id/membership", V1.RelayGroupMembershipController, :manage_membership
+    get "/v1/relay_groups/:id/bundles", V1.RelayGroupMembershipController, :index
+    post "/v1/relay_groups/:id/assignment", V1.RelayGroupMembershipController, :manage_assignment
   end
 
   scope "/", Cog do

--- a/web/views/bundles_view.ex
+++ b/web/views/bundles_view.ex
@@ -1,0 +1,36 @@
+defmodule Cog.V1.BundlesView do
+  use Cog.Web, :view
+
+  def render("bundle.json", %{bundle: bundle}) do
+    %{id: bundle.id,
+      name: bundle.name,
+      commands: render_commands(bundle.commands),
+      relay_groups: render_relay_groups(bundle.relay_groups),
+      enabled: bundle.enabled,
+      inserted_at: bundle.inserted_at,
+      updated_at: bundle.updated_at}
+  end
+  def render("index.json", %{bundles: bundles}) do
+    %{bundles: render_many(bundles, __MODULE__, "bundle.json", as: :bundle)}
+  end
+  def render("show.json", %{bundle: bundle}) do
+    %{bundle: render_one(bundle, __MODULE__, "bundle.json", as: :bundle)}
+  end
+
+  def render_relay_groups(groups) do
+    for group <- groups do
+      %{id: group.id,
+        name: group.name}
+    end
+  end
+
+  def render_commands(commands) do
+    for command <- commands do
+      %{id: command.id,
+        name: command.name,
+        documentation: command.documentation,
+        enforcing: command.enforcing,
+        execution: command.execution}
+    end
+  end
+end

--- a/web/views/relay_group_view.ex
+++ b/web/views/relay_group_view.ex
@@ -1,12 +1,11 @@
 defmodule Cog.V1.RelayGroupView do
   use Cog.Web, :view
 
-  alias Ecto.Association
-
   def render("relay_group.json", %{relay_group: relay_group}) do
     %{id: relay_group.id,
       name: relay_group.name,
-      relays: render_members(relay_group.relays()),
+      relays: render_relays(relay_group.relays()),
+      bundles: render_bundles(relay_group.bundles()),
       inserted_at: relay_group.inserted_at,
       updated_at: relay_group.updated_at}
   end
@@ -17,16 +16,20 @@ defmodule Cog.V1.RelayGroupView do
     %{relay_group: render_one(relay_group, __MODULE__, "relay_group.json")}
   end
   def render("relays.json", %{relay_group: relay_group}) do
-    %{relays: render_members(relay_group.relays())}
+    %{relays: render_relays(relay_group.relays())}
   end
 
-  defp render_members(%Association.NotLoaded{}) do
-    []
-  end
-  defp render_members(relays) do
+  defp render_relays(relays) do
     for relay <- relays do
       %{id: relay.id,
         name: relay.name}
+    end
+  end
+
+  defp render_bundles(bundles) do
+    for bundle <- bundles do
+      %{id: bundle.id,
+        name: bundle.name}
     end
   end
 

--- a/web/views/relay_view.ex
+++ b/web/views/relay_view.ex
@@ -1,8 +1,6 @@
 defmodule Cog.V1.RelayView do
   use Cog.Web, :view
 
-  alias Ecto.Association
-
   def render("relay.json", %{relay: relay}) do
     %{id: relay.id,
       name: relay.name,
@@ -19,9 +17,6 @@ defmodule Cog.V1.RelayView do
     %{relay: render_one(relay, __MODULE__, "relay.json")}
   end
 
-  defp render_groups(%Association.NotLoaded{}) do
-    []
-  end
   defp render_groups(groups) do
     for group <- groups do
       %{id: group.id,


### PR DESCRIPTION
This PR allows bundles to be associated with a group of relays through a RelayGroupAssignment association. From a high level, this involves:

* Add RelayGroupAssignments association between Bundles and RelayGroups
* Update RelayGroupMembershipController to support memberships and assignments and update routes accordingly
* Add Bundles to RelayGroupController#show and RelayGroupController#index
* Update BundlesController to use Phoenix views for rendering JSON and include RelayGroups