### PR TITLE
Simplify permission related APIs

### DIFF
--- a/test/controllers/v1/permission_controller_test.exs
+++ b/test/controllers/v1/permission_controller_test.exs
@@ -19,7 +19,11 @@ defmodule Cog.V1.PermissionControllerTest do
     # indeed required for requests
     unauthed_user = user("sadpanda") |> with_token
 
-    {:ok, [user: authed_user, unauthed: unauthed_user]}
+    # Role to use for permission grant/revoke tests
+    role = role("test-role")
+    |> with_permission(required_permission)
+
+    {:ok, [user: authed_user, unauthed: unauthed_user, role: role]}
   end
 
   test "lists all entries on index", %{user: user} do
@@ -38,10 +42,10 @@ defmodule Cog.V1.PermissionControllerTest do
                      "st-thorn"]
   end
 
-  test "lists permissions granted to user", %{user: user} do
-    :ok = Permittable.grant_to(user, permission("operable:manage_commands"))
+  test "lists permissions granted to role", %{user: user, role: role} do
+    :ok = Permittable.grant_to(role, permission("operable:manage_commands"))
 
-    conn = api_request(user, :get, "/v1/users/#{user.id}/permissions")
+    conn = api_request(user, :get, "/v1/roles/#{role.id}/permissions")
     permissions_list = json_response(conn, 200)["permissions"]
 
     names = permissions_list

--- a/test/controllers/v1/permission_grant_controller_test.exs
+++ b/test/controllers/v1/permission_grant_controller_test.exs
@@ -2,6 +2,12 @@ defmodule Cog.V1.PermissionGrantController.Test do
   use Cog.ModelCase
   use Cog.ConnCase
 
+  # When these tests were written, permissions were allowed to be
+  # associated with users, groups, or roles. This model has been
+  # simplified to only allow permissions to be associated with roles,
+  # but the parameterized test scaffolding has been retained for
+  # the time being. More information about this structure is below.
+  #
   # All the permission granting/revoking API endpoints share similar
   # structure, and are all implemented by the same code. As such, the
   # tests for granting permissions to users and granting them to roles
@@ -67,7 +73,7 @@ defmodule Cog.V1.PermissionGrantController.Test do
   # For each kind of entity we want to test, we'll generate a whole
   # series of tests focused around testing the manipulation of
   # permissions on that kind of entity.
-  [:user, :role, :group] |> Enum.each(
+  [:role] |> Enum.each(
     fn(base) ->
 
       # Grant

--- a/test/controllers/v1/permission_grant_controller_test.exs
+++ b/test/controllers/v1/permission_grant_controller_test.exs
@@ -2,6 +2,9 @@ defmodule Cog.V1.PermissionGrantController.Test do
   use Cog.ModelCase
   use Cog.ConnCase
 
+  # TODO: Clean this up when the underlying data model is simplified
+  #       to match what's exposed in the API.
+
   # When these tests were written, permissions were allowed to be
   # associated with users, groups, or roles. This model has been
   # simplified to only allow permissions to be associated with roles,

--- a/test/controllers/v1/role_grant_controller_test.exs
+++ b/test/controllers/v1/role_grant_controller_test.exs
@@ -2,6 +2,10 @@ defmodule Cog.V1.RoleGrantController.Test do
   use Cog.ModelCase
   use Cog.ConnCase
 
+
+  # TODO: Clean this up when the underlying data model is simplified
+  #       to match what's exposed in the API.
+ 
   # When these tests were written, permissions were allowed to be
   # associated with users, groups, or roles. This model has been
   # simplified to only allow permissions to be associated with roles,

--- a/test/controllers/v1/role_grant_controller_test.exs
+++ b/test/controllers/v1/role_grant_controller_test.exs
@@ -2,6 +2,12 @@ defmodule Cog.V1.RoleGrantController.Test do
   use Cog.ModelCase
   use Cog.ConnCase
 
+  # When these tests were written, permissions were allowed to be
+  # associated with users, groups, or roles. This model has been
+  # simplified to only allow permissions to be associated with roles,
+  # but the parameterized test scaffolding has been retained for
+  # the time being. More information about this structure is below.
+  #
   # All the permission granting/revoking API endpoints share similar
   # structure, and are all implemented by the same code. As such, the
   # tests for granting permissions to users and granting them to roles
@@ -64,7 +70,7 @@ defmodule Cog.V1.RoleGrantController.Test do
   # For each kind of entity we want to test, we'll generate a whole
   # series of tests focused around testing the manipulation of
   # permissions on that kind of entity.
-  [:user, :group] |> Enum.each(
+  [:group] |> Enum.each(
     fn(base) ->
 
       # Grant

--- a/web/controllers/v1/group_membership_controller.ex
+++ b/web/controllers/v1/group_membership_controller.ex
@@ -33,15 +33,12 @@ defmodule Cog.V1.GroupMembershipController do
   # %{"members" => %{"users" => %{"add" => ["user_to_add_1", "user_to_add_2"],
   #                               "remove" => ["user_to_remove"]},
   #                  "roles" => %{"add" => ["role_to_add_1", "role_to_add_2"],
-  #                               "remove" => ["role_to_remove"]},
-  #                  "groups" => %{"add" => ["group_to_add_1", "group_to_add_2"],
-  #                                "remove" => ["group_to_remove"]}}}
+  #                               "remove" => ["role_to_remove"]}}
   #
-  # Provide the email addresses of Users, and the names of Groups that you
-  # want to be members (or not) of the target group (as specified by
-  # `id`). All changes are made transactionally, so if any given names
-  # don't refer to a database entity, no changes in membership are
-  # made.
+  # Provide the email addresses of Users, that you want to be members (or not)
+  # of the target group (as specified by `id`). All changes are made
+  # transactionally, so if any given names don't refer to a database entity,
+  # no changes in membership are made.
   #
   # NOTE: As currently coded, this API endpoint is a bit too "chatty"
   # from a database interaction perspective. The resolution of names to
@@ -61,16 +58,14 @@ defmodule Cog.V1.GroupMembershipController do
       group = Repo.get!(Group, id)
 
       users_to_add     = lookup_or_fail(member_spec, ["users", "add"])
-      groups_to_add    = lookup_or_fail(member_spec, ["groups", "add"])
       roles_to_add    = lookup_or_fail(member_spec, ["roles", "grant"])
       users_to_remove  = lookup_or_fail(member_spec, ["users", "remove"])
-      groups_to_remove = lookup_or_fail(member_spec, ["groups", "remove"])
       roles_to_remove = lookup_or_fail(member_spec, ["roles", "revoke"])
 
       group
-      |> add(users_to_add ++ groups_to_add)
+      |> add(users_to_add)
       |> grant(roles_to_add)
-      |> remove(users_to_remove ++ groups_to_remove)
+      |> remove(users_to_remove)
       |> revoke(roles_to_remove)
       |> Repo.preload([:direct_user_members, :direct_group_members, :roles])
     end)

--- a/web/controllers/v1/permission_grant_controller.ex
+++ b/web/controllers/v1/permission_grant_controller.ex
@@ -1,28 +1,17 @@
 defmodule Cog.V1.PermissionGrantController do
   use Cog.Web, :controller
 
-  alias Cog.Models.User
   alias Cog.Models.Permission
   alias Cog.Models.Role
-  alias Cog.Models.Group
 
   plug Cog.Plug.Authentication
 
-  plug Cog.Plug.Authorization, [permission: "#{Cog.embedded_bundle}:manage_users"] when action == :manage_user_permissions
   plug Cog.Plug.Authorization, [permission: "#{Cog.embedded_bundle}:manage_roles"] when action == :manage_role_permissions
-  plug Cog.Plug.Authorization, [permission: "#{Cog.embedded_bundle}:manage_groups"] when action == :manage_group_permissions
 
   plug :put_view, Cog.V1.PermissionView
 
   def manage_role_permissions(conn, params),
     do: manage_permissions(conn, Role, params)
-
-  def manage_user_permissions(conn, params),
-    do: manage_permissions(conn, User, params)
-
-  def manage_group_permissions(conn, params),
-    do: manage_permissions(conn, Group, params)
-
 
   # Grant or revoke an arbitrary number of permissions (specified as
   # namespaced names) from the identified entity (i.e., the thing of

--- a/web/controllers/v1/role_grant_controller.ex
+++ b/web/controllers/v1/role_grant_controller.ex
@@ -1,19 +1,14 @@
 defmodule Cog.V1.RoleGrantController do
   use Cog.Web, :controller
 
-  alias Cog.Models.User
   alias Cog.Models.Role
   alias Cog.Models.Group
 
   plug Cog.Plug.Authentication
 
-  plug Cog.Plug.Authorization, [permission: "#{Cog.embedded_bundle}:manage_users"] when action == :manage_user_roles
   plug Cog.Plug.Authorization, [permission: "#{Cog.embedded_bundle}:manage_groups"] when action == :manage_group_roles
 
   plug :put_view, Cog.V1.RoleView
-
-  def manage_user_roles(conn, params),
-    do: manage_roles(conn, User, params)
 
   def manage_group_roles(conn, params),
     do: manage_roles(conn, Group, params)

--- a/web/controllers/v1/role_grant_controller.ex
+++ b/web/controllers/v1/role_grant_controller.ex
@@ -6,7 +6,7 @@ defmodule Cog.V1.RoleGrantController do
 
   plug Cog.Plug.Authentication
 
-  plug Cog.Plug.Authorization, [permission: "#{Cog.embedded_bundle}:manage_groups"] when action == :manage_group_roles
+  plug Cog.Plug.Authorization, [permission: "#{Cog.embedded_bundle}:manage_groups"]
 
   plug :put_view, Cog.V1.RoleView
 

--- a/web/router.ex
+++ b/web/router.ex
@@ -19,32 +19,25 @@ defmodule Cog.Router do
 
     resources "/v1/users", V1.UserController
 
-    resources "/v1/roles", V1.RoleController
-
     resources "/v1/groups", V1.GroupController
-    get "/v1/groups/:id/memberships", V1.GroupMembershipController, :index
-    post "/v1/groups/:id/membership", V1.GroupMembershipController, :manage_membership
+    get "/v1/groups/:id/users", V1.GroupMembershipController, :index
+    post "/v1/groups/:id/users", V1.GroupMembershipController, :manage_group_users
+
+    resources "/v1/roles", V1.RoleController
+    post "/v1/groups/:id/roles", V1.RoleGrantController, :manage_group_roles
 
     resources "/v1/permissions", V1.PermissionController, except: [:update]
-    get "/v1/users/:user_id/permissions", V1.PermissionController, :index
-    get "/v1/groups/:group_id/permissions", V1.PermissionController, :index
     get "/v1/roles/:role_id/permissions", V1.PermissionController, :index
-
-    post "/v1/token", V1.TokenController, :create
-
-    post "/v1/users/:id/permissions", V1.PermissionGrantController, :manage_user_permissions
-    post "/v1/groups/:id/permissions", V1.PermissionGrantController, :manage_group_permissions
     post "/v1/roles/:id/permissions", V1.PermissionGrantController, :manage_role_permissions
 
-    post "/v1/users/:id/roles", V1.RoleGrantController, :manage_user_roles
-    post "/v1/groups/:id/roles", V1.RoleGrantController, :manage_group_roles
+    post "/v1/token", V1.TokenController, :create
 
     get "/v1/rules", V1.RuleController, :show
     resources "/v1/rules", V1.RuleController, only: [:create, :delete]
 
     resources "/v1/bootstrap", V1.BootstrapController, only: [:index, :create]
-    resources "/v1/bundles", V1.BundlesController, only: [:index, :show, :delete]
 
+    resources "/v1/bundles", V1.BundlesController, only: [:index, :show, :delete]
     get "/v1/bundles/:id/status", V1.BundleStatusController, :show
     post "/v1/bundles/:id/status", V1.BundleStatusController, :manage_status
 


### PR DESCRIPTION
This PR significantly simplifies the behavior of permission related APIs in Cog. In the simplified model, users acquire a permission by belonging to a group that has been granted a role that has been granted some permissions.

This will cause some breakage in `cogctl` and `cog-api-client` when it is merged until they are updated to address the changes. The required updates are very minor since these changes largely remove endpoints, with just one exception for managing users within groups.

### Model Changes:

- Permissions cannot be granted directly to users or groups. They are only granted to roles.
- Roles cannot be directly granted to users. They are only granted to groups.
- Groups cannot contain other groups. Only users can be members of a group.

### API Changes: 

- **Groups API**:
  - (REMOVED) `/v1/groups/:group_id/membership`
  - (NEW) `/v1/groups/:group_id/users`
    - Behaves similarly to previous `/v1/groups/:id/membership` endpoint with the top-level members map replaced with the previously nested users map. **NOTE: The users map refers to users by email address rather than username**
    - JSON payload examples:
      - `{ "users": { "add": [ "mark@example.com", "kevin@example.com" ] }`
      - `{ "users": { "remove": [ "removed@example.com" ] }`
      - `{ "users": { "add": [ "mark@example.com", "kevin@example.com" ], "remove": [ "removed@example.com" ] }`
- **Permission API**:
  - Permissions may only be granted to roles; the ability to grant permissions directly to users and groups has been removed.
  - (REMOVED) `/v1/users/:user_id/permissions`
  - (REMOVED) `/v1/groups/:group_id/permissions`
- **Role API**:
  - (REMOVED) `/v1/users/:id/roles`