### PR TITLE
fetch_user_permissions honors group-granted roles

### DIFF
--- a/priv/repo/migrations/20160404135526_fetch_user_permissions_honors_roles.exs
+++ b/priv/repo/migrations/20160404135526_fetch_user_permissions_honors_roles.exs
@@ -1,0 +1,73 @@
+defmodule Cog.Repo.Migrations.FetchUserPermissionsHonorsRoles do
+  use Ecto.Migration
+
+  def up do
+    execute """
+CREATE OR REPLACE FUNCTION fetch_user_permissions (
+  p_user users.id%TYPE)
+RETURNS TABLE(id uuid, name text)
+LANGUAGE plpgsql STABLE STRICT
+AS $$
+BEGIN
+
+RETURN QUERY WITH
+
+  -- Walk the tree of group memberships and find
+  -- all the groups the user is a direct and
+  -- indirect member of.
+  all_groups as (
+  SELECT group_id
+    FROM groups_for_user(p_user)
+  ),
+  all_permissions as (
+
+  -- Retrieve all permissions granted to the list
+  -- groups returned from all_groups
+  SELECT gp.permission_id
+    FROM group_permissions as gp
+    JOIN all_groups as ag
+      ON gp.group_id = ag.group_id
+  UNION DISTINCT
+
+  -- Retrieve all permissions granted to the user
+  -- via roles
+  SELECT rp.permission_id
+    FROM role_permissions as rp
+    JOIN user_roles as ur
+      ON rp.role_id = ur.role_id
+    WHERE ur.user_id = p_user
+  UNION DISTINCT
+
+  -- Retrieve all permissions granted to the groups
+  -- via roles
+  SELECT rp.permission_id
+    FROM role_permissions as rp
+    JOIN group_roles as gr
+      ON rp.role_id = gr.role_id
+    JOIN all_groups AS ag
+      ON gr.group_id = ag.group_id
+  UNION DISTINCT
+
+  -- Retrieve all permissions granted directly to the user
+  SELECT up.permission_id
+    FROM user_permissions as up
+   WHERE up.user_id = p_user
+  )
+
+-- Join the permission ids returned by the CTE against
+-- the permissions and namespaces tables to produce
+-- the final result
+SELECT p.id, ns.name||':'||p.name as name
+  FROM permissions as p, namespaces as ns, all_permissions as ap
+ WHERE ap.permission_id = p.id and p.namespace_id = ns.id;
+END;
+$$;
+   """
+  end
+
+  def down do
+    Code.eval_file("20151118002150_fetch_user_permissions.exs", __DIR__)
+    Cog.Repo.Migrations.FetchUserPermissions.up()
+  end
+
+end

--- a/test/cog/models/user_repo_test.exs
+++ b/test/cog/models/user_repo_test.exs
@@ -1,0 +1,20 @@
+defmodule Cog.Models.UserRepoTest do
+  use ExUnit.Case
+
+  use Cog.ModelCase, async: false
+  alias Cog.Models.User
+
+  test "permission views are mutually consistent" do
+    user = user("cog")
+    group = group("test-group")
+    role = role("test-role")
+    permission = permission("site:test-permission")
+
+    Permittable.grant_to(role, permission)
+    Permittable.grant_to(group, role)
+    Groupable.add_to(user, group)
+
+    assert User.has_permission(user, permission)
+    assert "site:test-permission" in User.all_permissions(user)
+  end
+end


### PR DESCRIPTION
Previously, the `fetch_user_permissions` stored procedure returned
inconsistent results because it did not retrieve permissions a user had
by being in a group that had a role that had the permission.

Fixes #496