### PR TITLE
Allow a user to update their own user data with or without the manage_users permission

### DIFF
--- a/test/controllers/v1/user_controller_test.exs
+++ b/test/controllers/v1/user_controller_test.exs
@@ -179,4 +179,17 @@ defmodule Cog.V1.UserControllerTest do
                          "last_name" => @valid_attrs.last_name}
   end
 
+  test "user can get their own information without manage_users permission" do
+    tester = user("tester")
+    |> with_token
+    conn = api_request(tester, :get, "/v1/users/#{tester.id}")
+    new_user = json_response(conn, 200)["user"]
+    assert new_user == %{"id" => tester.id,
+                         "username" => tester.username,
+                         "first_name" => tester.first_name,
+                         "email_address" => tester.email_address,
+                         "groups" => [],
+                         "last_name" => tester.last_name}
+  end
+
 end

--- a/test/controllers/v1/user_controller_test.exs
+++ b/test/controllers/v1/user_controller_test.exs
@@ -165,4 +165,18 @@ defmodule Cog.V1.UserControllerTest do
     assert Map.fetch!(groups, "id") == group.id
   end
 
+  test "user updates their own information without manage_users permission" do
+    tester = user("tester")
+    |> with_token
+    conn = api_request(tester, :put, "/v1/users/#{tester.id}",
+                       body: %{"user" => @valid_attrs})
+    new_user = json_response(conn, 200)["user"]
+    assert new_user == %{"id" => tester.id,
+                         "username" => @valid_attrs.username,
+                         "first_name" => @valid_attrs.first_name,
+                         "email_address" => @valid_attrs.email_address,
+                         "groups" => [],
+                         "last_name" => @valid_attrs.last_name}
+  end
+
 end

--- a/web/controllers/v1/user_controller.ex
+++ b/web/controllers/v1/user_controller.ex
@@ -62,18 +62,13 @@ defmodule Cog.V1.UserController do
   ###############################################
   # Plug function - local only to user controller
   ###############################################
-  @spec check_self_updating(Plug.Conn.t, Plug.Conn.t) :: Plug.Conn.t
+  @spec check_self_updating(Plug.Conn.t, []) :: Plug.Conn.t
   def check_self_updating(conn, opts \\ []) do
     if determine_self_updating(conn) do
       conn
     else
       plug_opts = Cog.Plug.Authorization.init(opts)
-      case Cog.Plug.Authorization.call(conn, plug_opts) do
-        {:error, error} ->
-          error
-        updated_conn ->
-          updated_conn
-      end
+      Cog.Plug.Authorization.call(conn, plug_opts)
     end
   end
 


### PR DESCRIPTION
Add a new plug in the UserController that determines if this is a self updating task or if the manage_user permission is needed. Perform authorization only is not self_updating.

Fixes https://github.com/operable/cog/issues/489