### PR TITLE
Error templates

### DIFF
--- a/lib/cog/audit_message.ex
+++ b/lib/cog/audit_message.ex
@@ -1,0 +1,33 @@
+defmodule Cog.AuditMessage do
+  alias Cog.Models.Bundle
+  alias Cog.Models.Command
+
+  # Turn an error tuple into a message intended for the audit log
+  def render({:parse_error, msg}, request) when is_binary(msg),
+    do: "Error parsing command pipeline '#{request["text"]}': #{msg}"
+  def render({:redirect_error, invalid}, _request),
+    do: "Invalid redirects were specified: #{inspect invalid}"
+  def render({:binding_error, {:missing_key, var}}, request),
+    do: "Error preparing to execute command pipeline '#{request["text"]}': Unknown variable '#{var}'"
+  def render({:binding_error, msg}, request) when is_binary(msg) do
+    # TODO: Pretty sure this is not what we want, ultimately... this
+    # is coming from plan_next_invocation, not some top-level place
+    "Error preparing to execute command pipeline '#{request["text"]}': #{msg}"
+  end
+  def render({:denied, {_rule, current_invocation}}, request),
+    do: "User #{request["sender"]["handle"]} denied access to '#{current_invocation}'"
+  def render({:no_relays, bundle}, _request),
+    do: ErrorResponse.render({:no_relays, bundle}) # Uses same user message for now
+  def render({:disabled_bundle, %Bundle{name: name}}, _request),
+    do: "The #{name} bundle is currently disabled"
+  def render({:command_error, response}, _request),
+    do: response.status_message || response.body["message"]
+  def render({:template_rendering_error, {error, template, adapter}}, _request),
+    do: "Error rendering template '#{template}' for '#{adapter}': #{inspect error}"
+  def render({:timeout, %Command{}=command}, _request) do
+    name = Command.full_name(command)
+    "Timed out waiting on #{name} to reply"
+  end
+  def render({:no_rule, current_invocation}, _request),
+    do: "No rule matching '#{current_invocation}'"
+end

--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -467,12 +467,14 @@ defmodule Cog.Command.Pipeline.Executor do
   defp unregistered_user_message(request) do
     adapter = String.to_existing_atom(request["module"])
     handle = request["sender"]["handle"]
+    creators = user_creator_handles(request)
 
     context = %{
       handle: handle,
       mention_name: adapter.mention_name(handle),
       display_name: adapter.display_name(),
-      user_creators: user_creator_handles(request)
+      user_creators: creators,
+      user_creators?: Enum.any?(creators)
     }
 
     Template.render("any", "unregistered_user", context)

--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -455,7 +455,9 @@ defmodule Cog.Command.Pipeline.Executor do
   # Unregistered User Functions
 
   defp alert_unregistered_user(state) do
-    publish_response(unregistered_user_message(state.request),
+    {:ok, message} = unregistered_user_message(state.request)
+
+    publish_response(message,
                      state.request["room"],
                      state.request["adapter"],
                      state)
@@ -473,8 +475,7 @@ defmodule Cog.Command.Pipeline.Executor do
       user_creators: user_creator_handles(request)
     }
 
-    {:ok, output} = Template.render("any", nil, "unregistered_user", context)
-    output
+    Template.render("any", nil, "unregistered_user", context)
   end
 
   # Returns a list of adapter-appropriate "mention names" of all Cog
@@ -581,8 +582,7 @@ defmodule Cog.Command.Pipeline.Executor do
       execution_failure: execution_failure
     }
 
-    {:ok, output} = Template.render("any", nil, "error", context)
-    output
+    Template.render("any", nil, "error", context)
   end
 
   # Turn an error tuple into a textual message intended for chat users
@@ -643,7 +643,7 @@ defmodule Cog.Command.Pipeline.Executor do
   # Catch-all function that sends an error message back to the user,
   # emits a pipeline failure audit event, and terminates the pipeline.
   defp fail_pipeline_with_error({reason, _detail}=error, state) do
-    user_message = user_error(error, state)
+    {:ok, user_message} = user_error(error, state)
     publish_response(user_message,
                      state.request["room"],
                      state.request["adapter"],

--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -397,7 +397,7 @@ defmodule Cog.Command.Pipeline.Executor do
         {:ok, output}
       {:error, :template_not_found} ->
         Logger.warn("The template `#{template}` was not found for adapter `#{adapter}` in bundle `#{bundle.name}`; falling back to the json template")
-        Template.render(adapter, nil, "json", context)
+        Template.render(adapter, "json", context)
       {:error, error} ->
         {:error, error}
     end
@@ -475,7 +475,7 @@ defmodule Cog.Command.Pipeline.Executor do
       user_creators: user_creator_handles(request)
     }
 
-    Template.render("any", nil, "unregistered_user", context)
+    Template.render("any", "unregistered_user", context)
   end
 
   # Returns a list of adapter-appropriate "mention names" of all Cog
@@ -582,7 +582,7 @@ defmodule Cog.Command.Pipeline.Executor do
       execution_failure: execution_failure
     }
 
-    Template.render("any", nil, "error", context)
+    Template.render("any", "error", context)
   end
 
   # Turn an error tuple into a textual message intended for chat users

--- a/lib/cog/error_response.ex
+++ b/lib/cog/error_response.ex
@@ -1,0 +1,78 @@
+defmodule Cog.ErrorResponse do
+  alias Piper.Permissions.Ast
+  alias Cog.Models.Bundle
+  alias Cog.Models.Command
+
+  def render({:parse_error, msg}) when is_binary(msg),
+    do: "Whoops! An error occurred. " <> msg
+  def render({:redirect_error, invalid}),
+    do: "Whoops! An error occurred. " <> redirection_error_message(invalid)
+  def render({:binding_error, {:missing_key, var}}),
+    do: "I can't find the variable '$#{var}'."
+  def render({:binding_error, msg}) when is_binary(msg),
+    do: "Whoops! An error occurred. " <> msg
+  def render({:no_rule, current_invocation}),
+    do: "No rules match the supplied invocation of '#{current_invocation}'. Check your args and options, then confirm that the proper rules are in place."
+  def render({:denied, {%Ast.Rule{}=rule, current_invocation}}),
+    do: "Sorry, you aren't allowed to execute '#{current_invocation}' :(\n You will need the '#{rule.permission_selector.perms.value}' permission to run this command."
+  def render({:no_relays, %Bundle{name: name}}),
+    do: "Whoops! An error occurred. No Cog Relays supporting the `#{name}` bundle are currently online"
+  def render({:disabled_bundle, %Bundle{name: name}}),
+    do: "Whoops! An error occurred. The #{name} bundle is currently disabled"
+  def render({:timeout, %Command{}=command}) do
+    name = Command.full_name(command)
+    "The #{name} command timed out"
+  end
+  def render({:template_rendering_error, {error, template, adapter}}),
+    do: "Whoops! An error occurred. There was an error rendering the template '#{template}' for the adapter '#{adapter}': #{inspect error}"
+  def render({:command_error, response}) do
+    error = response.status_message || response.body["message"]
+    "Whoops! An error occurred. " <> error
+  end
+
+  # `errors` is a keyword list of [reason: name] for all bad redirect
+  # destinations that were found. `name` is the value as originally
+  # typed by the user.
+  defp redirection_error_message(errors) do
+    main_message = """
+
+    No commands were executed because the following redirects are invalid:
+
+    #{errors |> Keyword.values |> Enum.join(", ")}
+    """
+
+    not_a_member = Keyword.get_values(errors, :not_a_member)
+    not_a_member_message = unless Enum.empty?(not_a_member) do
+    """
+
+    Additionally, the bot must be invited to these rooms before it can
+    redirect to them:
+
+    #{Enum.join(not_a_member, ", ")}
+    """
+    end
+
+    # TODO: This is where I'd like to have error templates, so we can
+    # be specific about recommending the conventions the user use to
+    # refer to users and rooms
+    ambiguous = Keyword.get_values(errors, :ambiguous)
+    ambiguous_message = unless Enum.empty?(ambiguous) do
+    """
+
+    The following redirects are ambiguous; please refer to users and
+    rooms according to the conventions of your chat provider
+    (e.g. `@user`, `#room`):
+
+    #{Enum.join(ambiguous, ", ")}
+    """
+    end
+
+    # assemble final message
+    message_fragments = [main_message,
+                         not_a_member_message,
+                         ambiguous_message]
+    message_fragments
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("\n")
+  end
+end

--- a/lib/cog/template.ex
+++ b/lib/cog/template.ex
@@ -35,13 +35,9 @@ defmodule Cog.Template do
 
   defp fetch_source("any", nil, "unregistered_user", _context) do
     source = """
-    {{mention_name}}: I'm sorry, but either I don't have a Cog account for you, or
-    your {{display_name}} chat handle has not been registered. Currently, only
-    registered users can interact with me.
+    {{mention_name}}: I'm sorry, but either I don't have a Cog account for you, or your {{display_name}} chat handle has not been registered. Currently, only registered users can interact with me.
 
-    You'll need to ask a Cog administrator to fix this situation and to register
-    your {{display_name}} handle. The following users can help you right here in
-    chat:{{#user_creators}} {{.}}{{/user_creators}}
+    You'll need to ask a Cog administrator to fix this situation and to register your {{display_name}} handle. {{#user_creators?}}The following users can help you right here in chat:{{#user_creators}} {{.}}{{/user_creators}}{{/user_creators?}}
     """
 
     {:ok, source}
@@ -56,15 +52,15 @@ defmodule Cog.Template do
         `{{{pipeline_text}}}`
 
     {{#planning_failure}}
-      The pipeline failed planning the invocation:
+    The pipeline failed planning the invocation:
 
-          `{{{planning_failure}}}`
+        `{{{planning_failure}}}`
 
     {{/planning_failure}}
     {{#execution_failure}}
-      The pipeline failed executing the command:
+    The pipeline failed executing the command:
 
-          `{{{execution_failure}}}`
+        `{{{execution_failure}}}`
 
     {{/execution_failure}}
     The specific error was:

--- a/lib/cog/template.ex
+++ b/lib/cog/template.ex
@@ -31,6 +31,20 @@ defmodule Cog.Template do
     fetch_source(adapter, bundle_id, default_template(context), context)
   end
 
+  defp fetch_source("any", nil, "unregistered_user", _context) do
+    source = """
+    {{mention_name}}: I'm sorry, but either I don't have a Cog account for you, or
+    your {{display_name}} chat handle has not been registered. Currently, only
+    registered users can interact with me.
+
+    You'll need to ask a Cog administrator to fix this situation and to register
+    your {{display_name}} handle. The following users can help you right here in
+    chat:{{#user_creators}} {{.}}{{/user_creators}}
+    """
+
+    {:ok, source}
+  end
+
   # We check for fallback templates in the following order:
   #
   # 1. Fetch the exact template

--- a/lib/cog/template.ex
+++ b/lib/cog/template.ex
@@ -45,6 +45,35 @@ defmodule Cog.Template do
     {:ok, source}
   end
 
+  defp fetch_source("any", nil, "error", _context) do
+    source = """
+    An error has occured.
+
+    At `{{started}}`, {{initiator}} initiated the following pipeline, assigned the unique ID `{{id}}`:
+
+        `{{{pipeline_text}}}`
+
+    {{#planning_failure}}
+      The pipeline failed planning the invocation:
+
+          `{{{planning_failure}}}`
+
+    {{/planning_failure}}
+    {{#execution_failure}}
+      The pipeline failed executing the command:
+
+          `{{{execution_failure}}}`
+
+    {{/execution_failure}}
+    The specific error was:
+
+        {{{error_message}}}
+
+    """
+
+    {:ok, source}
+  end
+
   # We check for fallback templates in the following order:
   #
   # 1. Fetch the exact template

--- a/lib/cog/template.ex
+++ b/lib/cog/template.ex
@@ -33,45 +33,6 @@ defmodule Cog.Template do
     fetch_source(adapter, bundle_id, default_template(context), context)
   end
 
-  defp fetch_source("any", nil, "unregistered_user", _context) do
-    source = """
-    {{mention_name}}: I'm sorry, but either I don't have a Cog account for you, or your {{display_name}} chat handle has not been registered. Currently, only registered users can interact with me.
-
-    You'll need to ask a Cog administrator to fix this situation and to register your {{display_name}} handle. {{#user_creators?}}The following users can help you right here in chat:{{#user_creators}} {{.}}{{/user_creators}}{{/user_creators?}}
-    """
-
-    {:ok, source}
-  end
-
-  defp fetch_source("any", nil, "error", _context) do
-    source = """
-    An error has occured.
-
-    At `{{started}}`, {{initiator}} initiated the following pipeline, assigned the unique ID `{{id}}`:
-
-        `{{{pipeline_text}}}`
-
-    {{#planning_failure}}
-    The pipeline failed planning the invocation:
-
-        `{{{planning_failure}}}`
-
-    {{/planning_failure}}
-    {{#execution_failure}}
-    The pipeline failed executing the command:
-
-        `{{{execution_failure}}}`
-
-    {{/execution_failure}}
-    The specific error was:
-
-        {{{error_message}}}
-
-    """
-
-    {:ok, source}
-  end
-
   # We check for fallback templates in the following order:
   #
   # 1. Fetch the exact template

--- a/lib/cog/template.ex
+++ b/lib/cog/template.ex
@@ -5,6 +5,8 @@ defmodule Cog.Template do
 
   @fallback_adapter "any"
 
+  def render(adapter, template, context),
+    do: render(adapter, nil, template, context)
   def render(adapter, bundle_id, template, context) do
     with {:ok, template_fun} <- fetch_compiled_fun(adapter, bundle_id, template, context) do
       template_fun.(context)

--- a/priv/repo/migrations/20160406172300_insert_error_templates.exs
+++ b/priv/repo/migrations/20160406172300_insert_error_templates.exs
@@ -18,7 +18,7 @@ defmodule Cog.Repo.Migrations.InsertErrorTemplates do
       name: "error",
       adapter: "any",
       source: """
-      An error has occured.
+      An error has occurred.
 
       At `{{started}}`, {{initiator}} initiated the following pipeline, assigned the unique ID `{{id}}`:
 

--- a/priv/repo/migrations/20160406172300_insert_error_templates.exs
+++ b/priv/repo/migrations/20160406172300_insert_error_templates.exs
@@ -1,0 +1,46 @@
+defmodule Cog.Repo.Migrations.InsertErrorTemplates do
+  use Ecto.Migration
+  alias Cog.Models.Template
+  alias Cog.Repo
+
+  def change do
+    Repo.insert!(%Template{
+      name: "unregistered_user",
+      adapter: "any",
+      source: """
+      {{mention_name}}: I'm sorry, but either I don't have a Cog account for you, or your {{display_name}} chat handle has not been registered. Currently, only registered users can interact with me.
+
+      You'll need to ask a Cog administrator to fix this situation and to register your {{display_name}} handle. {{#user_creators?}}The following users can help you right here in chat:{{#user_creators}} {{.}}{{/user_creators}}{{/user_creators?}}
+      """
+    })
+
+    Repo.insert!(%Template{
+      name: "error",
+      adapter: "any",
+      source: """
+      An error has occured.
+
+      At `{{started}}`, {{initiator}} initiated the following pipeline, assigned the unique ID `{{id}}`:
+
+          `{{{pipeline_text}}}`
+
+      {{#planning_failure}}
+      The pipeline failed planning the invocation:
+
+          `{{{planning_failure}}}`
+
+      {{/planning_failure}}
+      {{#execution_failure}}
+      The pipeline failed executing the command:
+
+          `{{{execution_failure}}}`
+
+      {{/execution_failure}}
+      The specific error was:
+
+          {{{error_message}}}
+
+      """
+    })
+  end
+end


### PR DESCRIPTION
This provides only 2 basic error templates to start; an unregistered user template and a generic error template used from the `user_error` function. Also all custom messages for the generic errors and audit messages were pulled out into their own modules.

Closes https://github.com/operable/cog/issues/470