### PR TITLE
Rename Relay desc to description

### DIFF
--- a/lib/cog/models/relay.ex
+++ b/lib/cog/models/relay.ex
@@ -9,7 +9,7 @@ defmodule Cog.Models.Relay do
     field :token, :string, virtual: true
     field :token_digest, :string
     field :enabled, :boolean, default: false
-    field :desc, :string
+    field :description, :string
 
     has_many :group_memberships, RelayGroupMembership, foreign_key: :relay_id
     has_many :groups, through: [:group_memberships, :group]
@@ -18,7 +18,7 @@ defmodule Cog.Models.Relay do
   end
 
   @required_fields ~w(name)
-  @optional_fields ~w(token enabled desc)
+  @optional_fields ~w(token enabled description)
 
   def changeset(model, params \\ :empty) do
     model

--- a/priv/repo/migrations/20160328115654_create_relays.exs
+++ b/priv/repo/migrations/20160328115654_create_relays.exs
@@ -7,7 +7,7 @@ defmodule Cog.Repo.Migrations.AddRelays do
       add :name, :text, null: false
       add :token_digest, :text, null: false
       add :enabled, :boolean, null: false
-      add :desc, :text, null: true
+      add :description, :text, null: true
 
       timestamps
     end

--- a/test/controllers/v1/relay_controller_test.exs
+++ b/test/controllers/v1/relay_controller_test.exs
@@ -8,7 +8,7 @@ defmodule Cog.V1.RelayControllerTest do
   alias Cog.Queries
 
   @create_attrs %{name: "test-1", token: "foo"}
-  @update_attrs %{enabled: true}
+  @update_attrs %{enabled: true, description: "My test"}
 
   setup do
     # Requests handled by the role controller require this permission
@@ -49,6 +49,7 @@ defmodule Cog.V1.RelayControllerTest do
                           "name" => relay.name,
                           "enabled" => relay.enabled,
                           "groups" => [],
+                          "description" => nil,
                           "inserted_at" => "#{DateTime.to_iso8601(relay.inserted_at)}",
                           "updated_at" => "#{DateTime.to_iso8601(relay.updated_at)}"}} == json_response(conn, 200)
   end
@@ -82,6 +83,7 @@ defmodule Cog.V1.RelayControllerTest do
     assert updated["id"] == relay.id
     assert updated["name"] == relay.name
     assert updated["enabled"] == @update_attrs.enabled
+    assert updated["description"] == @update_attrs.description
   end
 
   test "updated token changes token digest", %{authed: requestor} do

--- a/web/views/relay_view.ex
+++ b/web/views/relay_view.ex
@@ -5,6 +5,7 @@ defmodule Cog.V1.RelayView do
     %{id: relay.id,
       name: relay.name,
       enabled: relay.enabled,
+      description: relay.description,
       groups: render_groups(relay.groups),
       inserted_at: relay.inserted_at,
       updated_at: relay.updated_at}


### PR DESCRIPTION
This is a quick PR to change the desc field to description, so that it is consistent throughout.

Fixes https://github.com/operable/cog/issues/487