### PR TITLE
Fix granting a group a role

### DIFF
--- a/test/controllers/v1/role_grant_controller_test.exs
+++ b/test/controllers/v1/role_grant_controller_test.exs
@@ -84,7 +84,10 @@ defmodule Cog.V1.RoleGrantController.Test do
       test "grant a single role to a #{base}", %{authed: requestor,
                                                  target: target,
                                                  path: path} do
+        role_permission = permission("site:deploy_test")
         role = role("admin")
+        Permittable.grant_to(role, role_permission)
+        assert_permission_is_granted(role, role_permission)
         refute_role_is_granted(target, role)
 
         conn = api_request(requestor, :post, path,
@@ -92,7 +95,9 @@ defmodule Cog.V1.RoleGrantController.Test do
 
         assert %{"roles" => [%{"id" => role.id,
                                "name" => role.name,
-                               "permissions" => []}]} == json_response(conn, 200)
+                               "permissions" => [%{"id" => role_permission.id,
+                                                 "name" => role_permission.name,
+                                                 "namespace" => "site"}]}]} == json_response(conn, 200)
 
         assert_role_is_granted(target, role)
       end

--- a/web/controllers/v1/role_grant_controller.ex
+++ b/web/controllers/v1/role_grant_controller.ex
@@ -28,7 +28,7 @@ defmodule Cog.V1.RoleGrantController do
       permittable
       |> grant(roles_to_grant)
       |> revoke(roles_to_revoke)
-      |> Repo.preload(roles: :permissions)
+      |> Repo.preload(roles: [permissions: :namespace])
     end)
 
     case result do


### PR DESCRIPTION
This allows a group to be assigned a role. The namespace information in a permission was not being preloaded.