### PR TITLE
Include rules in bundles#show and bundles#index

### DIFF
--- a/lib/cog/queries/bundles.ex
+++ b/lib/cog/queries/bundles.ex
@@ -6,7 +6,7 @@ defmodule Cog.Queries.Bundles do
 
   def all do
     from b in Bundle,
-    preload: [:commands, :relay_groups, :namespace]
+    preload: [:namespace, commands: [:rules], relay_groups: [:relays]]
   end
 
   def for_id(id) do

--- a/test/controllers/v1/bundles_controller_test.exs
+++ b/test/controllers/v1/bundles_controller_test.exs
@@ -33,6 +33,27 @@ defmodule Cog.V1.BundlesControllerTest do
                            "updated_at" => "#{DateTime.to_iso8601(bundle.updated_at)}"}} == json_response(conn, 200)
   end
 
+  test "includes rules in bundle resource", %{authed: requestor} do
+    bundle = bundle("cog")
+    command = command("hola")
+    permission("cog:hola")
+    rule_text = "when command is cog:hola must have cog:hola"
+    rule = rule(rule_text)
+
+    bundle_id = bundle.id
+    command_id = command.id
+    rule_id = rule.id
+
+    conn = api_request(requestor, :get, "/v1/bundles/#{bundle.id}")
+    assert %{"bundle" => %{"id" => ^bundle_id,
+                           "commands" => [
+                             %{"id" => ^command_id,
+                               "rules" => [
+                                 %{"id" => ^rule_id,
+                                   "command" => "cog:hola",
+                                   "rule" => ^rule_text}]}]}} = json_response(conn, 200)
+  end
+
   test "cannot view bundle without permission", %{unauthed: requestor} do
     bundle = bundle("test-1")
     conn = api_request(requestor, :get, "/v1/bundles/#{bundle.id}")

--- a/test/controllers/v1/relay_group_membership_controller_test.exs
+++ b/test/controllers/v1/relay_group_membership_controller_test.exs
@@ -26,9 +26,11 @@ defmodule Cog.V1.RelayGroupMembershipControllerTest do
     relay_group = relay_group("test-relay-group-1")
     add_relay_to_group(relay_group.id, relay.id)
     conn = api_request(requestor, :get, "/v1/relay_groups/#{relay_group.id}/relays")
-    relays = json_response(conn, 200)["relays"]
-    assert relays == [%{"id" => relay.id,
-                        "name" => relay.name}]
+    relay_id = relay.id
+    relay_name = relay.name
+
+    assert [%{"id" => ^relay_id,
+              "name" => ^relay_name}] = json_response(conn, 200)["relays"]
   end
 
   test "relay group includes member relays", %{authed: requestor} do

--- a/test/controllers/v1/rule_controller_test.exs
+++ b/test/controllers/v1/rule_controller_test.exs
@@ -35,7 +35,8 @@ defmodule Cog.V1.RuleController.Test do
     id = body["id"]
 
     assert %{"id" => id,
-            "rule" => rule_text} == body
+             "command" => "cog:s3",
+             "rule" => rule_text} == body
 
     # TODO: we don't provide a GET for rules just yet
     # expected_location = "/v1/rules/#{id}"

--- a/web/controllers/v1/relay_group_membership_controller.ex
+++ b/web/controllers/v1/relay_group_membership_controller.ex
@@ -10,7 +10,7 @@ defmodule Cog.V1.RelayGroupMembershipController do
 
   def index(conn, %{"id" => id}) do
     relay_group = Repo.one!(Queries.RelayGroup.for_id(id))
-    render(conn, Cog.V1.RelayGroupView, "relays.json", relay_group: relay_group)
+    render(conn, Cog.V1.RelayGroupView, "members.json", relay_group: relay_group)
   end
 
   def manage_membership(conn, %{"id" => id, "relays" => member_spec}),

--- a/web/views/bundles_view.ex
+++ b/web/views/bundles_view.ex
@@ -1,36 +1,45 @@
 defmodule Cog.V1.BundlesView do
   use Cog.Web, :view
 
-  def render("bundle.json", %{bundle: bundle}) do
+  alias Cog.V1.RelayGroupView
+  alias Cog.V1.RuleView
+
+  def render("bundle.json", %{bundle: bundle}=params) do
     %{id: bundle.id,
       name: bundle.name,
-      commands: render_commands(bundle.commands),
-      relay_groups: render_relay_groups(bundle.relay_groups),
       enabled: bundle.enabled,
       inserted_at: bundle.inserted_at,
       updated_at: bundle.updated_at}
+    |> Map.merge(render_includes(params, bundle))
   end
+
   def render("index.json", %{bundles: bundles}) do
-    %{bundles: render_many(bundles, __MODULE__, "bundle.json", as: :bundle)}
+    %{bundles: render_many(bundles, __MODULE__, "bundle.json", as: :bundle, include: [:commands, :relay_groups])}
   end
+
   def render("show.json", %{bundle: bundle}) do
-    %{bundle: render_one(bundle, __MODULE__, "bundle.json", as: :bundle)}
+    %{bundle: render_one(bundle, __MODULE__, "bundle.json", as: :bundle, include: [:commands, :relay_groups])}
   end
 
-  def render_relay_groups(groups) do
-    for group <- groups do
-      %{id: group.id,
-        name: group.name}
-    end
+  def render("command.json", %{command: command}) do
+    %{id: command.id,
+      name: command.name,
+      documentation: command.documentation,
+      enforcing: command.enforcing,
+      execution: command.execution,
+      rules: render_many(command.rules, RuleView, "rule.json")}
   end
 
-  def render_commands(commands) do
-    for command <- commands do
-      %{id: command.id,
-        name: command.name,
-        documentation: command.documentation,
-        enforcing: command.enforcing,
-        execution: command.execution}
-    end
+  defp render_includes(params, bundle) do
+    Map.get(params, :include, [])
+    |> Enum.reduce(%{}, fn(inc, reply) -> Map.put(reply, inc, render_include(inc, bundle)) end)
   end
+
+  defp render_include(:commands, bundle) do
+    render_many(bundle.commands, __MODULE__, "command.json", as: :command)
+  end
+  defp render_include(:relay_groups, bundle) do
+    render_many(bundle.relay_groups, RelayGroupView, "relay_group.json")
+  end
+
 end

--- a/web/views/relay_group_view.ex
+++ b/web/views/relay_group_view.ex
@@ -1,36 +1,37 @@
 defmodule Cog.V1.RelayGroupView do
   use Cog.Web, :view
 
-  def render("relay_group.json", %{relay_group: relay_group}) do
+  alias Cog.V1.BundlesView
+  alias Cog.V1.RelayView
+
+  def render("relay_group.json", %{relay_group: relay_group}=params) do
     %{id: relay_group.id,
       name: relay_group.name,
-      relays: render_relays(relay_group.relays()),
-      bundles: render_bundles(relay_group.bundles()),
       inserted_at: relay_group.inserted_at,
       updated_at: relay_group.updated_at}
+    |> Map.merge(render_includes(params, relay_group))
   end
+
   def render("index.json", %{relay_groups: relay_groups}) do
-    %{relay_groups: render_many(relay_groups, __MODULE__, "relay_group.json")}
+    %{relay_groups: render_many(relay_groups, __MODULE__, "relay_group.json", include: [:relays, :bundles])}
   end
   def render("show.json", %{relay_group: relay_group}) do
-    %{relay_group: render_one(relay_group, __MODULE__, "relay_group.json")}
+    %{relay_group: render_one(relay_group, __MODULE__, "relay_group.json", include: [:relays, :bundles])}
   end
-  def render("relays.json", %{relay_group: relay_group}) do
-    %{relays: render_relays(relay_group.relays())}
-  end
-
-  defp render_relays(relays) do
-    for relay <- relays do
-      %{id: relay.id,
-        name: relay.name}
-    end
+  def render("members.json", %{relay_group: relay_group}) do
+    %{relays: render_include(:relays, relay_group)}
   end
 
-  defp render_bundles(bundles) do
-    for bundle <- bundles do
-      %{id: bundle.id,
-        name: bundle.name}
-    end
+  defp render_includes(params, relay_group) do
+    Map.get(params, :include, [])
+    |> Enum.reduce(%{}, fn(inc, reply) -> Map.put(reply, inc, render_include(inc, relay_group)) end)
+  end
+
+  defp render_include(:bundles, relay_group) do
+    render_many(relay_group.bundles, BundlesView, "bundle.json", as: :bundle)
+  end
+  defp render_include(:relays, relay_group) do
+    render_many(relay_group.relays, RelayView, "relay.json", as: :relay)
   end
 
 end

--- a/web/views/relay_view.ex
+++ b/web/views/relay_view.ex
@@ -1,28 +1,32 @@
 defmodule Cog.V1.RelayView do
   use Cog.Web, :view
 
-  def render("relay.json", %{relay: relay}) do
+  alias Cog.V1.RelayGroupView
+
+  def render("relay.json", %{relay: relay}=params) do
     %{id: relay.id,
       name: relay.name,
       enabled: relay.enabled,
       description: relay.description,
-      groups: render_groups(relay.groups),
       inserted_at: relay.inserted_at,
       updated_at: relay.updated_at}
+    |> Map.merge(render_includes(params, relay))
   end
   def render("index.json", %{relays: relays}) do
-    %{relays: render_many(relays, __MODULE__, "relay.json")}
+    %{relays: render_many(relays, __MODULE__, "relay.json", include: [:groups])}
   end
 
   def render("show.json", %{relay: relay}) do
-    %{relay: render_one(relay, __MODULE__, "relay.json")}
+    %{relay: render_one(relay, __MODULE__, "relay.json", include: [:groups])}
   end
 
-  defp render_groups(groups) do
-    for group <- groups do
-      %{id: group.id,
-        name: group.name}
-    end
+  defp render_includes(params, relay) do
+    Map.get(params, :include, [])
+    |> Enum.reduce(%{}, fn(inc, reply) -> Map.put(reply, inc, render_include(inc, relay)) end)
+  end
+
+  defp render_include(:groups, relay) do
+    render_many(relay.groups, RelayGroupView, "relay_group.json", as: :relay_group)
   end
 
 end

--- a/web/views/rule_view.ex
+++ b/web/views/rule_view.ex
@@ -1,0 +1,27 @@
+defmodule Cog.V1.RuleView do
+  use Cog.Web, :view
+
+  def render("rule.json", %{rule: rule}) do
+    ast = to_ast(rule)
+    %{id: rule.id,
+      command: ast.command,
+      rule: to_string(ast)}
+  end
+
+  def render("rule_expression.json", %{rule: rule}) do
+    rule |> to_ast |> to_string
+  end
+
+  def render("index.json", %{rules: rules}) do
+    %{rules: render_many(rules, __MODULE__, "rule.json")}
+  end
+
+  def render("show.json", %{rule: rule}) do
+    %{rule: render_one(rule, __MODULE__, "rule.json")}
+  end
+
+  defp to_ast(rule) do
+    Piper.Permissions.Parser.json_to_rule!(rule.parse_tree)
+  end
+
+end

--- a/web/views/rule_view.ex
+++ b/web/views/rule_view.ex
@@ -8,10 +8,6 @@ defmodule Cog.V1.RuleView do
       rule: to_string(ast)}
   end
 
-  def render("rule_expression.json", %{rule: rule}) do
-    rule |> to_ast |> to_string
-  end
-
   def render("index.json", %{rules: rules}) do
     %{rules: render_many(rules, __MODULE__, "rule.json")}
   end


### PR DESCRIPTION
* Updated `GET /v1/bundles` and `GET /v1/bundles/:id` to include rules under the commands for each returned bundle and added a test.
* Refactored the related views in order to have a single canonical view for each resource. Rather than embedding functions like `render_rules` in `Cog.V1.BundleView`, we call `render(rule, RuleView, "rule.json")`. Note: I only applied this refactoring to views that were directly related to this change, rather than making it more globally.