### PR TITLE
Bundle versions are persisted when they are installed

### DIFF
--- a/lib/cog/models/bundle.ex
+++ b/lib/cog/models/bundle.ex
@@ -4,6 +4,7 @@ defmodule Cog.Models.Bundle do
 
   schema "bundles" do
     field :name, :string
+    field :version, :string
     field :config_file, :map
     field :enabled, :boolean, default: false
 
@@ -17,7 +18,7 @@ defmodule Cog.Models.Bundle do
     timestamps
   end
 
-  @required_fields ~w(name config_file)
+  @required_fields ~w(name version config_file)
   @optional_fields ~w(enabled)
 
   summary_fields [:id, :name, :namespace, :inserted_at, :enabled]

--- a/priv/repo/migrations/20160411203730_add_version_to_bundles.exs
+++ b/priv/repo/migrations/20160411203730_add_version_to_bundles.exs
@@ -1,0 +1,17 @@
+defmodule Cog.Repo.Migrations.AddVersionToBundles do
+  use Ecto.Migration
+  alias Cog.Repo
+  alias Cog.Models.Bundle
+
+  def change do
+    alter table(:bundles) do
+      add :version, :string
+    end
+
+    execute("UPDATE bundles SET version = '0.0.1'")
+
+    alter table(:bundles) do
+      modify :version, :string, null: false
+    end
+  end
+end

--- a/test/cog/command/command_resolver_test.exs
+++ b/test/cog/command/command_resolver_test.exs
@@ -114,6 +114,7 @@ defmodule Cog.Command.CommandResolver.Test do
           "module" => "Cog.Commands.Echo",
           "documentation" => "does stuff"}}}
     Cog.Bundle.Install.install_bundle(%{name: "test_bundle",
+                                        version: "0.0.1",
                                         config_file: config})
     user = user("testuser")
 

--- a/test/cog/models/bundle_test.exs
+++ b/test/cog/models/bundle_test.exs
@@ -2,7 +2,7 @@ defmodule Cog.Models.BundleTest do
   use Cog.ModelCase
   alias Cog.Models.Bundle
 
-  @valid_attrs %{name: "test_bundle", config_file: %{}, manifest_file: %{}}
+  @valid_attrs %{name: "test_bundle", version: "0.0.1", config_file: %{}, manifest_file: %{}}
 
   test "bundle names must be made up of word characters and dashes" do
     invalid_attrs = Map.merge(@valid_attrs, %{name: "weird:name"})

--- a/test/cog/models/bundle_test.exs
+++ b/test/cog/models/bundle_test.exs
@@ -2,7 +2,7 @@ defmodule Cog.Models.BundleTest do
   use Cog.ModelCase
   alias Cog.Models.Bundle
 
-  @valid_attrs %{name: "test_bundle", version: "0.0.1", config_file: %{}, manifest_file: %{}}
+  @valid_attrs %{name: "test_bundle", version: "0.0.1", config_file: %{}}
 
   test "bundle names must be made up of word characters and dashes" do
     invalid_attrs = Map.merge(@valid_attrs, %{name: "weird:name"})

--- a/test/cog/models/command_test.exs
+++ b/test/cog/models/command_test.exs
@@ -8,7 +8,7 @@ defmodule Cog.Models.CommandTest do
   alias Piper.Permissions.Parser
 
   setup do
-    {:ok, bundle} = Repo.insert(%Bundle{name: "test_bundle", config_file: %{}})
+    {:ok, bundle} = Repo.insert(%Bundle{name: "test_bundle", version: "0.0.1", config_file: %{}})
     {:ok, command} = Command.insert_new(%{name: "drop_database", bundle_id: bundle.id})
     {:ok, expr, _} = Parser.parse("when command is operable:drop_database must have drop_database:write")
     {:ok, rule} = Rule.insert_new(command, expr)

--- a/test/cog/queries/command_test.exs
+++ b/test/cog/queries/command_test.exs
@@ -7,7 +7,7 @@ defmodule Cog.Queries.Command.Test do
   alias Cog.Repo
 
   setup do
-    {:ok, bundle} = Repo.insert(%Bundle{name: "test_bundle", config_file: %{}})
+    {:ok, bundle} = Repo.insert(%Bundle{name: "test_bundle", version: "0.0.1", config_file: %{}})
     {:ok, qualified_command} = Command.insert_new(%{name: "drop_database", bundle_id: bundle.id})
     {:ok, shorthand_command} = Command.insert_new(%{name: "test_bundle", bundle_id: bundle.id})
     {:ok, [bundle: bundle.name,

--- a/test/cog/rule_test.exs
+++ b/test/cog/rule_test.exs
@@ -5,7 +5,7 @@ defmodule RuleTest do
   alias Cog.Models.Rule
 
   setup do
-    bundle = Bundle.changeset(%Bundle{}, %{name: "test_bundle", config_file: %{}, manifest_file: %{}}) |> Repo.insert!
+    bundle = Bundle.changeset(%Bundle{}, %{name: "test_bundle", version: "0.0.1", config_file: %{}, manifest_file: %{}}) |> Repo.insert!
     {:ok, command} = Command.insert_new(%{name: "pugbomb", bundle_id: bundle.id})
     {:ok, [command: command]}
   end
@@ -27,7 +27,7 @@ defmodule RuleTest do
     use Cog.ModelCase
 
     setup do
-      bundle = Bundle.changeset(%Bundle{}, %{name: "test_bundle", config_file: %{}, manifest_file: %{}}) |> Repo.insert!
+      bundle = Bundle.changeset(%Bundle{}, %{name: "test_bundle", version: "0.0.1", config_file: %{}, manifest_file: %{}}) |> Repo.insert!
       rule_text = "when command is s3:list must have s3:delete"
       {:ok, expr, _} = Piper.Permissions.Parser.parse(rule_text)
       {:ok, command} = Command.insert_new(%{name: "pugbomb", bundle_id: bundle.id})

--- a/test/cog/rule_test.exs
+++ b/test/cog/rule_test.exs
@@ -5,7 +5,7 @@ defmodule RuleTest do
   alias Cog.Models.Rule
 
   setup do
-    bundle = Bundle.changeset(%Bundle{}, %{name: "test_bundle", version: "0.0.1", config_file: %{}, manifest_file: %{}}) |> Repo.insert!
+    bundle = Bundle.changeset(%Bundle{}, %{name: "test_bundle", version: "0.0.1", config_file: %{}}) |> Repo.insert!
     {:ok, command} = Command.insert_new(%{name: "pugbomb", bundle_id: bundle.id})
     {:ok, [command: command]}
   end
@@ -27,7 +27,7 @@ defmodule RuleTest do
     use Cog.ModelCase
 
     setup do
-      bundle = Bundle.changeset(%Bundle{}, %{name: "test_bundle", version: "0.0.1", config_file: %{}, manifest_file: %{}}) |> Repo.insert!
+      bundle = Bundle.changeset(%Bundle{}, %{name: "test_bundle", version: "0.0.1", config_file: %{}}) |> Repo.insert!
       rule_text = "when command is s3:list must have s3:delete"
       {:ok, expr, _} = Piper.Permissions.Parser.parse(rule_text)
       {:ok, command} = Command.insert_new(%{name: "pugbomb", bundle_id: bundle.id})

--- a/test/controllers/v1/bundles_controller_test.exs
+++ b/test/controllers/v1/bundles_controller_test.exs
@@ -197,7 +197,7 @@ defmodule Cog.V1.BundlesControllerTest do
     cog_bundle_version: 2
 
     name: test_bundle
-    version: 0.1.0
+    version: "0.1.0"
     permissions:
     - test_bundle:date
     - test_bundle:time

--- a/test/support/database_test_setup.ex
+++ b/test/support/database_test_setup.ex
@@ -45,7 +45,6 @@ defmodule DatabaseTestSetup do
   """
   def bundle(name, commands \\ [%{"name": "echo"}], opts \\ []) do
     command_template = %{
-      "version" => "0.0.1",
       "options" => [],
       "name" => "echo",
       "executable" => "/bin/echo",
@@ -56,7 +55,8 @@ defmodule DatabaseTestSetup do
     }
 
     bundle_template = %{
-      "bundle" => %{"name" => "bundle_name"},
+      "bundle" => %{"name" => "bundle_name",
+                    "version" => "0.0.1"},
       "templates" => [],
       "rules" => [],
       "permissions" => [],
@@ -75,6 +75,7 @@ defmodule DatabaseTestSetup do
     bundle =
       %Bundle{}
       |> Bundle.changeset(%{name: name,
+                            version: "0.0.1",
                             config_file: bundle_config,
                             manifest_file: %{}})
       |> Repo.insert!

--- a/test/support/database_test_setup.ex
+++ b/test/support/database_test_setup.ex
@@ -72,13 +72,9 @@ defmodule DatabaseTestSetup do
     |> Map.put("commands", command_config)
     |> Map.merge(Enum.into(opts, %{}))
 
-    bundle =
-      %Bundle{}
-      |> Bundle.changeset(%{name: name,
-                            version: "0.0.1",
-                            config_file: bundle_config,
-                            manifest_file: %{}})
-      |> Repo.insert!
+    bundle = %Bundle{}
+    |> Bundle.changeset(%{name: name, version: "0.0.1", config_file: bundle_config})
+    |> Repo.insert!
 
     namespace(name, bundle.id)
 

--- a/web/controllers/v1/bundles_controller.ex
+++ b/web/controllers/v1/bundles_controller.ex
@@ -103,9 +103,9 @@ defmodule Cog.V1.BundlesController do
   end
 
   # Create a new record in the DB for the deploy
-  defp persist(%{"name" => name} = config) do
+  defp persist(%{"name" => name, "version" => version} = config) do
     try do
-      Install.install_bundle(%{name: name, config_file: config})
+      Install.install_bundle(%{name: name, version: version, config_file: config})
     rescue
       err in [Ecto.InvalidChangesetError] ->
         {:error, {:db_error, err.changeset.errors}}


### PR DESCRIPTION
:warning: Based on https://github.com/operable/cog/pull/503

We're not currently handling multiple versions of bundles at the same time, but we are now keeping track of the version installed. If you try to install another version of a previously installed bundle, you'll receive an error.

Closes https://github.com/operable/cog/issues/98