### PR TITLE
Embedded commands conform to new authz model

### DIFF
--- a/lib/cog/bundle/embedded.ex
+++ b/lib/cog/bundle/embedded.ex
@@ -17,7 +17,8 @@ defmodule Cog.Bundle.Embedded do
   # Permissions not required by any built-in commands yet, and thus
   # not present in automatically generated config for the embedded
   # bundle, unless we hack it in
-  @extra_permissions ["#{Cog.embedded_bundle}:manage_triggers"]
+  @extra_permissions ["#{Cog.embedded_bundle}:manage_relays",
+                      "#{Cog.embedded_bundle}:manage_triggers"]
 
   @doc """
   Start up a supervisor for the embedded `#{Cog.embedded_bundle}` bundle.

--- a/test/integration/group_test.exs
+++ b/test/integration/group_test.exs
@@ -35,22 +35,6 @@ defmodule Integration.GroupTest do
     assert_error_message_contains(response, "Whoops! An error occurred. ERROR! The group `test` already exists.")
   end
 
-  test "adding a group to a group", %{user: user} do
-    group = group("elves")
-
-    response = send_message(user, "@bot: operable:group --add --group=#{group.name} cheer")
-    assert_error_message_contains(response, "Whoops! An error occurred. ERROR! Could not find group `cheer`")
-
-    response = send_message(user, "@bot: operable:group --create cheer")
-    assert_payload(response, %{body: ["The group `cheer` has been created."]})
-
-    response = send_message(user, "@bot: operable:group --add --group=humbug cheer")
-    assert_error_message_contains(response, "Whoops! An error occurred. ERROR! Could not find group `humbug`")
-
-    response = send_message(user, "@bot: operable:group --add --group=#{group.name} cheer")
-    assert_payload(response, %{body: ["Added the group `elves` to the group `cheer`"]})
-  end
-
   test "errors using the group command", %{user: user} do
     response = send_message(user, "@bot: operable:group --create ")
     assert_error_message_contains(response, "Whoops! An error occurred. ERROR! Unable to create ``:\nMissing name")
@@ -72,27 +56,9 @@ defmodule Integration.GroupTest do
     assert_error_message_contains(response, "Whoops! An error occurred. ERROR! Could not find group `cheer`")
   end
 
-  test "removing a group", %{user: user} do
-    group("elves")
-
-    response = send_message(user, "@bot: operable:group --add --group=elves cheer")
-    assert_error_message_contains(response, "Whoops! An error occurred. ERROR! Could not find group `cheer`")
-
-    group("cheer")
-
-    response = send_message(user, "@bot: operable:group --add --group=elves cheer")
-    assert_payload(response, %{body: ["Added the group `elves` to the group `cheer`"]})
-
-    response = send_message(user, "@bot: operable:group --remove --group=elves cheer")
-    assert_payload(response, %{body: ["Removed the group `elves` from the group `cheer`"]})
-  end
-
   test "listing group", %{user: user} do
     group("elves")
     group("cheer")
-
-    response = send_message(user, "@bot: operable:group --add --group=elves cheer")
-    assert_payload(response, %{body: ["Added the group `elves` to the group `cheer`"]})
 
     response = send_message(user, "@bot: operable:group --add --user=belf cheer")
     assert_payload(response, %{body: ["Added the user `belf` to the group `cheer`"]})

--- a/test/integration/permission_test.exs
+++ b/test/integration/permission_test.exs
@@ -4,8 +4,6 @@ defmodule Integration.PermissionTest do
   setup do
     user = user("vanstee", first_name: "Patrick", last_name: "Van Stee")
     |> with_chat_handle_for("test")
-    |> with_permission("operable:manage_users")
-    |> with_permission("operable:manage_groups")
     |> with_permission("operable:manage_roles")
 
     group = group("ops")
@@ -17,28 +15,6 @@ defmodule Integration.PermissionTest do
     {:ok, %{user: user, group: group, role: role}}
   end
 
-  test "granting a permission to a user", %{user: user} do
-    response = send_message(user, "@bot: operable:st-echo test")
-    assert_error_message_contains(response, "Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command.")
-
-    response = send_message(user, "@bot: operable:permissions --grant --user=vanstee --permission=operable:st-echo")
-    assert_payload(response, %{body: ["Granted permission `operable:st-echo` to user `vanstee`"]})
-
-    response = send_message(user, "@bot: operable:st-echo test")
-    assert_payload(response, %{body: ["test"]})
-  end
-
-  test "granting a permission to a group", %{user: user} do
-    response = send_message(user, "@bot: operable:st-echo test")
-    assert_error_message_contains(response, "Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command.")
-
-    response = send_message(user, "@bot: operable:permissions --grant --group=ops --permission=operable:st-echo")
-    assert_payload(response, %{body: ["Granted permission `operable:st-echo` to group `ops`"]})
-
-    response = send_message(user, "@bot: operable:st-echo test")
-    assert_payload(response, %{body: ["test"]})
-  end
-
   test "granting a permission to a role", %{user: user} do
     response = send_message(user, "@bot: operable:st-echo test")
     assert_error_message_contains(response, "Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command.")
@@ -48,42 +24,6 @@ defmodule Integration.PermissionTest do
 
     response = send_message(user, "@bot: operable:st-echo test")
     assert_payload(response, %{body: ["test"]})
-  end
-
-  test "granting a permission to a user without the grant permission" do
-    mctesterson = user("mctesterson", first_name: "Testy", last_name: "McTesterson")
-    |> with_chat_handle_for("test")
-
-    response = send_message(mctesterson, "@bot: operable:permissions --grant --user=mctesterson --permission=operable:st-echo")
-    assert_error_message_contains(response, "Sorry, you aren't allowed to execute 'operable:permissions --grant --user=mctesterson --permission=operable:st-echo' :(\n You will need the 'operable:manage_users' permission to run this command.")
-  end
-
-  test "revoking a permission from a user", %{user: user} do
-    response = send_message(user, "@bot: operable:permissions --grant --user=vanstee --permission=operable:st-echo")
-    assert_payload(response, %{body: ["Granted permission `operable:st-echo` to user `vanstee`"]})
-
-    response = send_message(user, "@bot: operable:st-echo good_test")
-    assert_payload(response, %{body: ["good_test"]})
-
-    response = send_message(user, "@bot: operable:permissions --revoke --user=vanstee --permission=operable:st-echo")
-    assert_payload(response, %{body: ["Revoked permission `operable:st-echo` from user `vanstee`"]})
-
-    response = send_message(user, "@bot: operable:st-echo fail_test")
-    assert_error_message_contains(response, "Sorry, you aren't allowed to execute 'operable:st-echo fail_test' :(\n You will need the 'operable:st-echo' permission to run this command.")
-  end
-
-  test "revoking a permission from a group", %{user: user} do
-    response = send_message(user, "@bot: operable:permissions --grant --group=ops --permission=operable:st-echo")
-    assert_payload(response, %{body: ["Granted permission `operable:st-echo` to group `ops`"]})
-
-    response = send_message(user, "@bot: operable:st-echo test")
-    assert_payload(response, %{body: ["test"]})
-
-    response = send_message(user, "@bot: operable:permissions --revoke --group=ops --permission=operable:st-echo")
-    assert_payload(response, %{body: ["Revoked permission `operable:st-echo` from group `ops`"]})
-
-    response = send_message(user, "@bot: operable:st-echo test")
-    assert_error_message_contains(response, "Sorry, you aren't allowed to execute 'operable:st-echo test' :(\n You will need the 'operable:st-echo' permission to run this command.")
   end
 
   test "revoking a permission from a role", %{user: user} do

--- a/test/integration/role_test.exs
+++ b/test/integration/role_test.exs
@@ -4,28 +4,10 @@ defmodule Integration.RoleTest do
   setup do
     user = user("belf", first_name: "Buddy", last_name: "Elf")
     |> with_chat_handle_for("test")
-    |> with_permission("operable:manage_users")
     |> with_permission("operable:manage_groups")
     |> with_permission("operable:manage_roles")
 
     {:ok, %{user: user}}
-  end
-
-  test "granting a role to a user", %{user: user} do
-    response = send_message(user, "@bot: operable:role --grant --user=#{user.username} cheer")
-    assert_error_message_contains(response, "Whoops! An error occurred. ERROR! Could not find role `cheer`")
-
-    response = send_message(user, "@bot: operable:role --create cheer")
-    assert_payload(response, %{body: ["The role `cheer` has been created."]})
-
-    response = send_message(user, "@bot: operable:role --grant --user=papa_elf cheer")
-    assert_error_message_contains(response, "Whoops! An error occurred. ERROR! Could not find user `papa_elf`")
-
-    response = send_message(user, "@bot: operable:role --grant cheer")
-    assert_error_message_contains(response, "Whoops! An error occurred. ERROR! Must specify a target to act upon. See `operable:help operable:role` for more details.")
-
-    response = send_message(user, "@bot: operable:role --grant --user=belf cheer")
-    assert_payload(response, %{body: ["Granted role `cheer` to user `belf`"]})
   end
 
   test "creating a role", %{user: user} do
@@ -62,15 +44,16 @@ defmodule Integration.RoleTest do
 
   test "dropping a role", %{user: user} do
     role("cheer")
+    group("test-group")
 
-    response = send_message(user, "@bot: operable:role --grant --user=belf cheer")
-    assert_payload(response, %{body: ["Granted role `cheer` to user `belf`"]})
+    response = send_message(user, "@bot: operable:role --grant --group=test-group cheer")
+    assert_payload(response, %{body: ["Granted role `cheer` to group `test-group`"]})
 
     response = send_message(user, "@bot: operable:role --drop cheer")
-    assert_error_message_contains(response, "Whoops! An error occurred. ERROR! Unable to delete role `cheer`. There are assignments to this role: \n* user: belf\n")
+    assert_error_message_contains(response, "Whoops! An error occurred. ERROR! Unable to delete role `cheer`. There are assignments to this role: \n* group: test-group\n")
 
-    response = send_message(user, "@bot: operable:role --revoke --user=belf cheer")
-    assert_payload(response, %{body: ["Revoked role `cheer` from user `belf`"]})
+    response = send_message(user, "@bot: operable:role --revoke --group=test-group cheer")
+    assert_payload(response, %{body: ["Revoked role `cheer` from group `test-group`"]})
 
     response = send_message(user, "@bot: operable:role --drop cheer")
     assert_payload(response, %{body: ["The role `cheer` has been deleted."]})
@@ -91,19 +74,10 @@ defmodule Integration.RoleTest do
   end
 
   test "listing roles", %{user: user} do
-    group("elves")
     role("cheer")
-
-    response = send_message(user, "@bot: operable:role --grant --group=elves cheer")
-    assert_payload(response, %{body: ["Granted role `cheer` to group `elves`"]})
-
-    response = send_message(user, "@bot: operable:role --grant --user=belf cheer")
-    assert_payload(response, %{body: ["Granted role `cheer` to user `belf`"]})
+    role("happy")
 
     response = send_message(user, "@bot: operable:role --list")
-    assert_payload(response, %{body: ["The following are the available roles: \n* cheer\n"]})
-
-    response = send_message(user, "@bot: operable:role --drop cheer")
-    assert_error_message_contains(response, "Whoops! An error occurred. ERROR! Unable to delete role `cheer`. There are assignments to this role: \n* user: belf\n* group: elves\n")
+    assert_payload(response, %{body: ["The following are the available roles: \n* happy\n* cheer\n"]})
   end
 end


### PR DESCRIPTION
Recently we simplified the authorization model. Now, groups may only
contain users, roles can only be granted to groups, and permissions may
only be assigned to roles.

Now, the embedded bundle commands conform to this; you can no longer add
groups to groups, grant permissions to users or groups, or grant roles
to users.

Permissions used by the commands were cleaned up, and authorization
rules were tightened up.

Fixes #512