### PR TITLE
Log relay removal only if Cog knows the relay

### DIFF
--- a/lib/cog/relay/relays.ex
+++ b/lib/cog/relay/relays.ex
@@ -168,7 +168,6 @@ defmodule Cog.Relay.Relays do
     bundle_names = Enum.map(success_bundles, &Map.get(&1, :name)) # Just for logging purposes
     case {online_status, snapshot_status} do
       {:offline, _} ->
-        Logger.info("Removing Relay #{relay_id} from active relay list")
         Tracker.remove_relay(tracker, relay_id)
       {:online, :incremental} ->
         Logger.info("Incrementally adding bundles for Relay #{relay_id}: #{inspect bundle_names}")

--- a/lib/cog/relay/tracker.ex
+++ b/lib/cog/relay/tracker.ex
@@ -28,7 +28,7 @@ defmodule Cog.Relay.Tracker do
   """
   @spec remove_relay(t, String.t) :: t
   def remove_relay(tracker, relay) do
-    map = Enum.reduce(tracker.map, %{}, fn({bundle, relays}, acc) ->
+    updated = Enum.reduce(tracker.map, %{}, fn({bundle, relays}, acc) ->
       remaining = MapSet.delete(relays, relay)
       if Enum.empty?(remaining) do
         acc
@@ -36,7 +36,10 @@ defmodule Cog.Relay.Tracker do
         Map.put(acc, bundle, remaining)
       end
     end)
-    %{tracker | map: map}
+    if updated != tracker.map do
+      Logger.info("Removed Relay #{relay} from active relay list")
+    end
+    %{tracker | map: updated}
   end
 
   @doc """


### PR DESCRIPTION
MQTT last will messages are apparently delivered even if a connection
fails authentication. This commit moves the log statement declaring Cog
has removed a dead Relay from its active list to the Relay.Tracker where
it's only logged if Cog knows the Relay.