### PR TITLE
make bootstrap group and role aware and allow custom user params

### DIFF
--- a/lib/cog.ex
+++ b/lib/cog.ex
@@ -44,6 +44,12 @@ defmodule Cog do
   @doc "The name of the site namespace."
   def site_namespace, do: "site"
 
+  @doc "The name of the admin role."
+  def admin_role, do: "cog-admin"
+
+  @doc "The name of the admin group."
+  def admin_group, do: "cog-admin"
+
   ########################################################################
   # Adapter Resolution Functions
 

--- a/lib/cog/bootstrap.ex
+++ b/lib/cog/bootstrap.ex
@@ -5,20 +5,25 @@ defmodule Cog.Bootstrap do
 
   alias Cog.Models.Permission.Namespace
   alias Cog.Models.User
+  alias Cog.Models.Group
+  alias Cog.Models.Role
   alias Cog.Repo
 
-  @admin_name "admin"
-
-  @site_namespace "site"
   @command_option_types ["int", "float", "string", "bool"]
+  @default_admin_params %{
+    "username" => "admin",
+    "first_name" => "Cog",
+    "last_name" => "Administrator",
+    "email_address" => "cog@localhost"
+  }
 
   @doc """
   Returns true if the system has been bootstrapped,
   false if not.
   """
   def is_bootstrapped? do
-    case Repo.get_by(User, username: @admin_name) do
-      %User{} -> true
+    case Repo.get_by(Group, name: Cog.admin_group) do
+      %Group{} -> true
       nil -> false
     end
   end
@@ -27,52 +32,60 @@ defmodule Cog.Bootstrap do
   Create a user with permissions in the embedded namespace then
   returns the admin user
   """
-  def bootstrap do
-    {:ok, user} = Repo.transaction(fn() ->
-      user = create_admin
-      grant_embedded_permissions_to(user)
-      create_namespace(@site_namespace)
+  def bootstrap,
+  do: bootstrap(@default_admin_params)
+
+  def bootstrap(params) when params == %{},
+  do: bootstrap(@default_admin_params)
+
+  def bootstrap(params) do
+    Repo.transaction(fn() ->
+      user = create_admin(params)
+      role = create_by_name(Role, Cog.admin_role)
+      group = create_by_name(Group, Cog.admin_group)
+
+      grant_embedded_permissions_to(role)
+      grant_role_to_group(group, role)
+      add_user_to_group(user, group)
+
+      create_by_name(Namespace, Cog.site_namespace)
+
       user
     end)
-
-    {:ok, user}
   end
 
-  # TODO: require either username or email (or both), but if one is
-  #       missing, that's  OK.
-  # TODO: Make first/last name optional?
-
-  # Create a bootstrap admin user. The username will always be
-  # `@admin_name`, and the password will be randomly-generated, which
-  # will be available in the `password` field of the returned
-  # `Cog.Models.User` struct.
-  defp create_admin do
-    # Horrible quick n' dirty hack to strip
-    # ; and # from passwords so ConfigParse_Ex doesn't
-    # choke on them.
-    password = String.replace(Cog.Passwords.generate_password(32), ~r/[;#]/, "")
-
-    params = %{
-      username: @admin_name,
-      first_name: "Cog",
-      last_name: "Administrator",
-      password: password,
-      email_address: "cog@localhost"}
-
+  # Create a bootstrap admin user from the given parameter map. If
+  # the password is empty, generate a random one. Returns the username
+  # and password in the response.
+  defp create_admin(params) do
+    params = Map.put_new_lazy(params, "password", &generate_safe_password/0)
     User.changeset(%User{}, params) |> Repo.insert!
   end
 
-  defp grant_embedded_permissions_to(user) do
-    Cog.embedded_bundle
-    |> Cog.Queries.Permission.from_bundle_name
-    |> Repo.all
-    |> Enum.each(&Permittable.grant_to(user, &1))
-  end
-
-  defp create_namespace(name) do
-    %Namespace{}
-    |> Namespace.changeset(%{name: name})
+  defp create_by_name(model, name) do
+    model.__struct__
+    |> model.changeset(%{name: name})
     |> Repo.insert!
   end
 
+  defp grant_embedded_permissions_to(role) do
+    Cog.embedded_bundle
+    |> Cog.Queries.Permission.from_bundle_name
+    |> Repo.all
+    |> Enum.each(&Permittable.grant_to(role, &1))
+  end
+
+  defp grant_role_to_group(group, role) do
+    Permittable.grant_to(group, role)
+  end
+
+  defp add_user_to_group(user, group) do
+    Groupable.add_to(user, group)
+  end
+
+  defp generate_safe_password do
+    # Strip ; and # from passwords so that ConfigParse_Ex doesn't
+    # choke on them.
+    String.replace(Cog.Passwords.generate_password(32), ~r/[;#]/, "")
+  end
 end

--- a/test/integration/group_test.exs
+++ b/test/integration/group_test.exs
@@ -64,12 +64,12 @@ defmodule Integration.GroupTest do
     assert_payload(response, %{body: ["Added the user `belf` to the group `cheer`"]})
 
     response = send_message(user, "@bot: operable:group --list")
-    assert_payload(response, %{body: ["The following are the available groups: \n* cheer\n* elves\n"]})
+    assert_payload(response, %{body: ["The following are the available groups: \n* cheer\n* elves\n* cog-admin\n"]})
 
     response = send_message(user, "@bot: operable:group --drop cheer")
     assert_payload(response, %{body: ["The group `cheer` has been deleted."]})
 
     response = send_message(user, "@bot: operable:group --list")
-    assert_payload(response, %{body: ["The following are the available groups: \n* elves\n"]})
+    assert_payload(response, %{body: ["The following are the available groups: \n* elves\n* cog-admin\n"]})
   end
 end

--- a/test/integration/role_test.exs
+++ b/test/integration/role_test.exs
@@ -78,6 +78,6 @@ defmodule Integration.RoleTest do
     role("happy")
 
     response = send_message(user, "@bot: operable:role --list")
-    assert_payload(response, %{body: ["The following are the available roles: \n* happy\n* cheer\n"]})
+    assert_payload(response, %{body: ["The following are the available roles: \n* happy\n* cheer\n* cog-admin\n"]})
   end
 end


### PR DESCRIPTION
**Updated bootstrap flow:**

* Create a new administrative user, using a parameter hash for the fields in the `%User{}` map, if present. If not, use the previous defaults.
* Create a `cog-admin` group and add the new administrative user to it.
* Create a `cog-admin` role, grant all of the `operable:*` permissions to it, and grant it to the `cog-admin` group.