### PR TITLE
Do not install non-embedded bundles

### DIFF
--- a/lib/cog/relay/relays.ex
+++ b/lib/cog/relay/relays.ex
@@ -78,8 +78,6 @@ defmodule Cog.Relay.Relays do
     do: {:reply, Tracker.relays(state.tracker, bundle_name), state}
 
   def handle_info({:publish, @relays_discovery_topic, message}, state) do
-    # Not authenticating messages here, because we don't have the keys
-    # to authenticate them at this point!
     case Poison.decode(message) do
       {:ok, %{"announce" => announcement}} ->
         state = process_announcement(announcement, state)

--- a/lib/cog/relay/relays.ex
+++ b/lib/cog/relay/relays.ex
@@ -8,8 +8,6 @@ defmodule Cog.Relay.Relays do
   use Adz
   use GenServer
 
-  alias Carrier.Credentials
-  alias Carrier.CredentialManager
   alias Carrier.Messaging
   alias Cog.Models.Bundle
   alias Cog.Repo
@@ -57,7 +55,7 @@ defmodule Cog.Relay.Relays do
     end
   end
 
-  def handle_call({:announce_embedded_relay, message}, _from, state) do
+  def handle_call({:announce_embedded_relay, %{"announce" => announcement}}, _from, state) do
     # This function head acts as a private internal API used for
     # registering the bot as a host for the embedded command
     # bundle. (We don't provide a public API function for this message
@@ -67,7 +65,7 @@ defmodule Cog.Relay.Relays do
     # bundle is recorded in the database before proceeding.
     #
     # See `Cog.Bundle.Embedded` for more.
-    new_state = process_discovery(message, state, true)
+    new_state = process_announcement(announcement, state, true)
     {:reply, :ok, new_state}
   end
   def handle_call({:random_relay, bundle}, _from, state),
@@ -83,8 +81,8 @@ defmodule Cog.Relay.Relays do
     # Not authenticating messages here, because we don't have the keys
     # to authenticate them at this point!
     case Poison.decode(message) do
-      {:ok, json} ->
-        state = process_discovery(json, state)
+      {:ok, %{"announce" => announcement}} ->
+        state = process_announcement(announcement, state)
         {:noreply, state}
       _ ->
         {:noreply, state}
@@ -96,35 +94,7 @@ defmodule Cog.Relay.Relays do
 
   ########################################################################
 
-  # Common processing of relay announcements, whether they come from a
-  # real Relay instance, or from the bot itself, announcing the
-  # embedded bundle.
-  defp process_discovery(discovery, state, internal \\ false) when is_map(state) do
-    case discovery do
-      %{"intro" => intro} ->
-        process_introduction(intro, state)
-      %{"announce" => announcement} ->
-        process_announcement(announcement, state, internal)
-    end
-  end
-
-  defp process_introduction(%{"relay" => id,
-                              "reply_to" => reply_to}, state) do
-    case CredentialManager.get(id, by: :id) do
-      {:ok, nil} ->
-        creds = %Credentials{id: id}
-        CredentialManager.store(creds)
-        Logger.info("Stored credentials for Relay #{id}")
-      {:ok, _} ->
-        :ok
-    end
-    {:ok, my_creds} = CredentialManager.get()
-    Messaging.Connection.publish(state.mq_conn, %{intro: %{id: my_creds.id,
-                                                           role: "bot"}}, routed_by: reply_to)
-    state
-  end
-
-  defp process_announcement(announcement, %__MODULE__{tracker: tracker}=state, internal) do
+  defp process_announcement(announcement, %__MODULE__{tracker: tracker}=state, internal \\ false) do
     {success_bundles, failed_bundles} = announcement
     |> Map.get("bundles", [])
     |> Enum.map(&(lookup_or_install(&1, internal)))
@@ -153,6 +123,7 @@ defmodule Cog.Relay.Relays do
     do: %{"announcement_id" => announcement_id, "status" => "failed", "bundles" => failed_bundles}
 
   defp update_tracker(announcement, tracker, success_bundles) do
+    IO.puts "#{Map.keys(announcement)}"
     relay_id = Map.fetch!(announcement, "relay")
 
     online_status = case Map.fetch!(announcement, "online") do

--- a/lib/cog/relay/relays.ex
+++ b/lib/cog/relay/relays.ex
@@ -123,7 +123,6 @@ defmodule Cog.Relay.Relays do
     do: %{"announcement_id" => announcement_id, "status" => "failed", "bundles" => failed_bundles}
 
   defp update_tracker(announcement, tracker, success_bundles) do
-    IO.puts "#{Map.keys(announcement)}"
     relay_id = Map.fetch!(announcement, "relay")
 
     online_status = case Map.fetch!(announcement, "online") do

--- a/lib/cog/relay/relays.ex
+++ b/lib/cog/relay/relays.ex
@@ -67,7 +67,7 @@ defmodule Cog.Relay.Relays do
     # bundle is recorded in the database before proceeding.
     #
     # See `Cog.Bundle.Embedded` for more.
-    new_state = process_discovery(message, state)
+    new_state = process_discovery(message, state, true)
     {:reply, :ok, new_state}
   end
   def handle_call({:random_relay, bundle}, _from, state),
@@ -99,12 +99,12 @@ defmodule Cog.Relay.Relays do
   # Common processing of relay announcements, whether they come from a
   # real Relay instance, or from the bot itself, announcing the
   # embedded bundle.
-  defp process_discovery(discovery, state) when is_map(state) do
+  defp process_discovery(discovery, state, internal \\ false) when is_map(state) do
     case discovery do
       %{"intro" => intro} ->
         process_introduction(intro, state)
       %{"announce" => announcement} ->
-        process_announcement(announcement, state)
+        process_announcement(announcement, state, internal)
     end
   end
 
@@ -124,10 +124,10 @@ defmodule Cog.Relay.Relays do
     state
   end
 
-  defp process_announcement(announcement, %__MODULE__{tracker: tracker}=state) do
+  defp process_announcement(announcement, %__MODULE__{tracker: tracker}=state, internal) do
     {success_bundles, failed_bundles} = announcement
     |> Map.get("bundles", [])
-    |> Enum.map(&lookup_or_install/1)
+    |> Enum.map(&(lookup_or_install(&1, internal)))
     |> Enum.partition(&Util.is_ok?/1)
     |> Util.unwrap_partition_results
 
@@ -169,6 +169,7 @@ defmodule Cog.Relay.Relays do
     case {online_status, snapshot_status} do
       {:offline, _} ->
         Tracker.remove_relay(tracker, relay_id)
+        Logger.info("Removed Relay #{relay_id} from active relay list")
       {:online, :incremental} ->
         Logger.info("Incrementally adding bundles for Relay #{relay_id}: #{inspect bundle_names}")
         Tracker.add_bundles_for_relay(tracker, relay_id, success_bundles)
@@ -181,7 +182,7 @@ defmodule Cog.Relay.Relays do
   # If `config` exists in the database (by name), retrieves the
   # database record. If not, installs the bundle and returns the
   # database record.
-  defp lookup_or_install(%{"name" => name, "version" => version} = config) do
+  defp lookup_or_install(%{"name" => name, "version" => version} = config, internal) do
     case Repo.get_by(Bundle, name: name) do
       %Bundle{version: ^version}=bundle ->
         {:ok, bundle}
@@ -189,12 +190,20 @@ defmodule Cog.Relay.Relays do
         Logger.error("Error! Unable to install bundle #{inspect name} because version #{installed_version} already installed")
         {:error, name}
       nil ->
-        Logger.info("Installing bundle: #{inspect name}")
-        case Cog.Bundle.Install.install_bundle(%{name: name, version: version, config_file: config}) do
-          {:ok, bundle} ->
-            {:ok, bundle}
-          {:error, error} ->
-            Logger.error("Error! Unable to install bundle #{inspect name}: #{inspect error}")
+        case internal do
+          # This is the embedded bundle
+          true ->
+            Logger.info("Installing bundle: #{inspect name}")
+            case Cog.Bundle.Install.install_bundle(%{name: name, version: version, config_file: config}) do
+              {:ok, bundle} ->
+                {:ok, bundle}
+              {:error, error} ->
+                Logger.error("Error! Unable to install bundle #{inspect name}: #{inspect error}")
+                {:error, name}
+            end
+          false ->
+            # TODO: Pass Relay ID into lookup_or_install/2 so we can generate a better error message
+            Logger.error("Relay announced unknown command bundle #{name}")
             {:error, name}
         end
     end

--- a/lib/cog/relay/tracker.ex
+++ b/lib/cog/relay/tracker.ex
@@ -36,9 +36,6 @@ defmodule Cog.Relay.Tracker do
         Map.put(acc, bundle, remaining)
       end
     end)
-    if updated != tracker.map do
-      Logger.info("Removed Relay #{relay} from active relay list")
-    end
     %{tracker | map: updated}
   end
 


### PR DESCRIPTION
This PR does a few things:

1. Prevents Cog from installing non-embedded bundles. Unknown bundles announced from external relays are treated as an error.
1. Removes the introduction step of the announcement waltz. This is no longer necessary.
1. Fixes a potentially misleading log message about relay removals.