### PR TITLE
Add permissions to bundles

### DIFF
--- a/lib/cog/queries/bundles.ex
+++ b/lib/cog/queries/bundles.ex
@@ -6,7 +6,7 @@ defmodule Cog.Queries.Bundles do
 
   def all do
     from b in Bundle,
-    preload: [:namespace, commands: [:rules], relay_groups: [:relays]]
+    preload: [:namespace, commands: [rules: [permissions: :namespace]], relay_groups: [:relays]]
   end
 
   def for_id(id) do

--- a/lib/cog/queries/command.ex
+++ b/lib/cog/queries/command.ex
@@ -38,7 +38,7 @@ defmodule Cog.Queries.Command do
     do: from c in queryable, preload: [:bundle]
 
   def with_rules(queryable),
-    do: from c in queryable, preload: [:rules]
+    do: from c in queryable, preload: [rules: [permissions: :namespace]]
 
   def with_options(queryable),
     do: from c in queryable, preload: [options: :option_type]

--- a/test/controllers/v1/bundles_controller_test.exs
+++ b/test/controllers/v1/bundles_controller_test.exs
@@ -129,13 +129,14 @@ defmodule Cog.V1.BundlesControllerTest do
   test "includes rules in bundle resource", %{authed: requestor} do
     bundle = bundle("cog")
     command = command("hola")
-    permission("cog:hola")
-    rule_text = "when command is cog:hola must have cog:hola"
+    perm = permission("site:hola")
+    rule_text = "when command is cog:hola must have site:hola"
     rule = rule(rule_text)
 
     bundle_id = bundle.id
     command_id = command.id
     rule_id = rule.id
+    perm_id = perm.id
 
     conn = api_request(requestor, :get, "/v1/bundles/#{bundle.id}")
     assert %{"bundle" => %{"id" => ^bundle_id,
@@ -144,6 +145,9 @@ defmodule Cog.V1.BundlesControllerTest do
                                "rules" => [
                                  %{"id" => ^rule_id,
                                    "command" => "cog:hola",
+                                   "permissions" => [%{"id" => ^perm_id,
+                                                       "name" => "hola",
+                                                       "namespace" => "site"}],
                                    "rule" => ^rule_text}]}]}} = json_response(conn, 200)
   end
 

--- a/web/controllers/v1/bundles_controller.ex
+++ b/web/controllers/v1/bundles_controller.ex
@@ -42,8 +42,7 @@ defmodule Cog.V1.BundlesController do
   def create(conn, %{"bundle" => params}) do
     case install_bundle(params) do
       {:ok, bundle} ->
-        bundle = Repo.preload(bundle, commands: [:rules])
-
+        bundle = Repo.preload(bundle, commands: [rules: [permissions: :namespace]])
         conn
         |> put_status(:created)
         |> put_resp_header("location", bundles_path(conn, :show, bundle))

--- a/web/views/commands_view.ex
+++ b/web/views/commands_view.ex
@@ -1,0 +1,42 @@
+defmodule Cog.V1.CommandView do
+  use Cog.Web, :view
+
+  alias Cog.V1.RuleView
+
+  def render("command.json", %{command: command}=resource) do
+    %{id: command.id,
+      name: command.name,
+      documentation: command.documentation,
+      enforcing: command.enforcing,
+      execution: command.execution}
+    |> Map.merge(render_includes(resource, command))
+  end
+
+  def render("index.json", %{commands: commands}) do
+    %{commands: render_many(commands, __MODULE__, "command.json", as: :command, include: :rules)}
+  end
+
+  def render("show.json", %{command: command}) do
+    %{command: render_one(command, __MODULE__, "command.json", as: :command, include: :rules)}
+  end
+
+  defp render_includes(inc_fields, resource) do
+    Map.get(inc_fields, :include, []) |> Enum.reduce(%{}, fn(field, reply) -> 
+      case render_include(field, resource) do
+        nil -> reply
+        {key, value} -> Map.put(reply, key, value)
+      end
+    end)
+  end
+
+  defp render_include(:rules, command) do
+    value = Map.fetch!(command, :rules)
+    case Ecto.assoc_loaded?(value) do
+      true ->
+        {:rules, render_many(value, RuleView, "rule.json", as: :rule, include: [:permissions])}
+      false ->
+        nil
+    end
+  end
+
+end

--- a/web/views/rule_view.ex
+++ b/web/views/rule_view.ex
@@ -1,23 +1,43 @@
 defmodule Cog.V1.RuleView do
   use Cog.Web, :view
 
-  def render("rule.json", %{rule: rule}) do
+  def render("rule.json", %{rule: rule}=resource) do
     ast = to_ast(rule)
     %{id: rule.id,
       command: ast.command,
       rule: to_string(ast)}
+    |> Map.merge(render_includes(resource, rule))
   end
 
   def render("index.json", %{rules: rules}) do
-    %{rules: render_many(rules, __MODULE__, "rule.json")}
+    %{rules: render_many(rules, __MODULE__, "rule.json", as: :rule, include: [:permissions])}
   end
 
   def render("show.json", %{rule: rule}) do
-    %{rule: render_one(rule, __MODULE__, "rule.json")}
+    %{rule: render_one(rule, __MODULE__, "rule.json", as: :rule, include: [:permissions])}
   end
 
   defp to_ast(rule) do
     Piper.Permissions.Parser.json_to_rule!(rule.parse_tree)
   end
 
+  defp render_includes(resource, rule) do
+    Map.get(resource, :include, [])
+    |> Enum.reduce(%{}, fn(field, reply) ->
+      case render_include(field, rule) do
+        nil -> reply
+        {key, value} -> Map.put(reply, key, value)
+      end
+    end)
+  end
+
+  defp render_include(:permissions, rule) do
+    value = Map.fetch!(rule, :permissions)
+    case Ecto.assoc_loaded?(value) do
+      true ->
+        {:permissions, render_many(value, Cog.V1.PermissionView, "permission.json", as: :permission, include: [:namespace])}
+      false ->
+        nil
+    end
+  end
 end


### PR DESCRIPTION
This change adds permissions to the bundle under the command/rules path.

This PR also adds a CommandView for the command structure.

Fixes https://github.com/operable/cog/issues/540