### PR TITLE
Add some slack to trigger timeouts

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -133,4 +133,11 @@ config :cog, Cog.TriggerEndpoint,
 config :cog, :token_lifetime, {1, :week}
 config :cog, :token_reap_period, {1, :day}
 
+# Trigger timeouts are defined according to the needs of the
+# requestor, which includes network roundtrip time, as well as Cog's
+# internal processing. Cog itself can't wait that long to respond, as
+# that'll be guaranteed to exceed the HTTP requestor's timeout. As
+# such, we'll incorporate a buffer into our internal timeout.
+config :cog, :trigger_timeout_buffer_sec, (System.get_env("COG_TRIGGER_TIMEOUT_SLACK_SEC") || 2)
+
 import_config "#{Mix.env}.exs"

--- a/web/controllers/v1/trigger_execution_controller.ex
+++ b/web/controllers/v1/trigger_execution_controller.ex
@@ -25,7 +25,7 @@ defmodule Cog.V1.TriggerExecutionController do
 
             conn = Plug.Conn.fetch_query_params(conn)
             request_id = get_request_id(conn)
-            timeout    = trigger.timeout_sec * 1000
+            timeout    = computed_timeout(trigger)
 
             context = %{trigger_id: trigger_id,
                         headers: headers_to_map(conn.req_headers),
@@ -162,5 +162,14 @@ defmodule Cog.V1.TriggerExecutionController do
   defp get_parsed_body(conn),
     do: conn.assigns[:parsed_body]
 
+  ########################################################################
 
+  defp computed_timeout(%Trigger{timeout_sec: timeout_sec}) do
+    case Application.get_env(:cog, :trigger_timeout_buffer_sec) do
+      slack when slack <= timeout_sec ->
+        (timeout_sec - slack) * 1000
+      _ ->
+        0
+    end
+  end
 end


### PR DESCRIPTION
Trigger timeouts are defined according to the needs of the
requestor (e.g. Github webhooks must respond within 30 seconds), which
includes network roundtrip time, as well as Cog's internal
processing. Cog itself can't wait that long to respond, as that'll be
guaranteed to exceed the HTTP requestor's timeout. As such, we'll bake
some slack into our internal timeout, allowing us to return to the
requestor within their timeout.

This can be configured on a system-wide basis.