### PR TITLE
"Active" triggers are now "enabled"

### DIFF
--- a/lib/cog/models/trigger.ex
+++ b/lib/cog/models/trigger.ex
@@ -8,14 +8,14 @@ defmodule Cog.Models.Trigger do
     field :as_user, :string, default: nil
     field :timeout_sec, :integer, default: 30
 
-    field :active, :boolean, default: true
+    field :enabled, :boolean, default: true
     field :description, :string, default: nil
 
     timestamps
   end
 
   @required_fields ~w(name pipeline)
-  @optional_fields ~w(as_user timeout_sec active description)
+  @optional_fields ~w(as_user timeout_sec enabled description)
 
   def changeset(model, params \\ %{}) do
     model

--- a/priv/repo/migrations/20160418174310_triggers_enabled.exs
+++ b/priv/repo/migrations/20160418174310_triggers_enabled.exs
@@ -1,0 +1,7 @@
+defmodule Cog.Repo.Migrations.TriggersEnabled do
+  use Ecto.Migration
+
+  def change do
+    rename table(:triggers), :active, to: :enabled
+  end
+end

--- a/test/cog/models/trigger_test.exs
+++ b/test/cog/models/trigger_test.exs
@@ -33,10 +33,10 @@ defmodule Cog.Models.TriggerTest do
     assert 30 = Ecto.Changeset.get_field(changeset, :timeout_sec)
   end
 
-  test "triggers are active by default" do
+  test "triggers are enabled by default" do
     changeset = Trigger.changeset(%Trigger{}, @valid_attrs)
     assert changeset.valid?
-    assert Ecto.Changeset.get_field(changeset, :active)
+    assert Ecto.Changeset.get_field(changeset, :enabled)
   end
 
   test "triggers have no description by default" do

--- a/test/cog/repository/triggers_test.exs
+++ b/test/cog/repository/triggers_test.exs
@@ -30,7 +30,7 @@ defmodule Cog.Repository.TriggersTest do
                       pipeline: "echo $body.message > chat://#general",
                       as_user: "marvin",
                       timeout_sec: 30,
-                      active: true,
+                      enabled: true,
                       description: nil} = trigger
   end
 

--- a/test/controllers/v1/trigger_execution_controller_test.exs
+++ b/test/controllers/v1/trigger_execution_controller_test.exs
@@ -94,15 +94,15 @@ defmodule Cog.V1.TriggerExecutionControllerTest do
     assert [] = Snoop.messages(test_snoop)
   end
 
-  test "inactive triggers don't fire", %{conn: conn} do
+  test "disabled triggers don't fire", %{conn: conn} do
     user("cog")
     trigger = trigger(%{name: "echo",
-                  pipeline: "echo foo",
-                  as_user: "cog",
-                  active: false})
+                        pipeline: "echo foo",
+                        as_user: "cog",
+                        enabled: false})
 
     conn = post(conn, "/v1/triggers/#{trigger.id}", Poison.encode!(%{}))
-    assert "Trigger is not active" = json_response(conn, 422)["errors"]
+    assert "Trigger is not enabled" = json_response(conn, 422)["errors"]
   end
 
   test "request sent to executor is correctly set up", %{conn: conn} do

--- a/test/views/trigger_view_test.exs
+++ b/test/views/trigger_view_test.exs
@@ -12,14 +12,14 @@ defmodule Cog.V1.TriggerViewTest do
                        as_user: "user",
                        pipeline: "echo foo",
                        timeout_sec: 30,
-                       active: true,
+                       enabled: true,
                        description: "Something really awesome"}
     json = %{"id" => uuid,
              "name" => "echo",
              "as_user" => "user",
              "pipeline" => "echo foo",
              "timeout_sec" => 30,
-             "active" => true,
+             "enabled" => true,
              "description" => "Something really awesome",
              "invocation_url" => "http://localhost:4001/v1/triggers/#{uuid}"}
     {:ok, %{model: model, json: json}}

--- a/web/controllers/v1/trigger_execution_controller.ex
+++ b/web/controllers/v1/trigger_execution_controller.ex
@@ -18,7 +18,7 @@ defmodule Cog.V1.TriggerExecutionController do
 
   def execute_trigger(conn, %{"id" => trigger_id}) do
     case Triggers.trigger_definition(trigger_id) do
-      {:ok, %Trigger{active: true}=trigger} ->
+      {:ok, %Trigger{enabled: true}=trigger} ->
         conn = resolve_user(conn, trigger)
         case get_user(conn) do
           %User{username: as_user} ->
@@ -60,8 +60,8 @@ defmodule Cog.V1.TriggerExecutionController do
             # resolve_user/2 below
             conn
         end
-      {:ok, %Trigger{active: false}} ->
-        conn |> put_status(:unprocessable_entity) |> json(%{errors: "Trigger is not active"})
+      {:ok, %Trigger{enabled: false}} ->
+        conn |> put_status(:unprocessable_entity) |> json(%{errors: "Trigger is not enabled"})
       {:error, :not_found} ->
         conn
         |> put_status(:not_found)

--- a/web/views/trigger_view.ex
+++ b/web/views/trigger_view.ex
@@ -5,7 +5,7 @@ defmodule Cog.V1.TriggerView do
     %{id: trigger.id,
       name: trigger.name,
       description: trigger.description,
-      active: trigger.active,
+      enabled: trigger.enabled,
       pipeline: trigger.pipeline,
       as_user: trigger.as_user,
       timeout_sec: trigger.timeout_sec,


### PR DESCRIPTION
Terminology change to bring it in line with how we talk about bundles,
which can also be active/enabled or inactive/disabled.