### PR TITLE
prevent rename or delete of cog-admin group and role

### DIFF
--- a/priv/repo/migrations/20160415152542_protect_internal_rows.exs
+++ b/priv/repo/migrations/20160415152542_protect_internal_rows.exs
@@ -1,0 +1,77 @@
+defmodule Cog.Repo.Migrations.ProtectAdminRoleAndGroup do
+  use Ecto.Migration
+
+  def up do
+    execute """
+CREATE OR REPLACE FUNCTION protect_admin_role()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF OLD.NAME = '#{Cog.admin_role}' THEN
+    RAISE EXCEPTION 'cannot modify admin role';
+  END IF;
+  RETURN NULL;
+END;
+$$;
+"""
+    execute """
+CREATE CONSTRAINT TRIGGER protect_admin_role
+AFTER UPDATE OR DELETE
+ON roles
+FOR EACH ROW
+EXECUTE PROCEDURE protect_admin_role();
+"""
+
+    execute """
+CREATE OR REPLACE FUNCTION protect_admin_group()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF OLD.NAME = '#{Cog.admin_group}' THEN
+    RAISE EXCEPTION 'cannot modify admin group';
+  END IF;
+  RETURN NULL;
+END;
+$$;
+"""
+    execute """
+CREATE CONSTRAINT TRIGGER protect_admin_group
+AFTER UPDATE OR DELETE
+ON groups
+FOR EACH ROW
+EXECUTE PROCEDURE protect_admin_group();
+"""
+
+      execute """
+CREATE OR REPLACE FUNCTION protect_embedded_bundle()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF OLD.NAME = '#{Cog.embedded_bundle}' THEN
+    RAISE EXCEPTION 'cannot modify embedded bundle';
+  END IF;
+  RETURN NULL;
+END;
+$$;
+"""
+    execute """
+CREATE CONSTRAINT TRIGGER protect_embedded_bundle
+AFTER UPDATE OR DELETE
+ON bundles
+FOR EACH ROW
+EXECUTE PROCEDURE protect_embedded_bundle();
+"""
+  end
+
+  def down do
+    execute "DROP TRIGGER protect_admin_role ON roles;"
+    execute "DROP FUNCTION protect_admin_role();"
+    execute "DROP TRIGGER protect_admin_group ON groups;"
+    execute "DROP FUNCTION protect_admin_group();"
+    execute "DROP TRIGGER protect_embedded_bundle ON bundles;"
+    execute "DROP FUNCTION protect_embedded_bundle();"
+  end
+end

--- a/test/cog/models/group_test.exs
+++ b/test/cog/models/group_test.exs
@@ -1,0 +1,25 @@
+defmodule Cog.Models.Group.Test do
+  use Cog.ModelCase
+
+  alias Cog.Models.Group
+
+  test "names are required" do
+    changeset = Group.changeset(%Group{}, %{})
+    assert {:name, "can't be blank"} in changeset.errors
+  end
+
+  test "names are unique" do
+    {:ok, _group} = Repo.insert Group.changeset(%Group{}, %{"name" => "admin"})
+    {:error, changeset} = Repo.insert Group.changeset(%Group{}, %{"name" => "admin"})
+    assert {:name, "has already been taken"} in changeset.errors
+  end
+
+  test "admin group cannot be renamed" do
+    Cog.Bootstrap.bootstrap
+    group = Group |> Repo.get_by(name: Cog.admin_group)
+    assert group.name == Cog.admin_group
+    {:error, changeset} = Repo.update(Group.changeset(group, %{"name" => "not-cog-admin"}))
+    assert {:name, "admin group may not be modified"} in changeset.errors
+  end
+
+end

--- a/test/cog/models/role_test.exs
+++ b/test/cog/models/role_test.exs
@@ -14,4 +14,12 @@ defmodule Cog.Models.Role.Test do
     assert {:name, "has already been taken"} in changeset.errors
   end
 
+  test "admin role cannot be renamed" do
+    Cog.Bootstrap.bootstrap
+    role = Role |> Repo.get_by(name: Cog.admin_role)
+    assert role.name == Cog.admin_role
+    {:error, changeset} = Repo.update(Role.changeset(role, %{"name" => "not-cog-admin"}))
+    assert {:name, "admin role may not be modified"} in changeset.errors
+  end
+
 end

--- a/web/controllers/v1/group_controller.ex
+++ b/web/controllers/v1/group_controller.ex
@@ -52,8 +52,15 @@ defmodule Cog.V1.GroupController do
   end
 
   def delete(conn, %{"id" => id}) do
-    group = Repo.get!(Group, id)
-    Repo.delete!(group)
-    send_resp(conn, :no_content, "")
+    changeset = Repo.get!(Group, id) |> Cog.Models.Group.changeset(:delete)
+
+    case Repo.delete(changeset) do
+      {:ok, _} ->
+        send_resp(conn, :no_content, "")
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(Cog.ChangesetView, "error.json", changeset: changeset)
+    end
   end
 end

--- a/web/controllers/v1/role_controller.ex
+++ b/web/controllers/v1/role_controller.ex
@@ -57,8 +57,16 @@ defmodule Cog.V1.RoleController do
   end
 
   def delete(conn, %{"id" => id}) do
-    Role |> Repo.get!(id) |> Repo.delete!
-    send_resp(conn, :no_content, "")
+    changeset = Role |> Repo.get!(id) |> Cog.Models.Role.changeset(:delete)
+
+    case Repo.delete(changeset) do
+      {:ok, _} ->
+        send_resp(conn, :no_content, "")
+      {:error, changed} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(Cog.ChangesetView, "error.json", changeset: changed)
+    end
   end
 
 end


### PR DESCRIPTION
* adds  constraint triggers to Postgres to prevent the cog-admin group and role and the operable bundle from being deleted or renamed.
* adds a changeset function to validate deletes of Group and Role models.
* updates changeset functions in Group and Role to reject name changes for the admin group and role
* updates the Group and Role API controllers to use the new changesets to validate deletes.

Note, this **does not** update the commands in the embedded bundle to use a changeset, so attempts to delete protected objects will result in a crash of the command when Postgrex raises an exception. These should be cleaned up in a future pull request.