### PR TITLE
Moved Logger call to before remove_relay/2 call

### DIFF
--- a/lib/cog/relay/relays.ex
+++ b/lib/cog/relay/relays.ex
@@ -136,8 +136,8 @@ defmodule Cog.Relay.Relays do
     bundle_names = Enum.map(success_bundles, &Map.get(&1, :name)) # Just for logging purposes
     case {online_status, snapshot_status} do
       {:offline, _} ->
-        Tracker.remove_relay(tracker, relay_id)
         Logger.info("Removed Relay #{relay_id} from active relay list")
+        Tracker.remove_relay(tracker, relay_id)
       {:online, :incremental} ->
         Logger.info("Incrementally adding bundles for Relay #{relay_id}: #{inspect bundle_names}")
         Tracker.add_bundles_for_relay(tracker, relay_id, success_bundles)


### PR DESCRIPTION
Prior order was reversed which resulted in setting state.tracker to `:ok `with obvious bad consequences.