### PR TITLE
prevent embedded permissions in cog-admin role from being revoked

### DIFF
--- a/lib/cog/models/role.ex
+++ b/lib/cog/models/role.ex
@@ -58,11 +58,20 @@ defmodule Cog.Models.Role do
 end
 
 defimpl Permittable, for: Cog.Models.Role do
+  alias Cog.Repo
+  alias Cog.Models.JoinTable
+  alias Cog.Models.Permission.Namespace
 
   def grant_to(role, permission),
-    do: Cog.Models.JoinTable.associate(role, permission)
+  do: JoinTable.associate(role, permission)
 
-  def revoke_from(role, permission),
-    do: Cog.Models.JoinTable.dissociate(role, permission)
+  def revoke_from(role, permission) do
+    namespace = Repo.get(Namespace, permission.namespace_id)
+    if role.name == Cog.admin_role and namespace.name == Cog.embedded_bundle do
+      {:error, "cannot remove embedded permissions from admin role"}
+    else
+      JoinTable.dissociate(role, permission)
+    end
+  end
 
 end

--- a/priv/repo/migrations/20160419154716_protect_admin_role_permissions.exs
+++ b/priv/repo/migrations/20160419154716_protect_admin_role_permissions.exs
@@ -1,0 +1,43 @@
+defmodule Cog.Repo.Migrations.ProtectAdminRolePermissions do
+  use Ecto.Migration
+
+  def up do
+    execute """
+CREATE OR REPLACE FUNCTION protect_admin_role_permissions()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  role TEXT;
+  namespace TEXT;
+BEGIN
+  SELECT roles.name INTO role FROM roles WHERE roles.id=OLD.role_id;
+
+  SELECT namespaces.name
+    INTO namespace
+    FROM namespaces, permissions
+   WHERE namespaces.id=permissions.namespace_id
+     AND permissions.id=OLD.permission_id;
+
+  IF role = '#{Cog.admin_role}' AND namespace = '#{Cog.embedded_bundle}' THEN
+    RAISE EXCEPTION 'cannot remove embedded permissions from admin role';
+  END IF;
+  RETURN NULL;
+END;
+$$;
+"""
+    execute """
+CREATE CONSTRAINT TRIGGER protect_admin_role_permissions
+AFTER UPDATE OR DELETE
+ON role_permissions
+FOR EACH ROW
+EXECUTE PROCEDURE protect_admin_role_permissions();
+"""
+  end
+
+  def down do
+    execute "DROP TRIGGER protect_admin_role_permissions ON role_permissions;"
+    execute "DROP FUNCTION protect_admin_role_permissions();"
+  end
+
+end


### PR DESCRIPTION
* adds a constraint trigger to prevent `operable:*` permissions from being revoked from the `cog-admin` role.
* with tests!

Note, there's some weirdness where testing the database constraint trigger. Ideally, `assert_raise` would be used here, but I couldn't figure out how to get it to work. Also, note that we can only test one permission in the test since the exception in Postgrex causes the transaction for the test to abort.