### PR TITLE
Include *all* permissions in a bundle

### DIFF
--- a/lib/cog/queries/bundles.ex
+++ b/lib/cog/queries/bundles.ex
@@ -6,7 +6,7 @@ defmodule Cog.Queries.Bundles do
 
   def all do
     from b in Bundle,
-    preload: [:namespace, commands: [rules: [permissions: :namespace]], relay_groups: [:relays]]
+    preload: [namespace: [permissions: :namespace], commands: [rules: [permissions: :namespace]], relay_groups: [:relays]]
   end
 
   def for_id(id) do

--- a/test/controllers/v1/bundles_controller_test.exs
+++ b/test/controllers/v1/bundles_controller_test.exs
@@ -122,6 +122,7 @@ defmodule Cog.V1.BundlesControllerTest do
                            "enabled" => bundle.enabled,
                            "relay_groups" => [],
                            "commands" => [],
+                           "permissions" => [],
                            "inserted_at" => "#{DateTime.to_iso8601(bundle.inserted_at)}",
                            "updated_at" => "#{DateTime.to_iso8601(bundle.updated_at)}"}} == json_response(conn, 200)
   end
@@ -129,8 +130,8 @@ defmodule Cog.V1.BundlesControllerTest do
   test "includes rules in bundle resource", %{authed: requestor} do
     bundle = bundle("cog")
     command = command("hola")
-    perm = permission("site:hola")
-    rule_text = "when command is cog:hola must have site:hola"
+    perm = permission("cog:hello")
+    rule_text = "when command is cog:hola must have cog:hello"
     rule = rule(rule_text)
 
     bundle_id = bundle.id
@@ -140,14 +141,17 @@ defmodule Cog.V1.BundlesControllerTest do
 
     conn = api_request(requestor, :get, "/v1/bundles/#{bundle.id}")
     assert %{"bundle" => %{"id" => ^bundle_id,
+                           "permissions" => [%{"id" => ^perm_id,
+                                               "name" => "hello",
+                                               "namespace" => "cog"}],
                            "commands" => [
                              %{"id" => ^command_id,
                                "rules" => [
                                  %{"id" => ^rule_id,
                                    "command" => "cog:hola",
                                    "permissions" => [%{"id" => ^perm_id,
-                                                       "name" => "hola",
-                                                       "namespace" => "site"}],
+                                                       "name" => "hello",
+                                                       "namespace" => "cog"}],
                                    "rule" => ^rule_text}]}]}} = json_response(conn, 200)
   end
 

--- a/web/controllers/v1/bundles_controller.ex
+++ b/web/controllers/v1/bundles_controller.ex
@@ -42,7 +42,7 @@ defmodule Cog.V1.BundlesController do
   def create(conn, %{"bundle" => params}) do
     case install_bundle(params) do
       {:ok, bundle} ->
-        bundle = Repo.preload(bundle, commands: [rules: [permissions: :namespace]])
+        bundle = Repo.preload(bundle, [commands: [rules: [permissions: :namespace]], namespace: [permissions: :namespace]])
         conn
         |> put_status(:created)
         |> put_resp_header("location", bundles_path(conn, :show, bundle))

--- a/web/views/bundles_view.ex
+++ b/web/views/bundles_view.ex
@@ -3,6 +3,7 @@ defmodule Cog.V1.BundlesView do
 
   alias Cog.V1.RelayGroupView
   alias Cog.V1.CommandView
+  alias Cog.V1.PermissionView
 
   def render("bundle.json", %{bundle: bundle}=params) do
     %{id: bundle.id,
@@ -14,11 +15,11 @@ defmodule Cog.V1.BundlesView do
   end
 
   def render("index.json", %{bundles: bundles}) do
-    %{bundles: render_many(bundles, __MODULE__, "bundle.json", as: :bundle, include: [:commands, :relay_groups])}
+    %{bundles: render_many(bundles, __MODULE__, "bundle.json", as: :bundle, include: [:commands, :relay_groups, :namespace])}
   end
 
   def render("show.json", %{bundle: bundle}) do
-    %{bundle: render_one(bundle, __MODULE__, "bundle.json", as: :bundle, include: [:commands, :relay_groups])}
+    %{bundle: render_one(bundle, __MODULE__, "bundle.json", as: :bundle, include: [:commands, :relay_groups, :namespace])}
   end
 
   defp render_includes(inc_fields, resource) do
@@ -45,6 +46,15 @@ defmodule Cog.V1.BundlesView do
     case Ecto.assoc_loaded?(value) do
       true ->
         {:relay_groups, render_many(value, RelayGroupView, "relay_group.json", as: :relay_group)}
+      false ->
+        nil
+    end
+  end
+  defp render_include(:namespace, bundle) do
+    namespace = Map.fetch!(bundle, :namespace)
+    case Ecto.assoc_loaded?(namespace) do
+      true ->
+        {:permissions, render_many(namespace.permissions, PermissionView, "permission.json", as: :permission, include: [:namespace])}
       false ->
         nil
     end


### PR DESCRIPTION
Include all the possible permissions in a bundle and not only the permissions used in the bundle rules.

Connected to https://github.com/operable/cog/issues/540