### PR TITLE
allow a relay to be created with a user-defined ID

### DIFF
--- a/lib/cog/models/relay.ex
+++ b/lib/cog/models/relay.ex
@@ -24,9 +24,22 @@ defmodule Cog.Models.Relay do
     model
     |> Repo.preload(:groups)
     |> cast(params, @required_fields, @optional_fields)
+    |> allow_user_defined_id_on_insert(params)
     |> validate_presence_on_insert(:token)
     |> encode_token
     |> unique_constraint(:name)
+  end
+
+  def allow_user_defined_id_on_insert(changeset, params) do
+    case {get_field(changeset, :id), Map.get(params, "id")} do
+      {_, nil} ->
+        changeset
+      {nil, _} ->
+        changeset |> cast(params, [], [:id])
+      _ ->
+        changeset
+        |> add_error(:id, "cannot modify ID")
+    end
   end
 
   def validate_presence_on_insert(changeset, :token) do

--- a/lib/cog/models/relay.ex
+++ b/lib/cog/models/relay.ex
@@ -18,24 +18,24 @@ defmodule Cog.Models.Relay do
   end
 
   @required_fields ~w(name)
-  @optional_fields ~w(token enabled description)
+  @optional_fields ~w(id token enabled description)
 
   def changeset(model, params \\ :empty) do
     model
     |> Repo.preload(:groups)
     |> cast(params, @required_fields, @optional_fields)
-    |> allow_user_defined_id_on_insert(params)
+    |> allow_user_defined_id_on_insert
     |> validate_presence_on_insert(:token)
     |> encode_token
     |> unique_constraint(:name)
   end
 
-  def allow_user_defined_id_on_insert(changeset, params) do
-    case {get_field(changeset, :id), Map.get(params, "id")} do
-      {_, nil} ->
+  def allow_user_defined_id_on_insert(changeset) do
+    case {Map.get(changeset.model, :id), get_field(changeset, :id)} do
+      {nil, _changed_id} ->
         changeset
-      {nil, _} ->
-        changeset |> cast(params, [], [:id])
+      {id, id} ->
+        changeset
       _ ->
         changeset
         |> add_error(:id, "cannot modify ID")


### PR DESCRIPTION
Currently Relays require an ID to be set at startup time, but that ID is not known until after the Relay resource is created on Cog. This change allows the ID for a Relay to be included in the API call for the initial relay creation, which will make it easier for users to bootstrap an entire Cog cluster from scratch since a relay ID can be defined by the user in advance..

* Allow `POST /v1/relays` to include an ID. 
* Add tests to ensure that we don't allow the ID to be changed after create.