### PR TITLE
Rename trigger_timeout_buffer config flag

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -137,7 +137,8 @@ config :cog, :token_reap_period, {1, :day}
 # requestor, which includes network roundtrip time, as well as Cog's
 # internal processing. Cog itself can't wait that long to respond, as
 # that'll be guaranteed to exceed the HTTP requestor's timeout. As
-# such, we'll incorporate a buffer into our internal timeout.
-config :cog, :trigger_timeout_buffer_sec, (System.get_env("COG_TRIGGER_TIMEOUT_SLACK_SEC") || 2)
+# such, we'll incorporate a buffer into our internal timeout. Defined
+# as seconds
+config :cog, :trigger_timeout_buffer, (System.get_env("COG_TRIGGER_TIMEOUT_BUFFER") || 2)
 
 import_config "#{Mix.env}.exs"

--- a/test/controllers/v1/trigger_execution_controller_test.exs
+++ b/test/controllers/v1/trigger_execution_controller_test.exs
@@ -305,8 +305,8 @@ defmodule Cog.V1.TriggerExecutionControllerTest do
   ########################################################################
 
   defp set_timeout_buffer(new_buffer) do
-    old_buffer = Application.get_env(:cog, :trigger_timeout_buffer_sec)
-    on_exit(fn() -> Application.put_env(:cog, :trigger_timeout_buffer_sec, old_buffer) end)
-    Application.put_env(:cog, :trigger_timeout_buffer_sec, new_buffer)
+    old_buffer = Application.get_env(:cog, :trigger_timeout_buffer)
+    on_exit(fn() -> Application.put_env(:cog, :trigger_timeout_buffer, old_buffer) end)
+    Application.put_env(:cog, :trigger_timeout_buffer, new_buffer)
   end
 end

--- a/web/controllers/v1/trigger_execution_controller.ex
+++ b/web/controllers/v1/trigger_execution_controller.ex
@@ -165,7 +165,7 @@ defmodule Cog.V1.TriggerExecutionController do
   ########################################################################
 
   defp computed_timeout(%Trigger{timeout_sec: timeout_sec}) do
-    case Application.get_env(:cog, :trigger_timeout_buffer_sec) do
+    case Application.get_env(:cog, :trigger_timeout_buffer) do
       slack when slack <= timeout_sec ->
         (timeout_sec - slack) * 1000
       _ ->


### PR DESCRIPTION
Noticed we still had an environment variable named `"SLACK"` and not
`"BUFFER"`. Also removed the `_sec` suffix.