### PR TITLE
Hardcode and comment out extra env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,36 +4,28 @@
 # The following variables must be set in the shell that docker-compose
 # is executed from:
 #
-# POSTGRES_USER, POSTGRES_PASSWORD, SLACK_API_TOKEN
-#
-# In addition, a TAG variable may be defined. If present, it will be appended
-# to the Docker image names that are used for Cog and Relay. It should begin
-# with a colon (:), i.e. TAG=:0.2.1-dev
-#
-# $ docker-compose up
-#
+# SLACK_API_TOKEN
 
 postgres:
   image: postgres:9.5
-  environment:
-    - POSTGRES_USER=${POSTGRES_USER}
-    - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+  # environment:
+  #   - POSTGRES_USER=${POSTGRES_USER}
+  #   - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
 cog:
-  image: operable/cog${TAG}
+  image: 2ba2e73c6b43
   environment:
     - COG_MQTT_HOST=0.0.0.0
-    - DATABASE_URL=ecto://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/cog
-    - COG_ADAPTER=${COG_ADAPTER}
+    - DATABASE_URL=ecto://postgres:@localhost:5432/cog
+    - COG_ADAPTER=slack
     - SLACK_API_TOKEN=${SLACK_API_TOKEN}
-    - HIPCHAT_API_TOKEN=${HIPCHAT_API_TOKEN}
-    - HIPCHAT_MENTION_NAME=${HIPCHAT_MENTION_NAME}
-    - HIPCHAT_XMPP_NICKNAME=${HIPCHAT_XMPP_NICKNAME}
-    - HIPCHAT_XMPP_SERVER=${HIPCHAT_XMPP_SERVER}
-    - HIPCHAT_XMPP_ROOMS=${HIPCHAT_XMPP_ROOMS}
-    - HIPCHAT_XMPP_PORT=${HIPCHAT_XMPP_PORT}
-    - HIPCHAT_XMPP_JID=${HIPCHAT_XMPP_JID}
-    - HIPCHAT_XMPP_PASSWORD=${HIPCHAT_XMPP_PASSWORD}
-    - ERL_FLAGS=-smp enable
+    # - HIPCHAT_API_TOKEN=${HIPCHAT_API_TOKEN}
+    # - HIPCHAT_MENTION_NAME=${HIPCHAT_MENTION_NAME}
+    # - HIPCHAT_XMPP_NICKNAME=${HIPCHAT_XMPP_NICKNAME}
+    # - HIPCHAT_XMPP_SERVER=${HIPCHAT_XMPP_SERVER}
+    # - HIPCHAT_XMPP_ROOMS=${HIPCHAT_XMPP_ROOMS}
+    # - HIPCHAT_XMPP_PORT=${HIPCHAT_XMPP_PORT}
+    # - HIPCHAT_XMPP_JID=${HIPCHAT_XMPP_JID}
+    # - HIPCHAT_XMPP_PASSWORD=${HIPCHAT_XMPP_PASSWORD}
   links:
     - postgres:localhost
   ports:

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -1,5 +1,7 @@
 #!/bin/sh -x
 
+set -eo pipefail
+
 # install mix
 mix local.hex --force
 mix local.rebar --force
@@ -9,12 +11,12 @@ mix hex.info
 cd /home/operable/cog
 mix clean
 mix deps.get
-mix deps.compile
+ALLOW_WARNINGS=true mix deps.compile
 mix compile
 
 # build cogctl
 cd /home/operable/cogctl
 git clone https://github.com/operable/cogctl .
 mix deps.get
-mix deps.compile
+ALLOW_WARNINGS=true mix deps.compile
 mix escript

--- a/scripts/docker-start
+++ b/scripts/docker-start
@@ -8,7 +8,8 @@ export PATH="${PATH}:$(dirname $0)"
 echo "Waiting for Postgres to become available..."
 wait-for-it.sh -s -t 0 -h localhost -p 5432 && true
 
-echo "Apply database migrations..."
+echo "Create database and apply migrations..."
+mix ecto.create
 mix ecto.migrate --no-compile --no-deps-check
 
 echo "Launching Cog server..."


### PR DESCRIPTION
When starting up cog with docker-compose we had a lot of warnings and config that you had to worry about. Now, with this PR, you just have to set `SLACK_API_TOKEN` and you're done. All other config that you might want is currently commented out but is easy to include.

This mainly allows us to simply write `SLACK_API_TOKEN="..." docker-compose up` as the command to run in the docs.