### PR TITLE
Unregistered relays bug

### DIFF
--- a/lib/cog/relay/info.ex
+++ b/lib/cog/relay/info.ex
@@ -69,6 +69,9 @@ defmodule Cog.Relay.Info do
         respond(%{bundles: bundles}, reply_to, state)
       nil ->
         ## If we get a nil back then the relay isn't registered with Cog.
+        ## Technically we should never respond with an error, because relays
+        ## should never make it through the BusEnforcer if they aren't registered
+        ## but for completeness it's included here.
         respond(%{error: "Relay with id #{relay_id} was not recognized."}, reply_to, state)
     end
   end

--- a/lib/cog/relay/info.ex
+++ b/lib/cog/relay/info.ex
@@ -1,5 +1,15 @@
 defmodule Cog.Relay.Info do
 
+  @moduledoc """
+  Subscribes on #{@relay_info_topic} to provide info to relays
+  on request. Relays can publish the following special messages
+  on the topic:
+
+  list bundles - Returns the list of bundles assigned to the relay.
+    message: {"list_bundles": {"relay_id": <relay uuid>, "reply_to": <reply topic>}}
+    response: {"bundles": [<bundles>]}
+  """
+
   defstruct [mq_conn: nil]
 
   use Adz

--- a/lib/cog/relay/info.ex
+++ b/lib/cog/relay/info.ex
@@ -58,9 +58,8 @@ defmodule Cog.Relay.Info do
 
         respond(%{bundles: bundles}, reply_to, state)
       nil ->
-        ## If we get a nil back then the relay isn't registered with Cog, so we
-        ## ignore it.
-        :noop
+        ## If we get a nil back then the relay isn't registered with Cog.
+        respond(%{error: "Relay with id #{relay_id} was not recognized."}, reply_to, state)
     end
   end
 

--- a/lib/cog/relay/info.ex
+++ b/lib/cog/relay/info.ex
@@ -1,5 +1,7 @@
 defmodule Cog.Relay.Info do
 
+  @relay_info_topic "bot/relays/info"
+
   @moduledoc """
   Subscribes on #{@relay_info_topic} to provide info to relays
   on request. Relays can publish the following special messages
@@ -18,8 +20,6 @@ defmodule Cog.Relay.Info do
   alias Carrier.Messaging
   alias Cog.Repo
   alias Cog.Models.Relay
-
-  @relay_info_topic "bot/relays/info"
 
   def start_link do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)


### PR DESCRIPTION
If a relay wasn't registered with Cog and it requested it's list of
bundles, Cog would try to return a payload of an empty list. This
would cause Carrier to crash. Now we just ignore messages from
unregistered relays.