### PR TITLE
Include relay env on cog container

### DIFF
--- a/docker-compose-example.yml
+++ b/docker-compose-example.yml
@@ -48,6 +48,8 @@ cog:
     - COG_TRIGGER_URL_HOST=${COG_HOST}
     - COG_TRIGGER_URL_PORT=3000
     - COG_API_URL_PORT=80
+    - RELAY_ID=00000000-0000-0000-0000-000000000000
+    - RELAY_COG_TOKEN=supersecret
   links:
     - postgres:localhost
   ports:


### PR DESCRIPTION
This makes the docs easier to follow as you can copy and paste the following when creating a relay:

```
cogctl relays create default \
  --token=$RELAY_COG_TOKEN \
  --id=$RELAY_ID
```