### PR TITLE
Increase default HTTPotion timeout to 30 seconds (up from 5)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -44,6 +44,12 @@ config :cog, Cog.Adapters.IRC,
   password: System.get_env("IRC_PASSWORD"),
   use_ssl: System.get_env("IRC_USE_SSL") || true
 
+
+# Chat provider APIs may be slow to respond to requests in some cases
+# so we set a generous timeout.
+
+config :httpotion, :default_timeout, 30000
+
 # ========================================================================
 # Commands, Bundles, and Services
 


### PR DESCRIPTION
We received a report in public Slack that `cogctl chat-handles create` was failing without a timeout message. Upon further investigation, it turns out that the Slack API was taking more than 5 seconds to respond to the `users.list` API call -- in this case 9 seconds and the returned list was great than 5MB. Thanks @justinkinney for the great bug report and troubleshooting.

The path of least resistance here is to globally increase the HTTPotion timeout so we do that in `config/config.exs`.