### PR TITLE
Clean up command documentation

### DIFF
--- a/lib/cog/commands/alias.ex
+++ b/lib/cog/commands/alias.ex
@@ -6,7 +6,7 @@ defmodule Cog.Commands.Alias do
   @moduledoc """
   Manages aliases
 
-  Subcommands
+  ## Subcommands
   * new <alias-name> <alias-definition> -- creates a new alias visible to the creating user.
   * mv <alias-name> <site | user>:[new-alias-name] -- moves aliases between user and site visibility. Optionally renames aliases.
   * rm <alias-name> -- Removes aliases
@@ -14,23 +14,23 @@ defmodule Cog.Commands.Alias do
 
   ## Example
 
-    @bot #{Cog.embedded_bundle}:alias new my-awesome-alias "echo \"My Awesome Alias\""
-    > user:my-awesome-alias has been created
+      @bot #{Cog.embedded_bundle}:alias new my-awesome-alias "echo \"My Awesome Alias\""
+      > user:my-awesome-alias has been created
 
-    @bot #{Cog.embedded_bundle}:alias mv my-awesome-alias site:awesome-alias
-    > Moved user:my-awesome-alias to site:awesome-alias
+      @bot #{Cog.embedded_bundle}:alias mv my-awesome-alias site:awesome-alias
+      > Moved user:my-awesome-alias to site:awesome-alias
 
-    @bot #{Cog.embedded_bundle}:alias rm awesome-alias
-    > Removed site:awesome-alias
+      @bot #{Cog.embedded_bundle}:alias rm awesome-alias
+      > Removed site:awesome-alias
 
-    @bot #{Cog.embedded_bundle}:alias ls
-    > Name: 'my-awesome-alias'
-      Visibility: 'user'
-      Pipeline: 'echo my-awesome-alias'
+      @bot #{Cog.embedded_bundle}:alias ls
+      > Name: 'my-awesome-alias'
+        Visibility: 'user'
+        Pipeline: 'echo my-awesome-alias'
 
-      Name: 'my-other-awesome-alias'
-      Visibility: 'site'
-      Pipeline: 'echo my-other-awesome-alias'
+        Name: 'my-other-awesome-alias'
+        Visibility: 'site'
+        Pipeline: 'echo my-other-awesome-alias'
   """
 
   def handle_message(req, state) do

--- a/lib/cog/commands/filter.ex
+++ b/lib/cog/commands/filter.ex
@@ -12,12 +12,15 @@ defmodule Cog.Commands.Filter do
       > { "id": "91edb472-04cf-4bca-ba05-e51b63f26758",
           "rule": "operable:manage_users",
           "command": "operable:permissions" }
+
       @bot #{Cog.embedded_bundle}:seed --list --for-command="#{Cog.embedded_bundle}:permissions" | #{Cog.embedded_bundle}:filter --path="rule" --matches="/manage_users/"
       > { "id": "91edb472-04cf-4bca-ba05-e51b63f26758",
           "rule": "operable:manage_users",
           "command": "operable:permissions" }
+
       @bot #{Cog.embedded_bundle}:seed '[{"foo":{"bar.qux":{"baz":"stuff"}}}, {"foo": {"bar":{"baz":"me"}}}]' | #{Cog.embedded_bundle}:filter --path="foo.bar.baz""
       > [ {"foo": {"bar.qux": {"baz": "stuff"} } }, {"foo": {"bar": {"baz": "me"} } } ]
+
       @bot #{Cog.embedded_bundle}:seed '[{"foo":{"bar.qux":{"baz":"stuff"}}}, {"foo": {"bar":{"baz":"me"}}}]' | #{Cog.embedded_bundle}:filter --path="foo.\\"bar.qux\\".baz""
       > { "foo": {"bar.qux": {"baz": "stuff"} } }
 

--- a/lib/cog/commands/group.ex
+++ b/lib/cog/commands/group.ex
@@ -2,19 +2,22 @@ defmodule Cog.Commands.Group do
   @moduledoc """
   This command allows the user to manage groups of users.
 
-  Usage:
+  ## Usage
+
       group --create <groupname>
       group --drop <groupname>
       group --add --user=<username> <groupname>
       group --remove --user=<username> <groupname>
       group --list
-  Examples:
-  > @bot operable:group --create ops
-  > @bot operable:group --create engineering
-  > @bot operable:group --add --user=bob ops
-  > @bot operable:group --remove --user=bob ops
-  > @bot operable:group --drop ops
-  > @bot operable:group --list
+
+  ## Example
+
+      @bot operable:group --create ops
+      @bot operable:group --create engineering
+      @bot operable:group --add --user=bob ops
+      @bot operable:group --remove --user=bob ops
+      @bot operable:group --drop ops
+      @bot operable:group --list
   """
   use Spanner.GenCommand.Base, bundle: Cog.embedded_bundle
 

--- a/lib/cog/commands/help.ex
+++ b/lib/cog/commands/help.ex
@@ -4,10 +4,12 @@ defmodule Cog.Commands.Help do
   @moduledoc """
   Get help on all installed Cog bot commands.
 
-    * `@bot #{Cog.embedded_bundle}:help` - list all enabled commands
-    * `@bot #{Cog.embedded_bundle}:help --disabled` - list all disabled commands
-    * `@bot #{Cog.embedded_bundle}:help --all` - list all known commands, enabled and disabled
-    * `@bot #{Cog.embedded_bundle}:help "#{Cog.embedded_bundle}:help"` - list help for a specific command
+  ## Example
+
+      @bot #{Cog.embedded_bundle}:help - list all enabled commands
+      @bot #{Cog.embedded_bundle}:help --disabled - list all disabled commands
+      @bot #{Cog.embedded_bundle}:help --all - list all known commands, enabled and disabled
+      @bot #{Cog.embedded_bundle}:help "#{Cog.embedded_bundle}:help" - list help for a specific command
 
   """
 

--- a/lib/cog/commands/max.ex
+++ b/lib/cog/commands/max.ex
@@ -3,10 +3,11 @@ defmodule Cog.Commands.Max do
   This command allows the user to determine the maximum value given a
   list of inputs.
 
-  Examples:
-  > @bot operable:max 49 9 2 2
-  > @bot operable:max 0.48 0.2 1.8 3548.4 0.078
-  > @bot operable:max "apple" "ball" "car" "zebra"
+  ## Example
+
+      @bot operable:max 49 9 2 2
+      @bot operable:max 0.48 0.2 1.8 3548.4 0.078
+      @bot operable:max "apple" "ball" "car" "zebra"
   """
   use Spanner.GenCommand.Base, bundle: Cog.embedded_bundle, enforcing: false
   require Logger

--- a/lib/cog/commands/min.ex
+++ b/lib/cog/commands/min.ex
@@ -3,10 +3,11 @@ defmodule Cog.Commands.Min do
   This command allows the user to determine the minimum value given a
   list of inputs.
 
-  Examples:
-  > @bot operable:min 49 9 2 2
-  > @bot operable:min 0.48 0.2 1.8 3548.4 0.078
-  > @bot operable:min "apple" "ball" "car" "zebra"
+  ## Example
+
+      @bot operable:min 49 9 2 2
+      @bot operable:min 0.48 0.2 1.8 3548.4 0.078
+      @bot operable:min "apple" "ball" "car" "zebra"
   """
   use Spanner.GenCommand.Base, bundle: Cog.embedded_bundle, enforcing: false
   require Logger

--- a/lib/cog/commands/permissions.ex
+++ b/lib/cog/commands/permissions.ex
@@ -7,7 +7,7 @@ defmodule Cog.Commands.Permissions do
   * List all permissions in the system
   * Grant and revoke permissions from roles.
 
-  Format:
+  ## Format
 
       --list
       --create --permission=site:<name>
@@ -15,13 +15,13 @@ defmodule Cog.Commands.Permissions do
       --grant --permission=<namespace>:<permission> --role=<name>"
       --revoke --permission=<namespace>:<permission> --role=<name>"
 
-  Examples:
+  ## Example
 
-  > !#{Cog.embedded_bundle}:permissions --list
-  > !#{Cog.embedded_bundle}:permissions --create --permission=site:admin
-  > !#{Cog.embedded_bundle}:permissions --delete --permission=site:admin
-  > !#{Cog.embedded_bundle}:permissions --grant --role=dev --permission=site:write
-  > !#{Cog.embedded_bundle}:permissions --revoke --role=dev --permission=giphy:giphy
+      @bot #{Cog.embedded_bundle}:permissions --list
+      @bot #{Cog.embedded_bundle}:permissions --create --permission=site:admin
+      @bot #{Cog.embedded_bundle}:permissions --delete --permission=site:admin
+      @bot #{Cog.embedded_bundle}:permissions --grant --role=dev --permission=site:write
+      @bot #{Cog.embedded_bundle}:permissions --revoke --role=dev --permission=giphy:giphy
 
   """
   use Spanner.GenCommand.Base, bundle: Cog.embedded_bundle

--- a/lib/cog/commands/raw.ex
+++ b/lib/cog/commands/raw.ex
@@ -14,7 +14,7 @@ defmodule Cog.Command.Raw do
 
   Also useful as a debugging tool for command authors.
 
-  Example:
+  ## Example
 
       @bot #{Cog.embedded_bundle}:echo foo | #{Cog.embedded_bundle}:raw
       > {

--- a/lib/cog/commands/role.ex
+++ b/lib/cog/commands/role.ex
@@ -2,18 +2,21 @@ defmodule Cog.Commands.Role do
   @moduledoc """
   This command allows the user to manage roles.
 
-  Usage:
+  ## Usage
+
       role --create <rolename>
       role --drop <rolename>
       role --grant --group=<groupname> <rolename>
       role --revoke --group=<groupname> <rolename>
       role --list
-  Examples:
-  > @bot operable:role --create deployment
-  > @bot operable:role --grant --group=ops deployment
-  > @bot operable:role --revoke --group=ops deployment
-  > @bot operable:role --drop deployment
-  > @bot operable:role --list
+
+  ## Example
+
+      @bot operable:role --create deployment
+      @bot operable:role --grant --group=ops deployment
+      @bot operable:role --revoke --group=ops deployment
+      @bot operable:role --drop deployment
+      @bot operable:role --list
   """
   use Spanner.GenCommand.Base, bundle: Cog.embedded_bundle
 

--- a/lib/cog/commands/rules.ex
+++ b/lib/cog/commands/rules.ex
@@ -2,16 +2,17 @@ defmodule Cog.Commands.Rules do
   @moduledoc """
   This command allows the user to manage rules for commands.
 
-  Format:
-    Rules -
+  ## Format
+
       rules --add "when command is <full_command_name> must have <namespace>:<permission>"
       rules --add --for-command=<full_command_name> --permission=<namespace>:<permission>
       rules --list --for-command=<full_command_name>
       rules --drop --for-command=<full_command_name>
       rules --drop --id=<rule_id>
 
-  Examples:
-  > @bot operable:rules --add "when command is operable:ec2-terminate must have operable:ec2"
+  ## Example
+
+      @bot operable:rules --add "when command is operable:ec2-terminate must have operable:ec2"
   """
   use Spanner.GenCommand.Base, bundle: Cog.embedded_bundle
 

--- a/lib/cog/commands/seed.ex
+++ b/lib/cog/commands/seed.ex
@@ -16,7 +16,7 @@ defmodule Cog.Command.Seed do
 
   Best used for debugging and experimentation.
 
-  Examples:
+  ## Example
 
       !seed '{"thing":"stuff"}' | echo $thing
       > stuff

--- a/lib/cog/commands/sleep.ex
+++ b/lib/cog/commands/sleep.ex
@@ -15,7 +15,7 @@ defmodule Cog.Commands.Sleep do
 
   Currently useful mainly for debugging purposes.
 
-  Example:
+  ## Example
 
       !echo "Get up and stretch" | sleep 10 | echo $body > me`
 

--- a/lib/cog/commands/sort.ex
+++ b/lib/cog/commands/sort.ex
@@ -4,7 +4,8 @@ defmodule Cog.Commands.Sort do
   @moduledoc """
   Sorts the given inputs.
 
-  Examples
+  ## Example
+
       @bot #{Cog.embedded_bundle}:sort 3 2 1 5 4
       > [1, 2, 3, 4, 5]
       @bot #{Cog.embedded_bundle}:sort --asc 4.5 1.8 0.032 0.6 1.5 0.4
@@ -13,20 +14,20 @@ defmodule Cog.Commands.Sort do
       > [what, we, us, to, to, react, percent, it, is, how, happens, and, Life, %, 90, 10]
       @bot #{Cog.embedded_bundle}:rules --for-command=rules| sort --field=rule
       > {
-  "rule": "when command is operable:permissions with option[user] == /.*/ must have operable:manage_users",
-  "id": "12345678-abcd-efgh-ijkl-0987654321ab",
-  "command": "operable:permissions"
-}
-{
-  "rule": "when command is operable:permissions with option[role] == /.*/ must have operable:manage_roles",
-  "id": "87654321-mnop-qrst-uvwx-0123456789ab",
-  "command": "operable:permissions"
-}
-{
-  "rule": "when command is operable:permissions with option[group] == /.*/ must have operable:manage_groups",
-  "id": "24680135-azby-cxdw-evfu-ab0123456789",
-  "command": "operable:permissions"
-}
+          "rule": "when command is operable:permissions with option[user] == /.*/ must have operable:manage_users",
+          "id": "12345678-abcd-efgh-ijkl-0987654321ab",
+          "command": "operable:permissions"
+        }
+        {
+          "rule": "when command is operable:permissions with option[role] == /.*/ must have operable:manage_roles",
+          "id": "87654321-mnop-qrst-uvwx-0123456789ab",
+          "command": "operable:permissions"
+        }
+        {
+          "rule": "when command is operable:permissions with option[group] == /.*/ must have operable:manage_groups",
+          "id": "24680135-azby-cxdw-evfu-ab0123456789",
+          "command": "operable:permissions"
+        }
   """
   option "asc", type: "bool", required: false
   option "desc", type: "bool", required: false

--- a/lib/cog/commands/sum.ex
+++ b/lib/cog/commands/sum.ex
@@ -2,10 +2,11 @@ defmodule Cog.Commands.Sum do
   @moduledoc """
   This command allows the user to sum together a list of numbers
 
-  Examples:
-  > @bot operable:sum 2 2
-  > @bot operable:sum 2 "-9"
-  > @bot operable:sum 2 24 57 3.7 226.78
+  ## Example
+
+      @bot operable:sum 2 2
+      @bot operable:sum 2 "-9"
+      @bot operable:sum 2 24 57 3.7 226.78
   """
   use Spanner.GenCommand.Base, bundle: Cog.embedded_bundle, enforcing: false
   require Logger

--- a/lib/cog/commands/thorn.ex
+++ b/lib/cog/commands/thorn.ex
@@ -2,8 +2,9 @@ defmodule Cog.Commands.Thorn do
   @moduledoc """
   This command replaces `Th` following a word boundary with þ
 
-  Examples:
-  > @bot operable:thorn foo-Thbar-Thbaz
+  ## Example
+
+      @bot operable:thorn foo-Thbar-Thbaz
   """
   use Spanner.GenCommand.Base, bundle: Cog.embedded_bundle, enforcing: false
 

--- a/lib/cog/commands/unique.ex
+++ b/lib/cog/commands/unique.ex
@@ -2,9 +2,10 @@ defmodule Cog.Commands.Unique do
   @moduledoc """
   This command returns unique values given list of inputs
 
-  Examples:
-  > @bot operable:unique 49.3 9 2 2 42 49.3
-  > @bot operable:unique "apple" "apple" "ball" "car" "car" "zebra"
+  ## Example
+
+      @bot operable:unique 49.3 9 2 2 42 49.3
+      @bot operable:unique "apple" "apple" "ball" "car" "car" "zebra"
   """
   use Spanner.GenCommand.Base, bundle: Cog.embedded_bundle, enforcing: false, execution: :once
 

--- a/lib/cog/commands/wc.ex
+++ b/lib/cog/commands/wc.ex
@@ -1,13 +1,15 @@
 defmodule Cog.Commands.Wc do
   @moduledoc """
   This command allows the user to count the number of words or lines in the input string.
-    wc [--words | --lines]  <input string>
 
-  Examples:
-  > @bot wc --words "Hey, what will we do today?"
-  > @bot wc --lines "From time to time
-  The clouds give rest
-  To the moon-beholders."
+      wc [--words | --lines]  <input string>
+
+  ## Example
+
+      > @bot wc --words "Hey, what will we do today?"
+      > @bot wc --lines "From time to time
+      The clouds give rest
+      To the moon-beholders."
   """
   use Spanner.GenCommand.Base, bundle: Cog.embedded_bundle, enforcing: false
   alias Spanner.Command.Request

--- a/lib/cog/commands/which.ex
+++ b/lib/cog/commands/which.ex
@@ -18,14 +18,14 @@ defmodule Cog.Commands.Which do
 
   ## Example
 
-    @bot #{Cog.embedded_bundle}:which my-awesome-alias
-    > alias - user:my-awesome-alias -> "echo my awesome alias"
+      @bot #{Cog.embedded_bundle}:which my-awesome-alias
+      > alias - user:my-awesome-alias -> "echo my awesome alias"
 
-    @bot #{Cog.embedded_bundle}:which an-awesome-command
-    > command - operable:an-awesome-command
+      @bot #{Cog.embedded_bundle}:which an-awesome-command
+      > command - operable:an-awesome-command
 
-    @bot #{Cog.embedded_bundle}:which not-anything
-    > No matching commands or aliases.
+      @bot #{Cog.embedded_bundle}:which not-anything
+      > No matching commands or aliases.
   """
 
   def handle_message(req, state) do


### PR DESCRIPTION
Fixes indentation for markdown rendering and makes the headers and
formatting more consistent.