### PR TITLE
Wait until DB responds after processing bundle announcement

### DIFF
--- a/lib/cog/bundle/embedded.ex
+++ b/lib/cog/bundle/embedded.ex
@@ -60,7 +60,7 @@ defmodule Cog.Bundle.Embedded do
                                 "online" => true,
                                 "snapshot" => true,
                                 "bundles" => [bundle]}}
-    :ok = GenServer.call(Cog.Relay.Relays, {:announce_embedded_relay, message})
+    :ok = GenServer.call(Cog.Relay.Relays, {:announce_embedded_relay, message}, :infinity)
   end
 
   defp embedded_bundle do


### PR DESCRIPTION
Prevents a non-obvious failure at startup if the database is slow to respond.