### PR TITLE
Add /v1/users/me route

### DIFF
--- a/test/controllers/v1/user_controller_test.exs
+++ b/test/controllers/v1/user_controller_test.exs
@@ -49,6 +49,16 @@ defmodule Cog.V1.UserControllerTest do
               "username" => "sadpanda"}] == users_json |> sort_by("username")
   end
 
+  test "shows the authed user's resource", %{authed: requestor} do
+    conn = api_request(requestor, :get, "/v1/users/me")
+    assert %{"user" => %{"id" => requestor.id,
+                         "username" => requestor.username,
+                         "first_name" => requestor.first_name,
+                         "last_name" => requestor.last_name,
+                         "groups" => [],
+                         "email_address" => requestor.email_address}} == json_response(conn, 200)
+  end
+
   test "shows chosen resource", %{authed: requestor} do
     user = user("tester")
     conn = api_request(requestor, :get, "/v1/users/#{user.id}")

--- a/web/controllers/v1/user_controller.ex
+++ b/web/controllers/v1/user_controller.ex
@@ -37,6 +37,10 @@ defmodule Cog.V1.UserController do
     end
   end
 
+  def show(conn, %{"id" => "me"}) do
+    show(conn, %{"id" => conn.assigns.user.id})
+  end
+
   def show(conn, %{"id" => id}) do
     user = Repo.get!(User, id)
     |> Repo.preload([direct_group_memberships: [roles: [permissions: :namespace]]])
@@ -84,7 +88,8 @@ defmodule Cog.V1.UserController do
   @spec self_updating?(%Plug.Conn{}) :: true | false
   defp self_updating?(conn) do
     conn.private.phoenix_action in [:update, :show] and
-        conn.assigns.user.id == conn.params["id"]
+      conn.assigns.user.id == conn.params["id"] or
+      conn.params["id"] == "me"
   end
 
 end


### PR DESCRIPTION
This adds a `/v1/users/me` route to return a standard user resource for the user associated with the token that was used to make the API call. This is helpful since the user may not know their UUID in advance, so it's difficult to make use of the existing `/v1/users/:id` route.