### PR TITLE
Changed invalid config message to just "Invalid config."

### DIFF
--- a/web/controllers/v1/bundles_controller.ex
+++ b/web/controllers/v1/bundles_controller.ex
@@ -139,7 +139,7 @@ defmodule Cog.V1.BundlesController do
   end
 
   defp error(:no_config) do
-    {:bad_request, %{error: "'bundle_config' not specified. Make sure to use a multipart form and to send your file in the 'bundle_config' field."}}
+    {:bad_request, %{error: "Missing bundle config."}}
   end
   defp error(:unsupported_format) do
     msg = ~s(Unsupported file format. Please upload a file in one of the following formats: #{Enum.join(Spanner.Config.config_extensions, ", ")})


### PR DESCRIPTION
The message about the config file didn't make sense anymore, since you
can either send a file or pass the config directly.