### PR TITLE
Deal with existing state when starting a memory service

### DIFF
--- a/lib/cog/command/service/memory.ex
+++ b/lib/cog/command/service/memory.ex
@@ -145,7 +145,7 @@ defmodule Cog.Command.Service.Memory do
   end
 
   defp schedule_dead_process_cleanup(interval) do
-    Logger.info ("Scheduling dead process cleanup for #{round(interval / 1000)} from now")
+    Logger.info ("Scheduling dead process cleanup for #{round(interval / 1000)} seconds from now")
     Process.send_after(self(), :dead_process_cleanup, interval)
   end
 

--- a/lib/cog/command/service/memory.ex
+++ b/lib/cog/command/service/memory.ex
@@ -110,12 +110,9 @@ defmodule Cog.Command.Service.Memory do
   end
 
   def handle_info({:DOWN, _monitor_ref, :process, pid, reason}, state) do
-    Logger.debug("Process #{inspect pid} went down (#{inspect reason}); removing its memory storage")
-
     case ets_lookup(state.monitor_table, pid) do
       {:ok, token} ->
-        :ets.match_delete(state.memory_table, {{token, :_}, :_})
-        :ets.delete(state.monitor_table, pid)
+        cleanup_process(state.monitor_table, state.memory_table, pid, token)
       {:error, :unknown_key} ->
         Logger.warn("Unknown pid #{inspect pid} was monitored; ignoring")
     end

--- a/lib/cog/command/service/memory.ex
+++ b/lib/cog/command/service/memory.ex
@@ -109,7 +109,7 @@ defmodule Cog.Command.Service.Memory do
     {:reply, result, state}
   end
 
-  def handle_info({:DOWN, _monitor_ref, :process, pid, reason}, state) do
+  def handle_info({:DOWN, _monitor_ref, :process, pid, _reason}, state) do
     case ets_lookup(state.monitor_table, pid) do
       {:ok, token} ->
         cleanup_process(state.monitor_table, state.memory_table, pid, token)

--- a/lib/cog/command/service_sup.ex
+++ b/lib/cog/command/service_sup.ex
@@ -8,26 +8,15 @@ defmodule Cog.Command.Service.Supervisor do
     do: Supervisor.start_link(__MODULE__, [], name: __MODULE__)
 
   def init(_) do
-    token_tid = new_token_table
-    Logger.info("Created service token table with TID #{inspect token_tid}")
+    token_table          = :ets.new(:token_table,          [:public])
+    # token_monitor_table  = :ets.new(:token_monitor_table,  [:public])
+    memory_table         = :ets.new(:memory_table,         [:public])
+    memory_monitor_table = :ets.new(:memory_monitor_table, [:public])
 
-    memory_tid = new_memory_table
-    Logger.info("Created memory service table with TID #{inspect memory_tid}")
+    children = [# worker(Service.Tokens, [token_table, token_monitor_table]),
+                worker(Service.Tokens, [token_table]),
+                worker(Service.Memory, [memory_table, memory_monitor_table])]
 
-    children = [
-      worker(Service.Tokens, [token_tid]),
-      worker(Service.Memory, [memory_tid])
-    ]
     supervise(children, strategy: :one_for_one)
   end
-
-  ########################################################################
-
-  # Create ETS table for tokens
-  defp new_token_table,
-    do: :ets.new(:token_table, [:public])
-
-  defp new_memory_table,
-    do: :ets.new(:memory_table, [:public])
-
 end

--- a/test/cog/command/service/memory_test.exs
+++ b/test/cog/command/service/memory_test.exs
@@ -23,10 +23,6 @@ defmodule Cog.Command.Service.MemoryTest do
 
     {:ok, pid} = Memory.start_link(memory_table, monitor_table)
 
-    on_exit(fn ->
-      Process.exit(pid, :kill)
-    end)
-
     {:ok, %{pid: pid, memory_table: memory_table, monitor_table: monitor_table}}
   end
 


### PR DESCRIPTION
* Remonitor or delete related data for existing processes on init
* Periodically check all keys and remove anything that could have snuck in between process restarts