### PR TITLE
Tweak transaction logic in tests

### DIFF
--- a/test/support/adapter_case.ex
+++ b/test/support/adapter_case.ex
@@ -20,8 +20,6 @@ defmodule Cog.AdapterCase do
       setup_all do
         adapter = replace_adapter(unquote(adapter))
 
-        Ecto.Adapters.SQL.begin_test_transaction(Repo)
-
         on_exit(fn ->
           Ecto.Adapters.SQL.rollback_test_transaction(Repo)
           reset_adapter(adapter)

--- a/test/support/model_case.ex
+++ b/test/support/model_case.ex
@@ -29,16 +29,6 @@ defmodule Cog.ModelCase do
     end
   end
 
-  setup_all do
-    Ecto.Adapters.SQL.begin_test_transaction(Cog.Repo)
-
-    on_exit(fn ->
-      Ecto.Adapters.SQL.rollback_test_transaction(Cog.Repo)
-    end)
-
-    :ok
-  end
-
   setup tags do
     unless tags[:async] do
       Ecto.Adapters.SQL.restart_test_transaction(Cog.Repo, [])

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,6 +2,8 @@ exclude_slack = System.get_env("TEST_SLACK") == nil
 exclude_hipchat = System.get_env("TEST_HIPCHAT") == nil
 exclude_relay = System.get_env("TEST_RELAY") == nil
 
+Ecto.Adapters.SQL.begin_test_transaction(Cog.Repo)
+
 ExVCR.Config.cassette_library_dir("test/fixtures/cassettes")
 ExVCR.Config.filter_sensitive_data("token=[^&]+", "token=xoxb-filtered-token")
 ExVCR.Config.filter_sensitive_data("Bearer .*", "Bearer filtered-token")


### PR DESCRIPTION
Current Phoenix practice seems to be starting up a test transaction in
`test_helper.exs` and strategically rolling it back in specific test
cases as required.

The tests as they currently exist run fine, but in some I'm working on
in another branch, we can run into issues if we use our `ConnCase`
without also using our `ModelCase`, since the latter actually starts a
test transaction, but the former will roll one back.