### PR TITLE
A user should have one chat handle per provider

### DIFF
--- a/priv/repo/migrations/20160502183545_unique_handle_per_provider_per_user.exs
+++ b/priv/repo/migrations/20160502183545_unique_handle_per_provider_per_user.exs
@@ -1,0 +1,8 @@
+defmodule Cog.Repo.Migrations.UniqueHandlePerProviderPerUser do
+  use Ecto.Migration
+
+  def change do
+    create unique_index(:chat_handles, [:user_id, :provider_id])
+    drop index(:chat_handles, [:user_id, :provider_id, :handle])
+  end
+end


### PR DESCRIPTION
Previously, a Cog user could actually have an unlimited number of chat
handles for a given provider (e.g., 5 different Slack handles mapping to
a single Cog user). This was an oversight that is now corrected.

There is already a unique constraint on `{provider_id, handle}`. By
replacing the constraint on `{user_id, provider_id, handle}` with the
simpler `{user_id, provider_id}`, we get the effect we want.

The controller tests were implicitly depending on the ability to
assign multiple handles to each user. They have been minimally
refactored to accommodate this index change, under the assumption that
they'll change more extensively with work for #604.