### PR TITLE
Chat handle creation is now an "upsert"

### DIFF
--- a/lib/cog/repository/chat_handles.ex
+++ b/lib/cog/repository/chat_handles.ex
@@ -20,7 +20,7 @@ defmodule Cog.Repository.ChatHandles do
           result = user_id
           |> find_handle_for(provider_name)
           |> ChatHandle.changeset(params)
-          |> upsert
+          |> Repo.insert_or_update
 
           case result do
             {:ok, chat_handle} ->
@@ -54,17 +54,6 @@ defmodule Cog.Repository.ChatHandles do
     join: p in assoc(ch, :chat_provider),
     where: ch.user_id == ^user_id,
     where: p.name == ^provider_name
-  end
-
-  # TODO: When we can do database upserts, let's actually do a real
-  # one here
-  defp upsert(changeset) do
-    if changeset.model.id == nil do
-      # NOTE: for Ecto 2.0, it will be `data`, not `model`
-      Repo.insert(changeset)
-    else
-      Repo.update(changeset)
-    end
   end
 
   # We track the chat provider's "internal user ID" for a given

--- a/lib/cog/repository/chat_handles.ex
+++ b/lib/cog/repository/chat_handles.ex
@@ -77,9 +77,10 @@ defmodule Cog.Repository.ChatHandles do
   # question. That is, if you're running Cog with the Slack adapter,
   # you can _only_ create or update Slack chat handles.
   defp chat_handle_params(provider_name, handle, user_id) do
+    provider_name = String.downcase(provider_name)
     {:ok, adapter} = Cog.chat_adapter_module
-    if String.downcase(provider_name) == adapter.name do
-      case Repo.get_by(ChatProvider, name: String.downcase(provider_name)) do
+    if provider_name == adapter.name do
+      case Repo.get_by(ChatProvider, name: provider_name) do
         %ChatProvider{id: provider_id} ->
           case adapter.lookup_user(handle) do
             {:ok, %{id: chat_provider_user_id}} ->

--- a/lib/cog/repository/chat_handles.ex
+++ b/lib/cog/repository/chat_handles.ex
@@ -1,0 +1,101 @@
+defmodule Cog.Repository.ChatHandles do
+
+  alias Cog.Repo
+  alias Cog.Models.User
+  alias Cog.Models.ChatHandle
+  alias Cog.Models.ChatProvider
+
+  require Ecto.Query
+  import Ecto.Query, only: [from: 2]
+
+  @doc """
+  Sets the user's chat handle for the given provider. Each Cog user
+  can only have a single chat handle per provider.
+  """
+  def set_handle(%User{id: user_id}, provider_name, handle) do
+    Repo.transaction(fn() ->
+      case chat_handle_params(provider_name, handle, user_id) do
+        {:ok, params} ->
+
+          result = user_id
+          |> find_handle_for(provider_name)
+          |> ChatHandle.changeset(params)
+          |> upsert
+
+          case result do
+            {:ok, chat_handle} ->
+              Repo.preload(chat_handle, [:chat_provider, :user])
+            {:error, changeset} ->
+              Repo.rollback(changeset)
+          end
+        {:error, reason} ->
+          Repo.rollback(reason)
+      end
+    end)
+  end
+
+  ########################################################################
+
+  # As part of our "upsert" logic, we need to determine if the user
+  # already has a handle for this provider or not. If so, return it;
+  # otherwise, return an empty ChatHandle for further processing.
+  defp find_handle_for(user_id, provider_name) do
+    case Cog.Repo.one(handle_query(user_id, provider_name)) do
+      %ChatHandle{}=handle ->
+        handle
+      nil ->
+        %ChatHandle{}
+    end
+  end
+
+  # Find the one handle the user has for the provider, if any
+  defp handle_query(user_id, provider_name) do
+    from ch in ChatHandle,
+    join: p in assoc(ch, :chat_provider),
+    where: ch.user_id == ^user_id,
+    where: p.name == ^provider_name
+  end
+
+  # TODO: When we can do database upserts, let's actually do a real
+  # one here
+  defp upsert(changeset) do
+    if changeset.model.id == nil do
+      # NOTE: for Ecto 2.0, it will be `data`, not `model`
+      Repo.insert(changeset)
+    else
+      Repo.update(changeset)
+    end
+  end
+
+  # We track the chat provider's "internal user ID" for a given
+  # handle. Thus, when we create or change the handle, we need to
+  # consult the chat provider to obtain this information.
+  #
+  # One side effect of how things are currently structured is that we
+  # only allow handles to be created or edited if the currently
+  # running chat adapter is the one for the chat provider in
+  # question. That is, if you're running Cog with the Slack adapter,
+  # you can _only_ create or update Slack chat handles.
+  defp chat_handle_params(provider_name, handle, user_id) do
+    {:ok, adapter} = Cog.chat_adapter_module
+    if String.downcase(provider_name) == adapter.name do
+      case Repo.get_by(ChatProvider, name: String.downcase(provider_name)) do
+        %ChatProvider{id: provider_id} ->
+          case adapter.lookup_user(handle) do
+            {:ok, %{id: chat_provider_user_id}} ->
+              {:ok, %{"handle" => handle,
+                      "provider_id" => provider_id,
+                      "user_id" => user_id,
+                      "chat_provider_user_id" => chat_provider_user_id}}
+            {:error, _} ->
+              {:error, :invalid_handle}
+          end
+        nil ->
+          {:error, :invalid_provider}
+      end
+    else
+      {:error, :adapter_not_running}
+    end
+  end
+
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -41,9 +41,9 @@ defmodule Cog.Router do
     get "/v1/bundles/:id/status", V1.BundleStatusController, :show
     post "/v1/bundles/:id/status", V1.BundleStatusController, :manage_status
 
-    resources "/v1/chat_handles", V1.ChatHandleController, only: [:index, :update, :delete]
+    resources "/v1/chat_handles", V1.ChatHandleController, only: [:index, :delete]
     get "/v1/users/:id/chat_handles", V1.ChatHandleController, :index
-    post "/v1/users/:id/chat_handles", V1.ChatHandleController, :create
+    post "/v1/users/:id/chat_handles", V1.ChatHandleController, :upsert
 
     # Relay management
     resources "/v1/relays", V1.RelayController


### PR DESCRIPTION
Previously it was a bit awkward to know whether or not you needed to
create or update a chat handle for a user. It turns out we can simplify
things, because a user can only ever have a single chat handle for a
given chat provider. Whether the user already has a chat handle or not,
we can just say we're "setting" the chat handle and basically do an
"upsert" operation on the backend.

This removes the `PUT` operation on the chat handle controller. Now, to
both create and update a user's chat handle, send a `POST` to
`/v1/users/:id/chat_handles`.

This also puts a guard in against the situation where a user tries to
set a chat handle for a provider that differs from the
currently-configured Cog chat adapter. Previously, this would crash Cog;
now it's just an error tuple.

This also pulls this chat handle logic out of the controller and into a
chat handle "repository", in keeping with the new work to consolidate
domain functionality in the core of the system.

Fixes #604