### PR TITLE
Make dead token clean up less noisy

### DIFF
--- a/lib/cog/command/service/memory.ex
+++ b/lib/cog/command/service/memory.ex
@@ -71,6 +71,7 @@ defmodule Cog.Command.Service.Memory do
     # are still alive after a restart. If anything dies between restarting and
     # monitoring, the dead process cleanup will catch it.
     account_for_existing_pipelines(monitor_table, memory_table, &{&1, :_})
+    Logger.info ("Dead pipeline token clean up interval set to #{round(@dead_pipeline_cleanup_interval / 1000)} seconds.")
     schedule_dead_pipeline_cleanup(@dead_pipeline_cleanup_interval)
 
     state = %__MODULE__{memory_table: memory_table, monitor_table: monitor_table}

--- a/lib/cog/command/service/pipeline_monitor.ex
+++ b/lib/cog/command/service/pipeline_monitor.ex
@@ -64,7 +64,6 @@ defmodule Cog.Command.Service.PipelineMonitor do
   milliseconds in the future.
   """
   def schedule_dead_pipeline_cleanup(interval) do
-    Logger.info ("Scheduling dead process cleanup for #{round(interval / 1000)} seconds from now")
     Process.send_after(self(), :dead_process_cleanup, interval)
   end
 


### PR DESCRIPTION
I think this still logs all relevant info without making Cog logs too noisy. Since we log whenever a stale token is cleaned up we shouldn't lose any visibility.