### PR TITLE
commands with the 'allow' rule can be ran by anyone

### DIFF
--- a/lib/cog/permissions/eval/conditional_expr.ex
+++ b/lib/cog/permissions/eval/conditional_expr.ex
@@ -3,6 +3,9 @@ defimpl Cog.Eval, for: Piper.Permissions.Ast.ConditionalExpr do
   alias Cog.Eval
   alias Piper.Permissions.Ast
 
+  def value_of(%Ast.ConditionalExpr{op: :allow}, context) do
+    {true, context}
+  end
   def value_of(%Ast.ConditionalExpr{op: op, left: lhs, right: rhs}, context) do
     f = operator(op)
     {lhsv, context} = Eval.value_of(lhs, context)

--- a/lib/cog/rule_ingestion.ex
+++ b/lib/cog/rule_ingestion.ex
@@ -97,7 +97,7 @@ defmodule Cog.RuleIngestion do
       (_) -> :error
     end)
 
-    %__MODULE__{input | permissions: Map.get(grouped, :permission),
+    %__MODULE__{input | permissions: Map.get(grouped, :permission, []),
                 errors: errors ++ Map.get(grouped, :error, [])}
   end
   def validate_permissions(input),

--- a/mix.exs
+++ b/mix.exs
@@ -70,6 +70,9 @@ defmodule Cog.Mixfile do
      {:gproc, "~> 0.5.0", override: true},
      {:html_entities, "~> 0.3.0"},
      {:adz, github: "operable/adz", tag: "0.2"},
+     # Just need this until the piper branch is merged, then we can bump
+     # deps in spanner and here
+     {:piper, github: "operable/piper", branch: "peck/add-allow-keyword", override: true},
      {:spanner, github: "operable/spanner"},
      {:probe, github: "operable/probe", tag: "0.2"},
      {:exml, github: "paulgray/exml", tag: "2.2.1"},

--- a/mix.lock
+++ b/mix.lock
@@ -47,7 +47,7 @@
   "phoenix_ecto": {:hex, :phoenix_ecto, "2.0.1"},
   "phoenix_html": {:hex, :phoenix_html, "2.5.0"},
   "phoenix_live_reload": {:hex, :phoenix_live_reload, "1.0.3"},
-  "piper": {:git, "https://github.com/operable/piper.git", "6aa971e940d296d1d8e0f5be14a939b29c0706c9", []},
+  "piper": {:git, "https://github.com/operable/piper.git", "911e561221e5b306b0d14f4d8d3ebd1ad4ceb9e5", [branch: "peck/add-allow-keyword"]},
   "plug": {:hex, :plug, "1.1.2"},
   "poison": {:hex, :poison, "1.5.2"},
   "poolboy": {:hex, :poolboy, "1.5.1"},


### PR DESCRIPTION
Commands can now define an open rule, `when command is bundle:command allow`. Commands with this rule may be executed by any registered user.

depends on https://github.com/operable/piper/pull/17