### PR TITLE
change 'enforcing: false' commands to 'allowed' commands

### DIFF
--- a/lib/cog/commands/alias.ex
+++ b/lib/cog/commands/alias.ex
@@ -1,5 +1,5 @@
 defmodule Cog.Commands.Alias do
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle, enforcing: false
+  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle
   alias Cog.Commands.Alias
   alias Cog.Commands.Helpers
 
@@ -32,6 +32,8 @@ defmodule Cog.Commands.Alias do
       Visibility: 'site'
       Pipeline: 'echo my-other-awesome-alias'
   """
+
+  rule "when command is #{Cog.embedded_bundle}:alias allow"
 
   def handle_message(req, state) do
     {subcommand, args} = get_subcommand(req.args)

--- a/lib/cog/commands/echo.ex
+++ b/lib/cog/commands/echo.ex
@@ -1,5 +1,5 @@
 defmodule Cog.Commands.Echo do
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle, enforcing: false
+  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle
 
   @moduledoc """
   Repeats whatever it is passed.
@@ -10,6 +10,8 @@ defmodule Cog.Commands.Echo do
       > this if nifty
 
   """
+
+  rule "when command is #{Cog.embedded_bundle}:echo allow"
 
   def handle_message(req, state),
     do: {:reply, req.reply_to, Enum.join(req.args, " "), state}

--- a/lib/cog/commands/filter.ex
+++ b/lib/cog/commands/filter.ex
@@ -1,5 +1,5 @@
 defmodule Cog.Commands.Filter do
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle, enforcing: false
+  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle
 
   @moduledoc """
   Filters a collection where the `path` equals the `matches`.
@@ -22,6 +22,8 @@ defmodule Cog.Commands.Filter do
       > { "foo": {"bar.qux": {"baz": "stuff"} } }
 
   """
+
+  rule "when command is #{Cog.embedded_bundle}:filter allow"
 
   option "matches", type: "string", required: false
   option "path", type: "string", required: false

--- a/lib/cog/commands/greet.ex
+++ b/lib/cog/commands/greet.ex
@@ -1,5 +1,5 @@
 defmodule Cog.Commands.Greet do
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle, enforcing: false
+  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle
 
   @moduledoc """
   Introduce the bot to new coworkers!
@@ -11,6 +11,8 @@ defmodule Cog.Commands.Greet do
       > I'm Cog! I can do lots of things ...
 
   """
+
+  rule "when command is #{Cog.embedded_bundle}:greet allow"
 
   def handle_message(req, state) do
     {:reply, req.reply_to, "greet", %{greetee: List.first(req.args)}, state}

--- a/lib/cog/commands/help.ex
+++ b/lib/cog/commands/help.ex
@@ -1,5 +1,5 @@
 defmodule Cog.Commands.Help do
-  use Cog.Command.GenCommand.Base, bundle: "#{Cog.embedded_bundle}", enforcing: false
+  use Cog.Command.GenCommand.Base, bundle: "#{Cog.embedded_bundle}"
 
   @moduledoc """
   Get help on all installed Cog bot commands.
@@ -14,6 +14,8 @@ defmodule Cog.Commands.Help do
   use Cog.Models
   alias Cog.Repo
   alias Cog.Queries
+
+  rule "when command is #{Cog.embedded_bundle}:help allow"
 
   option "all", type: "bool", required: false
   option "disabled", type: "bool", required: false

--- a/lib/cog/commands/max.ex
+++ b/lib/cog/commands/max.ex
@@ -8,8 +8,10 @@ defmodule Cog.Commands.Max do
   > @bot operable:max 0.48 0.2 1.8 3548.4 0.078
   > @bot operable:max "apple" "ball" "car" "zebra"
   """
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle, enforcing: false
+  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle
   require Logger
+
+  rule "when command is #{Cog.embedded_bundle}:max allow"
 
   def handle_message(req, state) do
     max_val = Enum.max(req.args)

--- a/lib/cog/commands/min.ex
+++ b/lib/cog/commands/min.ex
@@ -8,8 +8,10 @@ defmodule Cog.Commands.Min do
   > @bot operable:min 0.48 0.2 1.8 3548.4 0.078
   > @bot operable:min "apple" "ball" "car" "zebra"
   """
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle, enforcing: false
+  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle
   require Logger
+
+  rule "when command is #{Cog.embedded_bundle}:min allow"
 
   def handle_message(req, state) do
     min_val = Enum.min(req.args)

--- a/lib/cog/commands/raw.ex
+++ b/lib/cog/commands/raw.ex
@@ -1,6 +1,5 @@
 defmodule Cog.Command.Raw do
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle,
-                               enforcing: false
+  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle
 
   alias Cog.Command.Request
 
@@ -24,6 +23,9 @@ defmodule Cog.Command.Raw do
         }
 
   """
+
+  rule "when command is #{Cog.embedded_bundle}:raw allow"
+
   def handle_message(%Request{cog_env: nil}=req, state),
     do: {:reply, req.reply_to, "nil", state}
   def handle_message(req, state),

--- a/lib/cog/commands/seed.ex
+++ b/lib/cog/commands/seed.ex
@@ -1,6 +1,5 @@
 defmodule Cog.Command.Seed do
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle,
-                               enforcing: false
+  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle
 
   alias Cog.Command.Request
   require Logger
@@ -26,6 +25,9 @@ defmodule Cog.Command.Seed do
       > more stuff
 
   """
+
+  rule "when command is #{Cog.embedded_bundle}:seed allow"
+
   def handle_message(%Request{args: [input]}=req, state) when not(is_binary(input)),
     do: {:error, req.reply_to, "Argument must be a string", state}
   def handle_message(%Request{args: [input]}=req, state) do

--- a/lib/cog/commands/sleep.ex
+++ b/lib/cog/commands/sleep.ex
@@ -1,6 +1,5 @@
 defmodule Cog.Commands.Sleep do
   use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle,
-                               enforcing: false,
                                execution: :once,
                                name: "sleep"
 
@@ -20,6 +19,8 @@ defmodule Cog.Commands.Sleep do
       !echo "Get up and stretch" | sleep 10 | echo $body > me`
 
   """
+
+  rule "when command is #{Cog.embedded_bundle}:sleep allow"
 
   alias Cog.Command.Request
 

--- a/lib/cog/commands/sort.ex
+++ b/lib/cog/commands/sort.ex
@@ -1,5 +1,5 @@
 defmodule Cog.Commands.Sort do
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle, enforcing: false, execution: :once
+  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle, execution: :once
 
   @moduledoc """
   Sorts the given inputs.
@@ -28,6 +28,9 @@ defmodule Cog.Commands.Sort do
   "command": "operable:permissions"
 }
   """
+
+  rule "when command is #{Cog.embedded_bundle}:sort allow"
+
   option "asc", type: "bool", required: false
   option "desc", type: "bool", required: false
   option "field", type: "string", required: false

--- a/lib/cog/commands/sum.ex
+++ b/lib/cog/commands/sum.ex
@@ -7,9 +7,11 @@ defmodule Cog.Commands.Sum do
   > @bot operable:sum 2 "-9"
   > @bot operable:sum 2 24 57 3.7 226.78
   """
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle, enforcing: false
+  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle
   require Logger
   import Cog.Helpers, only: [get_number: 1]
+
+  rule "when command is #{Cog.embedded_bundle}:sum allow"
 
   def handle_message(req, state) do
     {:reply, req.reply_to, %{sum: sum_list(req.args)}, state}

--- a/lib/cog/commands/table.ex
+++ b/lib/cog/commands/table.ex
@@ -1,5 +1,5 @@
 defmodule Cog.Commands.Table do
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle, enforcing: false, execution: :once
+  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle, execution: :once
   alias Cog.Formatters.Table
 
   @moduledoc """
@@ -14,6 +14,8 @@ defmodule Cog.Commands.Table do
       > How to replace a character for a newline in Vim?  920
 
   """
+
+  rule "when command is #{Cog.embedded_bundle}:table allow"
 
   option "fields", type: "list", required: true
 

--- a/lib/cog/commands/thorn.ex
+++ b/lib/cog/commands/thorn.ex
@@ -5,7 +5,9 @@ defmodule Cog.Commands.Thorn do
   Examples:
   > @bot operable:thorn foo-Thbar-Thbaz
   """
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle, enforcing: false
+  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle
+
+  rule "when command is #{Cog.embedded_bundle}:thorn allow"
 
   @upcase_thorn "Þ"
   @downcase_thorn "þ"

--- a/lib/cog/commands/unique.ex
+++ b/lib/cog/commands/unique.ex
@@ -6,7 +6,9 @@ defmodule Cog.Commands.Unique do
   > @bot operable:unique 49.3 9 2 2 42 49.3
   > @bot operable:unique "apple" "apple" "ball" "car" "car" "zebra"
   """
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle, enforcing: false, execution: :once
+  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle, execution: :once
+
+  rule "when command is #{Cog.embedded_bundle}:unique allow"
 
   def handle_message(req, state) do
     entries = get_entries(req)

--- a/lib/cog/commands/wc.ex
+++ b/lib/cog/commands/wc.ex
@@ -9,8 +9,10 @@ defmodule Cog.Commands.Wc do
   The clouds give rest
   To the moon-beholders."
   """
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle, enforcing: false
+  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle
   alias Cog.Command.Request
+
+  rule "when command is #{Cog.embedded_bundle}:wc allow"
 
   option "words", type: "bool", required: false
   option "lines", type: "bool", required: false

--- a/lib/cog/commands/which.ex
+++ b/lib/cog/commands/which.ex
@@ -1,5 +1,5 @@
 defmodule Cog.Commands.Which do
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle, enforcing: false
+  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle
   alias Cog.Commands.Helpers
   alias Cog.Models.UserCommandAlias
   alias Cog.Models.SiteCommandAlias
@@ -27,6 +27,8 @@ defmodule Cog.Commands.Which do
     @bot #{Cog.embedded_bundle}:which not-anything
     > No matching commands or aliases.
   """
+
+  rule "when command is #{Cog.embedded_bundle}:which allow"
 
   def handle_message(req, state) do
     results = with {:ok, [arg]} <- Helpers.get_args(req.args, count: 1),


### PR DESCRIPTION
The removes references to enforcing commands and adds the rule `when command is operable:<command> allow` for all our internal commands.

reference #621 