### PR TITLE
Nest chat_handles under users

### DIFF
--- a/lib/cog/queries/chat_handle.ex
+++ b/lib/cog/queries/chat_handle.ex
@@ -1,8 +1,0 @@
-defmodule Cog.Queries.ChatHandle do
-  use Cog.Queries
-
-  def for_user_id(query \\ ChatHandle, user_id) do
-    from ch in query,
-    where: ch.user_id == ^user_id
-  end
-end

--- a/test/controllers/v1/chat_handle_controller_test.exs
+++ b/test/controllers/v1/chat_handle_controller_test.exs
@@ -97,24 +97,6 @@ defmodule Cog.V1.ChatHandleControllerTest do
                                    "name" => "test"}}] == chat_handles_json
   end
 
-  @tag :create_handles
-  test "lists all entries for a specified user", params do
-    conn = api_request(params.authed, :get, "/v1/users/#{params.authed.id}/chat_handles")
-    chat_handles_json = json_response(conn, 200)["chat_handles"]
-    assert [%{"id" => params.authed_handle.id,
-              "handle" => "Cogswell",
-              "chat_provider_user_id" => "U024BE7LH",
-              "user" => %{
-                "id" => params.authed.id,
-                "email_address" => params.authed.email_address,
-                "first_name" => params.authed.first_name,
-                "last_name" => params.authed.last_name,
-                "username" => params.authed.username
-              },
-              "chat_provider" => %{"id" => params.provider.id,
-                                   "name" => "test"}}] == chat_handles_json
-  end
-
   test "deletes an entry", params do
     delete_test = ChatHandle.changeset(%ChatHandle{}, %{"handle" => "DeleteTest",
                                                         "provider_id" => params.provider.id,

--- a/test/controllers/v1/user_controller_test.exs
+++ b/test/controllers/v1/user_controller_test.exs
@@ -40,12 +40,14 @@ defmodule Cog.V1.UserControllerTest do
               "last_name" => "McCog",
               "email_address" => "cog@operable.io",
               "groups" => [],
+              "chat_handles" => [],
               "username" => "cog"},
             %{"id" => other.id,
               "first_name" => "Sadpanda",
               "last_name" => "McSadpanda",
               "email_address" => "sadpanda@operable.io",
               "groups" => [],
+              "chat_handles" => [],
               "username" => "sadpanda"}] == users_json |> sort_by("username")
   end
 
@@ -56,6 +58,7 @@ defmodule Cog.V1.UserControllerTest do
                          "first_name" => requestor.first_name,
                          "last_name" => requestor.last_name,
                          "groups" => [],
+                         "chat_handles" => [],
                          "email_address" => requestor.email_address}} == json_response(conn, 200)
   end
 
@@ -67,6 +70,26 @@ defmodule Cog.V1.UserControllerTest do
                          "first_name" => "Tester",
                          "last_name" => "McTester",
                          "groups" => [],
+                         "chat_handles" => [],
+                         "email_address" => "tester@operable.io"}} == json_response(conn, 200)
+  end
+
+  test "renders the associated chat handles", %{authed: requestor} do
+    user = user("tester") |> with_chat_handle_for("test") |> Repo.preload(:chat_handles)
+    [chat_handle] = user.chat_handles
+    conn = api_request(requestor, :get, "/v1/users/#{user.id}")
+    assert %{"user" => %{"id" => user.id,
+                         "username" => "tester",
+                         "first_name" => "Tester",
+                         "last_name" => "McTester",
+                         "groups" => [],
+                         "chat_handles" => [%{
+                            "id" => chat_handle.id,
+                            "handle" => chat_handle.handle,
+                            "chat_provider" => %{
+                              "name" => "test"
+                            },
+                         }],
                          "email_address" => "tester@operable.io"}} == json_response(conn, 200)
   end
 
@@ -95,6 +118,7 @@ defmodule Cog.V1.UserControllerTest do
                                                  "first_name" => @valid_attrs.first_name,
                                                  "email_address" => @valid_attrs.email_address,
                                                  "groups" => [],
+                                                 "chat_handles" => [],
                                                  "last_name" => @valid_attrs.last_name}
   end
 
@@ -186,6 +210,7 @@ defmodule Cog.V1.UserControllerTest do
                          "first_name" => @valid_attrs.first_name,
                          "email_address" => @valid_attrs.email_address,
                          "groups" => [],
+                         "chat_handles" => [],
                          "last_name" => @valid_attrs.last_name}
   end
 
@@ -199,6 +224,7 @@ defmodule Cog.V1.UserControllerTest do
                          "first_name" => tester.first_name,
                          "email_address" => tester.email_address,
                          "groups" => [],
+                         "chat_handles" => [],
                          "last_name" => tester.last_name}
   end
 
@@ -227,6 +253,7 @@ defmodule Cog.V1.UserControllerTest do
                                                               "namespace" => "site"}]
                             }]
                         }],
+              "chat_handles" => []
               } == user_json["user"]
   end
 

--- a/test/integration/commands/relay_group_test.exs
+++ b/test/integration/commands/relay_group_test.exs
@@ -50,7 +50,7 @@ defmodule Integration.Commands.RelayGroupTest do
   end
 
   test "deleting a relay group", %{user: user} do
-    relay_group = ModelUtilities.relay_group("relay_group")
+    ModelUtilities.relay_group("relay_group")
 
     response = send_message(user, "@bot: operable:relay-group delete relay_group")
 
@@ -62,7 +62,7 @@ defmodule Integration.Commands.RelayGroupTest do
   end
 
   test "adding relays to relay groups", %{user: user} do
-    relay_group = ModelUtilities.relay_group("relay_group")
+    ModelUtilities.relay_group("relay_group")
     relay = ModelUtilities.relay("relay", "foo")
 
     response = send_message(user, "@bot: operable:relay-group add relay_group relay")
@@ -100,7 +100,7 @@ defmodule Integration.Commands.RelayGroupTest do
   end
 
   test "assigning bundles to relay groups", %{user: user} do
-    relay_group = ModelUtilities.relay_group("relay_group")
+    ModelUtilities.relay_group("relay_group")
     bundle = ModelUtilities.bundle("bundle")
 
     response = send_message(user, "@bot: operable:relay-group assign relay_group bundle")

--- a/web/controllers/v1/chat_handle_controller.ex
+++ b/web/controllers/v1/chat_handle_controller.ex
@@ -4,7 +4,6 @@ defmodule Cog.V1.ChatHandleController do
   alias Cog.Models.EctoJson
   alias Cog.Models.ChatHandle
   alias Cog.Models.User
-  alias Cog.Queries
 
   plug Cog.Plug.Authentication
   plug Cog.Plug.Authorization, [permission: "#{Cog.embedded_bundle}:manage_users",
@@ -12,13 +11,6 @@ defmodule Cog.V1.ChatHandleController do
 
   plug :scrub_params, "chat_handle" when action in [:create, :update]
 
-  def index(conn, %{"id" => user_id}) do
-    chat_handles = Queries.ChatHandle.for_user_id(user_id)
-    |> Repo.all
-    |> Repo.preload([:chat_provider, :user])
-
-    json(conn, EctoJson.render(chat_handles, envelope: :chat_handles))
-  end
   def index(conn, _params) do
     chat_handles = ChatHandle
     |> Repo.all

--- a/web/controllers/v1/user_controller.ex
+++ b/web/controllers/v1/user_controller.ex
@@ -12,12 +12,10 @@ defmodule Cog.V1.UserController do
   # Search by username only for now
   def index(conn, %{"username" => name}) do
     user = Repo.get_by!(User, username: name)
-    |> Repo.preload([direct_group_memberships: [roles: [permissions: :namespace]]])
     render(conn, "show.json", user: user)
   end
   def index(conn, _params) do
     users = Repo.all(User)
-    |> Repo.preload([direct_group_memberships: [roles: [permissions: :namespace]]])
     render(conn, "index.json", users: users)
   end
 
@@ -26,11 +24,10 @@ defmodule Cog.V1.UserController do
 
     case Repo.insert(changeset) do
       {:ok, user} ->
-        loaded_user = Repo.preload(user, [direct_group_memberships: [roles: [permissions: :namespace]]])
         conn
         |> put_status(:created)
-        |> put_resp_header("location", user_path(conn, :show, loaded_user))
-        |> render("show.json", user: loaded_user)
+        |> put_resp_header("location", user_path(conn, :show, user))
+        |> render("show.json", user: user)
       {:error, changeset} ->
         conn
         |> put_status(:unprocessable_entity)
@@ -44,7 +41,6 @@ defmodule Cog.V1.UserController do
 
   def show(conn, %{"id" => id}) do
     user = Repo.get!(User, id)
-    |> Repo.preload([direct_group_memberships: [roles: [permissions: :namespace]]])
     render(conn, "show.json", user: user)
   end
 
@@ -54,8 +50,7 @@ defmodule Cog.V1.UserController do
 
     case Repo.update(changeset) do
       {:ok, user} ->
-        updated = Repo.preload(user, [direct_group_memberships: [roles: [permissions: :namespace]]])
-        render(conn, "show.json", user: updated)
+        render(conn, "show.json", user: user)
       {:error, changeset} ->
         conn
         |> put_status(:unprocessable_entity)
@@ -68,6 +63,5 @@ defmodule Cog.V1.UserController do
     Repo.delete!(user)
     send_resp(conn, :no_content, "")
   end
-
 end
 

--- a/web/views/chat_handle_view.ex
+++ b/web/views/chat_handle_view.ex
@@ -1,0 +1,13 @@
+defmodule Cog.V1.ChatHandleView do
+  use Cog.Web, :view
+
+  def render("show.json", %{chat_handle: chat_handle}) do
+    %{id: chat_handle.id,
+      handle: chat_handle.handle,
+      chat_provider: render_one(
+        chat_handle.chat_provider,
+        Cog.V1.ChatProviderView,
+        "show.json"
+      )}
+  end
+end

--- a/web/views/chat_provider_view.ex
+++ b/web/views/chat_provider_view.ex
@@ -1,0 +1,7 @@
+defmodule Cog.V1.ChatProviderView do
+  use Cog.Web, :view
+
+  def render("show.json", %{chat_provider: chat_provider}) do
+    %{name: chat_provider.name}
+  end
+end

--- a/web/views/user_view.ex
+++ b/web/views/user_view.ex
@@ -7,7 +7,8 @@ defmodule Cog.V1.UserView do
       first_name: user.first_name,
       last_name: user.last_name,
       email_address: user.email_address,
-      groups: render_many(user.group_memberships, __MODULE__, "member.json", as: :member)}
+      groups: render_many(user.group_memberships, __MODULE__, "member.json", as: :member),
+      chat_handles: render_many(user.chat_handles, Cog.V1.ChatHandleView, "show.json")}
   end
   def render("member.json", %{member: member}) do
     %{id: member.group.id,
@@ -21,10 +22,21 @@ defmodule Cog.V1.UserView do
   end
 
   def render("index.json", %{users: users}) do
+    users = users |> preload_associations
     %{users: render_many(users, __MODULE__, "user.json")}
   end
 
   def render("show.json", %{user: user}) do
+    user = user |> preload_associations
     %{user: render_one(user, __MODULE__, "user.json")}
+  end
+
+
+  defp preload_associations(user) do
+    Cog.Repo.preload(user, [
+      chat_handles: [:chat_provider],
+      direct_group_memberships: [roles: [permissions:
+          :namespace]]
+    ])
   end
 end


### PR DESCRIPTION
We needed a way for non-admin users to view their own chat handles. We
could have opened up chat_handle#index to the current_user, but I think
this is a more desirable option since it's a bit easier from an
implementation side in Cog, and it prevents having to make a second
request just to get the associated chat handle.