### PR TITLE
Switch sort to multi, make improvements

### DIFF
--- a/lib/cog/command/service/memory_client.ex
+++ b/lib/cog/command/service/memory_client.ex
@@ -1,0 +1,52 @@
+defmodule Cog.Command.Service.MemoryClient do
+  require HTTPotion
+
+  @service_url "/v1/services"
+  @memory_url "/memory/1.0.0"
+
+  def fetch(base_url, token, key) do
+    request(:get, base_url, token, key)
+  end
+
+  def accum(base_url, token, key, value) do
+    body = %{"op" => "accum", "value" => value}
+    request(:post, base_url, token, key, body)
+  end
+
+  def join(base_url, token, key, value) do
+    body = %{"op" => "join", "value" => value}
+    request(:post, base_url, token, key, body)
+  end
+
+  def replace(base_url, token, key, value) do
+    request(:put, base_url, token, key, value)
+  end
+
+  def delete(base_url, token, key) do
+    request(:delete, base_url, token, key)
+  end
+
+  defp request(method, base_url, token, key) when method in [:get, :delete] do
+    url = build_url(base_url, key)
+    headers = build_headers(token)
+    response = HTTPotion.request(method, url, headers: headers)
+    Poison.decode!(response.body)
+  end
+
+  defp request(method, base_url, token, key, body) when method in [:post, :put] do
+    url = build_url(base_url, key)
+    headers = build_headers(token)
+    response = HTTPotion.post(url, headers: headers, body: Poison.encode!(body))
+    Poison.decode!(response.body)
+  end
+
+  defp build_url(base_url, key) do
+    base_url <> @service_url <> @memory_url <> "/#{key}"
+  end
+
+  defp build_headers(token) do
+    ["Authorization": "pipeline #{token}",
+     "Accepts":       "application/json",
+     "Content-Type":  "application/json"]
+  end
+end


### PR DESCRIPTION
`sort` is now a multi command that uses the `COG_INVOCATION_STEP` and memory service to accumulate input and then sort and return output on the last step. I also made some improvements to how it is used by providing short flags and specifying fields as args (instead of input, as `sort` previously accepted).

Examples:

```
    @cog seed '[{"a": 1}, {"a": 3}, {"a": 2}]' | sort
    > [{"a": 1}, {"a": 2}, {"a": 3}]

    @cog seed '[{"a": 1}, {"a": 3}, {"a": 2}]' | sort --desc
    > [{"a": 3}, {"a": 2}, {"a": 1}]

    @cog seed '[{"a": 3, "b": 4}, {"a": 1, "b": 4}, {"a": 2, "b": 6}]' | sort b a
    > [{"a": 1, "b": 4}, {"a: 3, "b": 4}, {"a": 2, "b": 6}]
```