### PR TITLE
update bundles controller for config validator changes

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -70,7 +70,7 @@ defmodule Cog.Mixfile do
      {:gproc, "~> 0.5.0", override: true},
      {:html_entities, "~> 0.3.0"},
      {:adz, github: "operable/adz", tag: "0.2"},
-     {:spanner, github: "operable/spanner", branch: "peck/update-schema"},
+     {:spanner, github: "operable/spanner"},
      {:probe, github: "operable/probe", tag: "0.2"},
      {:exml, github: "paulgray/exml", tag: "2.2.1"},
      {:fumanchu, github: "operable/fumanchu"},

--- a/mix.exs
+++ b/mix.exs
@@ -70,7 +70,7 @@ defmodule Cog.Mixfile do
      {:gproc, "~> 0.5.0", override: true},
      {:html_entities, "~> 0.3.0"},
      {:adz, github: "operable/adz", tag: "0.2"},
-     {:spanner, github: "operable/spanner"},
+     {:spanner, github: "operable/spanner", branch: "peck/update-schema"},
      {:probe, github: "operable/probe", tag: "0.2"},
      {:exml, github: "paulgray/exml", tag: "2.2.1"},
      {:fumanchu, github: "operable/fumanchu"},

--- a/mix.lock
+++ b/mix.lock
@@ -56,7 +56,7 @@
   "probe": {:git, "https://github.com/operable/probe.git", "c8ebf0877651b3cc5370e3f6ca7790a277106016", [tag: "0.2"]},
   "ranch": {:hex, :ranch, "1.2.1"},
   "slack": {:git, "https://github.com/BlakeWilliams/Elixir-Slack.git", "4520d42070b2d9f4aefc97a41d2b035e8a8a46aa", []},
-  "spanner": {:git, "https://github.com/operable/spanner.git", "d24239dfa58a9e143c711b0e25ae774f7ef18da2", []},
+  "spanner": {:git, "https://github.com/operable/spanner.git", "b019af5717071879544714f9896af399c0d51579", [branch: "peck/update-schema"]},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0"},
   "uuid": {:hex, :uuid, "1.1.3"},
   "websocket_client": {:git, "https://github.com/jeremyong/websocket_client.git", "f6892c8b55004008ce2d52be7d98b156f3e34569", []},

--- a/mix.lock
+++ b/mix.lock
@@ -56,7 +56,7 @@
   "probe": {:git, "https://github.com/operable/probe.git", "c8ebf0877651b3cc5370e3f6ca7790a277106016", [tag: "0.2"]},
   "ranch": {:hex, :ranch, "1.2.1"},
   "slack": {:git, "https://github.com/BlakeWilliams/Elixir-Slack.git", "4520d42070b2d9f4aefc97a41d2b035e8a8a46aa", []},
-  "spanner": {:git, "https://github.com/operable/spanner.git", "b019af5717071879544714f9896af399c0d51579", [branch: "peck/update-schema"]},
+  "spanner": {:git, "https://github.com/operable/spanner.git", "db4225d33820563439581cf4560f0d94466e46df", [branch: "peck/update-schema"]},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0"},
   "uuid": {:hex, :uuid, "1.1.3"},
   "websocket_client": {:git, "https://github.com/jeremyong/websocket_client.git", "f6892c8b55004008ce2d52be7d98b156f3e34569", []},

--- a/mix.lock
+++ b/mix.lock
@@ -56,7 +56,7 @@
   "probe": {:git, "https://github.com/operable/probe.git", "c8ebf0877651b3cc5370e3f6ca7790a277106016", [tag: "0.2"]},
   "ranch": {:hex, :ranch, "1.2.1"},
   "slack": {:git, "https://github.com/BlakeWilliams/Elixir-Slack.git", "4520d42070b2d9f4aefc97a41d2b035e8a8a46aa", []},
-  "spanner": {:git, "https://github.com/operable/spanner.git", "db4225d33820563439581cf4560f0d94466e46df", [branch: "peck/update-schema"]},
+  "spanner": {:git, "https://github.com/operable/spanner.git", "3ff0d98af2d819071a170783965f02ff250d996f", []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0"},
   "uuid": {:hex, :uuid, "1.1.3"},
   "websocket_client": {:git, "https://github.com/jeremyong/websocket_client.git", "f6892c8b55004008ce2d52be7d98b156f3e34569", []},

--- a/test/controllers/v1/bundles_controller_test.exs
+++ b/test/controllers/v1/bundles_controller_test.exs
@@ -56,6 +56,26 @@ defmodule Cog.V1.BundlesControllerTest do
     end
   end)
 
+  test "accepts an upgradable config", %{authed: requestor} do
+    config_path = make_config_file("old_config.yaml", contents: old_config)
+    upload = %Plug.Upload{path: config_path, filename: "old_config.yaml"}
+
+    conn = api_request(requestor, :post, "/v1/bundles", body: %{bundle: %{config_file: upload}}, content_type: :multipart)
+
+    response = Poison.decode!(conn.resp_body)
+
+    warnings = get_in(response, ["warnings"])
+    bundle_id = get_in(response, ["bundle", "id"])
+    bundle = Cog.Repo.get_by(Cog.Models.Bundle, id: bundle_id)
+    config = Spanner.Config.Parser.read_from_file!(config_path)
+
+    assert conn.status == 201
+    assert bundle.name == config["name"]
+    assert warnings == [
+      "Warning near #/cog_bundle_version: Bundle config version 2 has been deprecated. Please update to version 3.",
+      "Warning near #/commands/date/enforcing: Non-enforcing commands have been deprecated. Please update your bundle config to version 3."]
+  end
+
   test "rejects a file with an improper extension", %{authed: requestor} do
     filename = "config.jpg"
 
@@ -223,6 +243,44 @@ defmodule Cog.V1.BundlesControllerTest do
             short_flag: o
         rules:
         - when command is test_bundle:date must have test_bundle:date
+      time:
+        executable: /usr/local/bin/time
+        rules:
+        - when command is test_bundle:time must have test_bundle:time
+    templates:
+      time:
+        slack: "{{time}}"
+        hipchat: "{{time}}"
+      date:
+        slack: "{{date}}"
+        hipchat: "{{date}}"
+    """
+  end
+
+  defp old_config do
+    """
+    ---
+    # Format version
+    cog_bundle_version: 2
+
+    name: test_bundle
+    version: "0.1.0"
+    permissions:
+    - test_bundle:date
+    - test_bundle:time
+    docker:
+      image: operable-bundle/test_bundle
+      tag: v0.1.0
+    commands:
+      date:
+        executable: /usr/local/bin/date
+        enforcing: false
+        options:
+          option1:
+            type: string
+            description: An option
+            required: false
+            short_flag: o
       time:
         executable: /usr/local/bin/time
         rules:

--- a/test/controllers/v1/bundles_controller_test.exs
+++ b/test/controllers/v1/bundles_controller_test.exs
@@ -202,7 +202,7 @@ defmodule Cog.V1.BundlesControllerTest do
     """
     ---
     # Format version
-    cog_bundle_version: 2
+    cog_bundle_version: 3
 
     name: test_bundle
     version: "0.1.0"

--- a/web/controllers/v1/bundles_controller.ex
+++ b/web/controllers/v1/bundles_controller.ex
@@ -42,16 +42,11 @@ defmodule Cog.V1.BundlesController do
   def create(conn, %{"bundle" => params}) do
     case install_bundle(params) do
       {:ok, bundle, warnings} ->
-        view = if length(warnings) > 0 do
-          "show_with_warnings.json"
-        else
-          "show.json"
-        end
         bundle = Repo.preload(bundle, [commands: [rules: [permissions: :namespace]], namespace: [permissions: :namespace]])
         conn
         |> put_status(:created)
         |> put_resp_header("location", bundles_path(conn, :show, bundle))
-        |> render(view, %{bundle: bundle, warnings: warnings})
+        |> render("show.json", %{bundle: bundle, warnings: warnings})
       {:error, err} ->
         send_failure(conn, err)
     end

--- a/web/controllers/v1/bundles_controller.ex
+++ b/web/controllers/v1/bundles_controller.ex
@@ -41,12 +41,17 @@ defmodule Cog.V1.BundlesController do
 
   def create(conn, %{"bundle" => params}) do
     case install_bundle(params) do
-      {:ok, bundle} ->
+      {:ok, bundle, warnings} ->
+        view = if length(warnings) > 0 do
+          "show_with_warnings.json"
+        else
+          "show.json"
+        end
         bundle = Repo.preload(bundle, [commands: [rules: [permissions: :namespace]], namespace: [permissions: :namespace]])
         conn
         |> put_status(:created)
         |> put_resp_header("location", bundles_path(conn, :show, bundle))
-        |> render("show.json", %{bundle: bundle})
+        |> render(view, %{bundle: bundle, warnings: warnings})
       {:error, err} ->
         send_failure(conn, err)
     end
@@ -59,10 +64,12 @@ defmodule Cog.V1.BundlesController do
   #### BUNDLE CREATION HELPERS ####
 
   defp install_bundle(params) do
-    with {:ok, config}       <- parse_config(params),
-         {:ok, valid_config} <- validate_config(config),
-         {:ok, params}       <- merge_config(params, valid_config),
-         do: persist(params)
+    with {:ok, config}                 <- parse_config(params),
+         {:ok, valid_config, warnings} <- validate_config(config),
+         {:ok, params}                 <- merge_config(params, valid_config),
+         {:ok, bundle}                 <- persist(params) do
+           {:ok, bundle, warnings}
+    end
   end
 
   defp parse_config(%{"config" => config}) when is_map(config) do
@@ -101,9 +108,11 @@ defmodule Cog.V1.BundlesController do
   defp validate_config(config) do
     case Config.validate(config) do
       {:ok, validated_config} ->
-        {:ok, validated_config}
-      {:error, errors} ->
-        {:error, {:validation_error, errors}}
+        {:ok, validated_config, []}
+      {:warning, validated_config, warnings} ->
+        {:ok, validated_config, warnings}
+      {:error, errors, warnings} ->
+        {:error, {:validation_error, errors, warnings}}
     end
   end
 
@@ -149,10 +158,11 @@ defmodule Cog.V1.BundlesController do
     msg = ["Unable to parse config file."]
     {:unprocessable_entity, %{errors: msg ++ errors}}
   end
-  defp error({:validation_error, errors}) do
+  defp error({:validation_error, errors, warnings}) do
     msg = ["Invalid config file."]
     errors = Enum.map(errors, fn({msg, meta}) -> ~s(Error near #{meta}: #{msg}) end)
-    {:unprocessable_entity, %{errors: msg ++ errors}}
+    warnings = Enum.map(warnings, fn({msg, meta}) -> ~s(Warning near #{meta}: #{msg}) end)
+    {:unprocessable_entity, %{errors: msg ++ errors, warnings: warnings}}
   end
   defp error({:db_error, errors}) do
     msg = ["Could not save bundle."]

--- a/web/views/bundles_view.ex
+++ b/web/views/bundles_view.ex
@@ -18,14 +18,13 @@ defmodule Cog.V1.BundlesView do
     %{bundles: render_many(bundles, __MODULE__, "bundle.json", as: :bundle, include: [:commands, :relay_groups, :namespace])}
   end
 
-  def render("show.json", %{bundle: bundle}) do
-    %{bundle: render_one(bundle, __MODULE__, "bundle.json", as: :bundle, include: [:commands, :relay_groups, :namespace])}
-  end
-
-  def render("show_with_warnings.json", %{bundle: bundle, warnings: warnings}) do
+  def render("show.json", %{bundle: bundle, warnings: warnings}) when length(warnings) > 0 do
     warnings = Enum.map(warnings, fn({msg, meta}) -> ~s(Warning near #{meta}: #{msg}) end)
     %{warnings: warnings,
       bundle: render_one(bundle, __MODULE__, "bundle.json", as: :bundle, include: [:commands, :relay_groups, :namespace])}
+  end
+  def render("show.json", %{bundle: bundle}) do
+    %{bundle: render_one(bundle, __MODULE__, "bundle.json", as: :bundle, include: [:commands, :relay_groups, :namespace])}
   end
 
   defp render_includes(inc_fields, resource) do

--- a/web/views/bundles_view.ex
+++ b/web/views/bundles_view.ex
@@ -22,6 +22,12 @@ defmodule Cog.V1.BundlesView do
     %{bundle: render_one(bundle, __MODULE__, "bundle.json", as: :bundle, include: [:commands, :relay_groups, :namespace])}
   end
 
+  def render("show_with_warnings.json", %{bundle: bundle, warnings: warnings}) do
+    warnings = Enum.map(warnings, fn({msg, meta}) -> ~s(Warning near #{meta}: #{msg}) end)
+    %{warnings: warnings,
+      bundle: render_one(bundle, __MODULE__, "bundle.json", as: :bundle, include: [:commands, :relay_groups, :namespace])}
+  end
+
   defp render_includes(inc_fields, resource) do
     Map.get(inc_fields, :include, [])
     |> Enum.reduce(%{}, fn(field, reply) ->


### PR DESCRIPTION
updates bundles controller to handle the new response signature of `Spanner.Config.validate`. Now if warnings are generated they are passed back to the user.

depends on https://github.com/operable/spanner/pull/70
reference https://github.com/operable/cog/issues/623