### PR TITLE
Partially revert "removes the thorn and greet commands"

### DIFF
--- a/lib/cog/commands/greet.ex
+++ b/lib/cog/commands/greet.ex
@@ -1,0 +1,20 @@
+defmodule Cog.Commands.Greet do
+  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle
+
+  @moduledoc """
+  Introduce the bot to new coworkers!
+
+  ## Example
+
+      @bot #{Cog.embedded_bundle}:greet @new_hire
+      > Hello @new_hire
+      > I'm Cog! I can do lots of things ...
+
+  """
+
+  rule "when command is #{Cog.embedded_bundle}:greet allow"
+
+  def handle_message(req, state) do
+    {:reply, req.reply_to, "greet", %{greetee: List.first(req.args)}, state}
+  end
+end

--- a/lib/cog/commands/thorn.ex
+++ b/lib/cog/commands/thorn.ex
@@ -1,0 +1,23 @@
+defmodule Cog.Commands.Thorn do
+  @moduledoc """
+  This command replaces `Th` following a word boundary with þ
+
+  ## Example
+
+      @bot operable:thorn foo-Thbar-Thbaz
+  """
+  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle
+
+  rule "when command is #{Cog.embedded_bundle}:thorn allow"
+
+  @upcase_thorn "Þ"
+  @downcase_thorn "þ"
+
+  def handle_message(req, state) do
+    text = Enum.join(req.args, " ")
+    |> String.replace(~r{\bTh}, @upcase_thorn)
+    |> String.replace(~r{\bth}, @downcase_thorn)
+
+    {:reply, req.reply_to, text, state}
+  end
+end

--- a/lib/cog/commands/thorn.ex
+++ b/lib/cog/commands/thorn.ex
@@ -10,14 +10,9 @@ defmodule Cog.Commands.Thorn do
 
   rule "when command is #{Cog.embedded_bundle}:thorn allow"
 
-  @upcase_thorn "Þ"
-  @downcase_thorn "þ"
+  @message "The thorn command has been deprecated and will be removed in a future release"
 
   def handle_message(req, state) do
-    text = Enum.join(req.args, " ")
-    |> String.replace(~r{\bTh}, @upcase_thorn)
-    |> String.replace(~r{\bth}, @downcase_thorn)
-
-    {:reply, req.reply_to, text, state}
+    {:reply, req.reply_to, @message, state}
   end
 end


### PR DESCRIPTION
This partially reverts commit 142f79e6b3478f007f4919ef77c87b0b4f2f6554.

Until bundle upgrades are in place, removing these commands actually
prevents the embedded bundle from starting, which blocks the entire
system from coming up.