### PR TITLE
Expire channel in cache when channel events are received

### DIFF
--- a/lib/cog/adapters/slack/api.ex
+++ b/lib/cog/adapters/slack/api.ex
@@ -297,7 +297,7 @@ defmodule Cog.Adapters.Slack.API do
     end
   end
 
-  def expire_key(key) do
+  defp expire_key(key) do
     :ets.delete(@channel_cache, key)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,7 @@ defmodule Cog.Mixfile do
   end
 
   defp deps do
-    [{:slack, github: "BlakeWilliams/Elixir-Slack"},
+    [{:slack, "~> 0.5.0"},
      {:websocket_client, github: "jeremyong/websocket_client"},
      {:poison, "~> 1.5.2"},
      {:ibrowse, "~> 4.2.2", override: true},

--- a/mix.lock
+++ b/mix.lock
@@ -55,7 +55,7 @@
   "postgrex": {:hex, :postgrex, "0.11.1"},
   "probe": {:git, "https://github.com/operable/probe.git", "c8ebf0877651b3cc5370e3f6ca7790a277106016", [tag: "0.2"]},
   "ranch": {:hex, :ranch, "1.2.1"},
-  "slack": {:git, "https://github.com/BlakeWilliams/Elixir-Slack.git", "4520d42070b2d9f4aefc97a41d2b035e8a8a46aa", []},
+  "slack": {:hex, :slack, "0.5.0"},
   "spanner": {:git, "https://github.com/operable/spanner.git", "3ff0d98af2d819071a170783965f02ff250d996f", []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0"},
   "uuid": {:hex, :uuid, "1.1.3"},


### PR DESCRIPTION
Closes #676 

We should also look into using the cached channels that the slack lib provides instead of keeping our own.