### PR TITLE
Rework help command

### DIFF
--- a/lib/cog/commands/help.ex
+++ b/lib/cog/commands/help.ex
@@ -1,29 +1,54 @@
 defmodule Cog.Commands.Help do
-  use Cog.Command.GenCommand.Base, bundle: "#{Cog.embedded_bundle}"
-
-  @moduledoc """
-  Get help on all installed Cog bot commands. By default only enabled
-  commands are listed.
-
-  USAGE:
-    help [OPTIONS] [ARGS]
-
-  OPTIONS:
-    -d, --disabled    list all disabled commands
-    -a, --all         list all know commands, enabled and disabled
-
-  ARGS:
-    command_name      list specific help for a command
-  """
+  use Cog.Command.GenCommand.Base,
+    bundle: Cog.embedded_bundle
 
   use Cog.Models
   alias Cog.Repo
   alias Cog.Queries
 
+  @moduledoc """
+  Prints help documentation for all commands.
+
+  USAGE
+    help [FLAGS] <command>
+
+  ARGS
+    command  prints long form documentation
+
+  FLAGS
+    -a, --all       Lists all enabled and disabled commands
+    -d, --disabled  Lists all disabled commands
+
+  EXAMPLES
+    help
+    > operable:alias
+      operable:bundle
+      operable:echo
+      operable:filter
+      operable:group
+      operable:help
+      operable:max
+      operable:min
+      operable:permissions
+      operable:raw
+      operable:relay
+      operable:relay-group
+      operable:role
+      operable:rules
+      operable:seed
+      operable:sleep
+      operable:sort
+      operable:sum
+      operable:table
+      operable:unique
+      operable:wc
+      operable:which
+  """
+
   rule "when command is #{Cog.embedded_bundle}:help allow"
 
-  option "all", type: "bool", required: false
-  option "disabled", type: "bool", required: false
+  option "all",      short: "a", type: "bool", required: false
+  option "disabled", short: "d", type: "bool", required: false
 
   def handle_message(%{args: [], options: options, reply_to: reply_to}, state) do
     case commands(options) do

--- a/lib/cog/commands/help.ex
+++ b/lib/cog/commands/help.ex
@@ -83,19 +83,19 @@ defmodule Cog.Commands.Help do
 
   defp find_commands_query(%{"all" => true}) do
     Command
-    |> Queries.Command.qualified_names
+    |> Queries.Command.sorted_by_qualified_name
   end
 
   defp find_commands_query(%{"disabled" => true}) do
     Command
     |> Queries.Command.disabled
-    |> Queries.Command.qualified_names
+    |> Queries.Command.sorted_by_qualified_name
   end
 
   defp find_commands_query(%{}) do
     Command
     |> Queries.Command.enabled
-    |> Queries.Command.qualified_names
+    |> Queries.Command.sorted_by_qualified_name
   end
 
   defp find_command_query(command) do

--- a/lib/cog/commands/help.ex
+++ b/lib/cog/commands/help.ex
@@ -50,63 +50,55 @@ defmodule Cog.Commands.Help do
   option "all",      short: "a", type: "bool", required: false
   option "disabled", short: "d", type: "bool", required: false
 
-  def handle_message(%{args: [], options: options, reply_to: reply_to}, state) do
-    case commands(options) do
-      # We do not allow embedded commands to be disabled, so this
-      # would only happen for looking for disabled commands
-      [] -> {:reply, reply_to, "There are no disabled commands.", state}
-      commands -> {:reply, reply_to, "help", %{"commands" => commands}, state}
-    end
+  def handle_message(%{args: [], options: options} = req, state) do
+    commands = Repo.all(find_commands_query(options))
+    {:reply, req.reply_to, "help", commands, state}
   end
-  def handle_message(%{args: [command], reply_to: reply_to}, state) when is_binary(command) do
-    case get_docs(command) do
-      {:ok, docs} ->
-        {:reply, reply_to, "help", docs, state}
-      {:error, msg} ->
-        {:error, reply_to, msg, state}
-    end
-  end
-  def handle_message(%{reply_to: reply_to}, state),
-    do: {:error, reply_to, "Call this command with either no arguments or 1 string argument only", state}
 
-  defp get_docs(command_name) do
-    case Repo.all(Cog.Queries.Command.by_any_name(command_name)) do
+  def handle_message(%{args: [command]} = req, state) do
+    case Repo.all(find_command_query(command)) do
+      [%{documentation: documentation} = command] when is_binary(documentation) ->
+        {:reply, req.reply_to, "help-command", [command], state}
+      [%{documentation: nil} = command] ->
+        name = Command.full_name(command)
+        {:error, req.reply_to, "Command #{inspect name} does not have any documentation", state}
       [] ->
-        {:error, "No command `#{command_name}` found"}
-      [command] ->
-        case command.documentation do
-          "" ->
-            {:error, "No documentation for command '#{qualified_name(command)}' found."}
-          docs ->
-            {:ok, %{"command" => qualified_name(command), "documentation" => docs}}
-        end
+        {:error, req.reply_to, "Command #{inspect command} does not exist", state}
       commands when is_list(commands) ->
-        # More than one; ambiguous!
-        all_names = commands
-        |> Enum.map(&qualified_name/1)
-        |> Enum.map(&("* #{&1}\n"))
+        names = Enum.map_join(commands, "\n", &Command.full_name/1)
+
         message = """
+        Multiple commands found for command #{inspect command}. Please choose one:
 
-                  Multiple commands found for `#{command_name}`; please choose one:
+        #{names}
+        """
 
-                  #{all_names}
-                  """
-        {:error, message}
+        {:error, req.reply_to, message, state}
     end
   end
 
-  defp qualified_name(command),
-    do: "#{command.bundle.name}:#{command.name}"
-
-  defp commands(options) do
-    determine_inclusion(options)
-    |> Repo.all
-    |> Enum.map(&Enum.join(&1, ":"))
-    |> Enum.sort
+  def handle_message(req, state) do
+    {:reply, req.reply_to, "usage", %{usage: @moduledoc}, state}
   end
 
-  defp determine_inclusion(%{"disabled" => true}), do: Queries.Command.names_for(false)
-  defp determine_inclusion(%{"all" => true}), do: Queries.Command.names
-  defp determine_inclusion(_), do: Queries.Command.names_for(true)
+  defp find_commands_query(%{"all" => true}) do
+    Command
+    |> Queries.Command.qualified_names
+  end
 
+  defp find_commands_query(%{"disabled" => true}) do
+    Command
+    |> Queries.Command.disabled
+    |> Queries.Command.qualified_names
+  end
+
+  defp find_commands_query(%{}) do
+    Command
+    |> Queries.Command.enabled
+    |> Queries.Command.qualified_names
+  end
+
+  defp find_command_query(command) do
+    Queries.Command.by_any_name(command)
+  end
 end

--- a/lib/cog/models/bundle.ex
+++ b/lib/cog/models/bundle.ex
@@ -65,3 +65,12 @@ defimpl Groupable, for: Cog.Models.Bundle do
 
 end
 
+defimpl Poison.Encoder, for: Cog.Models.Bundle do
+  def encode(struct, options) do
+    map = struct
+    |> Map.from_struct
+    |> Map.take([:name])
+
+    Poison.Encoder.Map.encode(map, options)
+  end
+end

--- a/lib/cog/models/command.ex
+++ b/lib/cog/models/command.ex
@@ -85,7 +85,7 @@ defimpl Poison.Encoder, for: Cog.Models.Command do
   def encode(%Cog.Models.Command{} = struct, options) do
     map = struct
     |> Map.from_struct
-    |> Map.take([:name, :version])
+    |> Map.take([:name, :version, :documentation])
 
     Poison.Encoder.Map.encode(map, options)
   end

--- a/lib/cog/models/command.ex
+++ b/lib/cog/models/command.ex
@@ -85,7 +85,7 @@ defimpl Poison.Encoder, for: Cog.Models.Command do
   def encode(%Cog.Models.Command{} = struct, options) do
     map = struct
     |> Map.from_struct
-    |> Map.take([:name, :version, :documentation])
+    |> Map.take([:name, :version, :documentation, :bundle])
 
     Poison.Encoder.Map.encode(map, options)
   end

--- a/lib/cog/queries/command.ex
+++ b/lib/cog/queries/command.ex
@@ -81,8 +81,26 @@ defmodule Cog.Queries.Command do
     end
   end
 
+  def qualified_names(query \\ Command) do
+    from c in query,
+    join: b in assoc(c, :bundle),
+    order_by: [b.name, c.name],
+    select: fragment("? || ':' || ?", b.name, c.name)
+  end
+
+  def enabled(query \\ Command) do
+    from c in query,
+    join: b in assoc(c, :bundle),
+    where: b.enabled
+  end
+
+  def disabled(query \\ Command) do
+    from c in query,
+    join: b in assoc(c, :bundle),
+    where: not(b.enabled)
+  end
+
   # Split a string as though it were a qualified name
   defp is_qualified?(name),
     do: length(String.split(name, ":", parts: 2)) == 2
-
 end

--- a/lib/cog/queries/command.ex
+++ b/lib/cog/queries/command.ex
@@ -81,11 +81,11 @@ defmodule Cog.Queries.Command do
     end
   end
 
-  def qualified_names(query \\ Command) do
+  def sorted_by_qualified_name(query \\ Command) do
     from c in query,
     join: b in assoc(c, :bundle),
     order_by: [b.name, c.name],
-    select: fragment("? || ':' || ?", b.name, c.name)
+    preload: [:bundle]
   end
 
   def enabled(query \\ Command) do

--- a/lib/cog/templates/slack/help-command.mustache
+++ b/lib/cog/templates/slack/help-command.mustache
@@ -1,0 +1,3 @@
+```
+{{{documentation}}}
+```

--- a/lib/cog/templates/slack/help.mustache
+++ b/lib/cog/templates/slack/help.mustache
@@ -1,1 +1,1 @@
-{{.}}
+{{#bundle}}{{name}}{{/bundle}}:{{name}}

--- a/lib/cog/templates/slack/help.mustache
+++ b/lib/cog/templates/slack/help.mustache
@@ -1,15 +1,1 @@
-{{#command}}
-  Documentation for `{{command}}`
-
-  {{{documentation}}}
-{{/command}}
-
-{{^command}}
-  I know about these commands:
-
-  {{#commands}}
-  * {{.}}
-  {{/commands}}
-
-  Try calling `operable:help COMMAND` to find out more.
-{{/command}}
+{{.}}

--- a/test/integration/commands/help_test.exs
+++ b/test/integration/commands/help_test.exs
@@ -11,43 +11,49 @@ defmodule Integration.Commands.HelpTest do
 
   test "listing enabled commands", %{user: user} do
     response = send_message(user, "@bot: operable:help")
-
-    [commands] = decode_payload(response)
+    commands = decode_payload(response)
 
     # We should only have the operable bundle installed at this point
-    assert Enum.all?(commands.commands, &String.starts_with?(&1, "operable"))
+    assert Enum.all?(commands, fn command ->
+      command.bundle.name == "operable"
+    end)
   end
 
   test "list disabled commands", %{user: user} do
     ModelUtilities.command("test_command")
 
     response = send_message(user, "@bot: operable:help --disabled")
+    [command] = decode_payload(response)
 
-    [commands] = decode_payload(response)
-
-    assert Enum.all?(commands.commands, &match?("cog:test_command", &1))
+    assert command.bundle.name == "cog"
+    assert command.name == "test_command"
   end
 
   test "list enabled commands when there are also disabled commands", %{user: user} do
     ModelUtilities.command("test_command")
 
     response = send_message(user, "@bot: operable:help")
-
-    [commands] = decode_payload(response)
+    commands = decode_payload(response)
 
     # All enabled commands should be in the operable bundle
-    assert Enum.all?(commands.commands, &String.starts_with?(&1, "operable"))
+    assert Enum.all?(commands, fn command ->
+      command.bundle.name == "operable"
+    end)
   end
 
   test "list all commands", %{user: user} do
     ModelUtilities.command("test_command")
 
     response = send_message(user, "@bot: operable:help --all")
-
-    [commands] = decode_payload(response)
+    commands = decode_payload(response)
 
     # Now we should have some commands that start with operable and some with cog
-    assert Enum.any?(commands.commands, &String.starts_with?(&1, "operable"))
-    assert Enum.any?(commands.commands, &String.starts_with?(&1, "cog"))
+    assert Enum.any?(commands, fn command ->
+      command.bundle.name == "operable"
+    end)
+
+    assert Enum.any?(commands, fn command ->
+      command.bundle.name == "cog"
+    end)
   end
 end


### PR DESCRIPTION
`help` now returns a list of commands or a single command when running `help` or `help <command>`. However, this does limit what we can print since templates are rendered per item in the list and not for the entire response. For instance description at the top of the old help output ("I know about these commands:") is no longer included in the output.

Also any errors encountered are returned as errors rather than returning a string of output.

Closes #672 