### PR TITLE
Fix up permission linkage

### DIFF
--- a/lib/cog/models/bundle_version.ex
+++ b/lib/cog/models/bundle_version.ex
@@ -11,6 +11,9 @@ defmodule Cog.Models.BundleVersion do
     has_many :commands, CommandVersion # TODO: or `:command_versions`?
     has_many :templates, Template
 
+    has_many :permission_registration, Cog.Models.PermissionBundleVersion
+    has_many :permissions, through: [:permission_registration, :permission]
+
     timestamps
   end
 

--- a/lib/cog/models/bundle_version_permission.ex
+++ b/lib/cog/models/bundle_version_permission.ex
@@ -1,0 +1,12 @@
+defmodule Cog.Models.PermissionBundleVersion do
+  use Cog.Model
+
+  @primary_key false
+  schema "permission_bundle_version_v2" do
+    belongs_to :permission, Cog.Models.Permission, references: :id
+    belongs_to :bundle_version, Cog.Models.BundleVersion, references: :id
+  end
+
+  # Insertions are handled via JoinTable, so nothing else is needed
+  # for this model
+end

--- a/lib/cog/repository/bundles.ex
+++ b/lib/cog/repository/bundles.ex
@@ -549,18 +549,20 @@ defmodule Cog.Repository.Bundles do
     |> MapSet.new
 
     # Determine which of those already exist in the database
+    bundle_permission_names = Enum.map(bundle.permissions, &(&1.name)) |> MapSet.new
 
-    existing_permissions = bundle.permissions
-    existing_permission_names = Enum.map(existing_permissions, &(&1.name)) |> MapSet.new
-    missing_permission_names  = MapSet.difference(raw_names, existing_permission_names)
+    new_to_this_version  = MapSet.difference(raw_names, bundle_permission_names)
 
-    # Create new permissions for the remaining ones
-    missing_permission_names
+    already_existing_names = MapSet.intersection(raw_names, bundle_permission_names)
+    already_existing = Enum.filter(bundle.permissions, &(Enum.member?(already_existing_names, &1.name)))
+
+    # Create new permissions the ones we haven't seen yet
+    new_to_this_version
     |> Enum.map(&Cog.Repository.Permissions.create_permission(bundle_version, &1))
     |> Enum.map(fn({:ok, p}) -> p end)
 
     # Link preexisting permissions to the current bundle version
-    Enum.each(existing_permissions, &Cog.Repository.Permissions.link_permission_to_bundle_version(bundle_version, &1))
+    Enum.each(already_existing, &Cog.Repository.Permissions.link_permission_to_bundle_version(bundle_version, &1))
 
     :ok
   end

--- a/test/cog/models/bundle_version_repo_test.exs
+++ b/test/cog/models/bundle_version_repo_test.exs
@@ -1,0 +1,29 @@
+defmodule Cog.Models.BundleVersionRepoTest do
+  use Cog.ModelCase, async: false
+
+  alias Cog.Repository.Bundles
+
+  test "permissions are version-specific" do
+    {:ok, v1} = Bundles.install(%{"name" => "foo",
+                                  "version" => "1.0.0",
+                                  "config_file" => %{"name" => "foo",
+                                                     "version" => "1.0.0",
+                                                     "permissions" => ["foo:a", "foo:b", "foo:c"]}})
+
+    {:ok, v2} = Bundles.install(%{"name" => "foo",
+                                  "version" => "2.0.0",
+                                  "config_file" => %{"name" => "foo",
+                                                     "version" => "2.0.0",
+                                                     "permissions" => ["foo:c", "foo:d"]}})
+
+    assert ["a", "b", "c"] = sorted_permission_names(v1)
+    assert ["c", "d"] = sorted_permission_names(v2)
+  end
+
+  defp sorted_permission_names(version) do
+    Cog.Repo.preload(version, :permissions).permissions
+    |> Enum.map(&(&1.name))
+    |> Enum.sort
+  end
+
+end


### PR DESCRIPTION
We now expose the permissions of a bundle version as an Ecto association
on the BundleVersion model. This also exposed a bug in how we were
linking permissions to bundle versions: previously, we ended up linking
_all_ permissions from a bundle to the bundle version, instead of just
the permissions present in _that_ specific version. That's now fixed.