### PR TITLE
Override service and trigger base URLs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -148,6 +148,9 @@ config :cog, Cog.ServiceEndpoint,
   check_origin: true,
   render_errors: [accepts: ~w(json)]
 
+config :cog, :trigger_url_base, (String.replace((System.get_env("COG_TRIGGER_URL_BASE") || ""), ~r/\/$/, ""))
+config :cog, :services_url_base, (String.replace((System.get_env("COG_SERVICE_URL_BASE") || ""), ~r/\/$/, ""))
+
 config :cog, :token_lifetime, {1, :week}
 config :cog, :token_reap_period, {1, :day}
 

--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -625,7 +625,7 @@ defmodule Cog.Command.Pipeline.Executor do
       room:            room,
       reply_to:        reply_to,
       service_token:   service_token,
-      services_root:   ServiceEndpoint.url
+      services_root:   ServiceEndpoint.public_url
     }
   end
 

--- a/lib/cog/service_endpoint.ex
+++ b/lib/cog/service_endpoint.ex
@@ -11,4 +11,13 @@ defmodule Cog.ServiceEndpoint do
 
   plug Cog.ServiceRouter
 
+  def public_url() do
+    case Application.get_env(:cog, :services_url_base) do
+      "" ->
+        url()
+      base ->
+        base
+    end
+  end
+
 end

--- a/web/views/service_view.ex
+++ b/web/views/service_view.ex
@@ -19,7 +19,13 @@ defmodule Cog.V1.ServiceView do
     do: %{service: render_one(service, __MODULE__, "service.json")}
 
   # Generate a URL where specific service metadata can be obtained.
-  defp meta_url(service),
-    do: Cog.ServiceRouter.Helpers.service_url(Cog.ServiceEndpoint, :show, service.name)
+  defp meta_url(service) do
+    case Application.get_env(:cog, :services_url_base) do
+      "" ->
+        Cog.ServiceRouter.Helpers.service_url(Cog.ServiceEndpoint, :show, service.name)
+      base ->
+        Enum.join([base, Cog.ServiceRouter.Helpers.service_path(Cog.ServiceEndpoint, :show, service.name)])
+    end
+  end
 
 end

--- a/web/views/trigger_view.ex
+++ b/web/views/trigger_view.ex
@@ -23,8 +23,15 @@ defmodule Cog.V1.TriggerView do
   # may need to use information from the `conn` to generate this if
   # installed behind a proxy that handles routing between the two
   # endpoints.
-  defp invocation_url(trigger),
-    do: Cog.TriggerRouter.Helpers.trigger_execution_url(Cog.TriggerEndpoint, :execute_trigger, trigger.id)
-
+  defp invocation_url(trigger) do
+    case Application.get_env(:cog, :trigger_url_base) do
+      "" ->
+        Cog.TriggerRouter.Helpers.trigger_execution_url(Cog.TriggerEndpoint, :execute_trigger, trigger.id)
+      base ->
+        Enum.join([base, Cog.TriggerRouter.Helpers.trigger_execution_path(Cog.TriggerEndpoint,
+                                                                          :execute_trigger,
+                                                                          trigger.id)])
+    end
+  end
 
 end


### PR DESCRIPTION
This commit introduces two new environment variables which can be used
to override the base URLs for services and triggers:

$COG_TRIGGER_URL_BASE
$COG_SERVICE_URL_BASE

Setting either/both of these variables will override the base portion of the corresponding URL. This capability is useful when Cog is unable to detect the correct routable URL to send to clients. For example, firewalls and load balancers interpose themselves between clients and servers and require hosts behind them to carefully build any URLs returned in output so clients are able to access those resources.

Fixes #694