### PR TITLE
Add uniqueness constraint to bundle version model

### DIFF
--- a/lib/cog/models/bundle_version.ex
+++ b/lib/cog/models/bundle_version.ex
@@ -31,8 +31,7 @@ defmodule Cog.Models.BundleVersion do
     model
     |> cast(params, @required_fields, [])
     |> unique_constraint(:version,
-                         name: :bundle_versions_v2_bundle_id_version_index,
-                         message: "The bundle version already exists.")
+                         name: :bundle_versions_v2_bundle_id_version_index)
   end
 
   def enabled?(bundle_version) do

--- a/lib/cog/models/bundle_version.ex
+++ b/lib/cog/models/bundle_version.ex
@@ -28,7 +28,11 @@ defmodule Cog.Models.BundleVersion do
   detail_fields [:id, :inserted_at]
 
   def changeset(model, params \\ :empty) do
-    model |> cast(params, @required_fields, [])
+    model
+    |> cast(params, @required_fields, [])
+    |> unique_constraint(:version,
+                         name: :bundle_versions_v2_bundle_id_version_index,
+                         message: "The bundle version already exists.")
   end
 
   def enabled?(bundle_version) do

--- a/lib/cog/repository/bundles.ex
+++ b/lib/cog/repository/bundles.ex
@@ -438,11 +438,6 @@ defmodule Cog.Repository.Bundles do
     where: bv.version == ^version
   end
 
-
-
-
-
-
   defp find_or_create_bundle(name) do
     bundle = case Repo.get_by(Bundle, name: name) do
                %Bundle{}=bundle ->
@@ -456,9 +451,6 @@ defmodule Cog.Repository.Bundles do
     Repo.preload(bundle, [:permissions, :commands])
   end
 
-
-  # TODO: This raises an exception if it can't insert... is this
-  # globally OK?
   defp new_version(bundle, params) do
     bundle
     |> Ecto.Model.build(:versions)
@@ -500,38 +492,42 @@ defmodule Cog.Repository.Bundles do
 
   defp install_bundle(bundle_params) do
     Repo.transaction(fn ->
+      try do
+        # Create a bundle record if it doesn't exist yet
+        bundle = find_or_create_bundle(bundle_params["name"])
 
-      # Create a bundle record if it doesn't exist yet
-      bundle = find_or_create_bundle(bundle_params["name"])
+        # Create a new version record
+        version = new_version(bundle, bundle_params)
 
-      # Create a new version record
-      version = new_version(bundle, bundle_params)
+        # Add permissions, after deduping
+        :ok = register_permissions_for_version(bundle, version)
 
-      # Add permissions, after deduping
-      :ok = register_permissions_for_version(bundle, version)
+        # Add commands, after deduping
+        commands = register_commands_for_version(bundle, version)
 
-      # Add commands, after deduping
-      commands = register_commands_for_version(bundle, version)
+        # Add command_versions; rules get ingested in this process as
+        # well
+        version.config_file
+        |> Map.get("commands", %{})
+        |> Enum.each(&create_command_version(version, commands, &1))
 
-      # Add command_versions; rules get ingested in this process as
-      # well
-      version.config_file
-      |> Map.get("commands", %{})
-      |> Enum.each(&create_command_version(version, commands, &1))
+        # Add templates
+        version.config_file
+        |> Map.get("templates", %{})
+        |> Enum.each(&create_template(version, &1))
 
-      # Add templates
-      version.config_file
-      |> Map.get("templates", %{})
-      |> Enum.each(&create_template(version, &1))
-
-      # Once we go to Ecto 2.0 and there's a Repo.preload/3, I'd like
-      # to add the ability to selectively force preloading on our
-      # private preload/2 function. Until then, without having to muck
-      # around too much with the internals of the model, I'm just
-      # going to grab a fresh version from the database.
-      #
-      # :(
-      Cog.Repo.get(BundleVersion, version.id)
+        # Once we go to Ecto 2.0 and there's a Repo.preload/3, I'd like
+        # to add the ability to selectively force preloading on our
+        # private preload/2 function. Until then, without having to muck
+        # around too much with the internals of the model, I'm just
+        # going to grab a fresh version from the database.
+        #
+        # :(
+        Cog.Repo.get(BundleVersion, version.id)
+      rescue
+        e in [Ecto.InvalidChangesetError] ->
+          Repo.rollback({:db_errors, e.changeset.errors})
+      end
     end)
   end
 

--- a/test/cog/repository/bundles_test.exs
+++ b/test/cog/repository/bundles_test.exs
@@ -147,6 +147,11 @@ defmodule Cog.Repository.BundlesTest do
 
   end
 
+  test "installing the same version multiple times is an error" do
+    {:ok, _version} = Bundles.install(%{"name" => "testing", "version" => "1.0.0", "config_file" => %{}})
+    assert {:error, {:db_errors, [version: "The bundle version already exists."]}} = Bundles.install(%{"name" => "testing", "version" => "1.0.0", "config_file" => %{}})
+  end
+
   test "deleting the last version of a bundle deletes the bundle itself" do
     {:ok, version} = Bundles.install(%{"name" => "testing", "version" => "1.0.0", "config_file" => %{}})
 

--- a/test/cog/repository/bundles_test.exs
+++ b/test/cog/repository/bundles_test.exs
@@ -149,7 +149,7 @@ defmodule Cog.Repository.BundlesTest do
 
   test "installing the same version multiple times is an error" do
     {:ok, _version} = Bundles.install(%{"name" => "testing", "version" => "1.0.0", "config_file" => %{}})
-    assert {:error, {:db_errors, [version: "The bundle version already exists."]}} = Bundles.install(%{"name" => "testing", "version" => "1.0.0", "config_file" => %{}})
+    assert {:error, {:db_errors, [version: "has already been taken"]}} = Bundles.install(%{"name" => "testing", "version" => "1.0.0", "config_file" => %{}})
   end
 
   test "deleting the last version of a bundle deletes the bundle itself" do

--- a/test/controllers/v1/bundles_controller_test.exs
+++ b/test/controllers/v1/bundles_controller_test.exs
@@ -150,7 +150,7 @@ defmodule Cog.V1.BundlesControllerTest do
     # Now try to do the same thing again
     conn = api_request(requestor, :post, "/v1/bundles", body: %{"bundle" => %{"config" => config}})
     assert ["Could not save bundle.",
-            "The bundle version already exists."] = json_response(conn, 422)["errors"] # TODO: want it to be 409 in this case
+            "version has already been taken"] = json_response(conn, 409)["errors"]
   end
 
   test "shows disabled bundle", %{authed: requestor} do

--- a/test/controllers/v1/bundles_controller_test.exs
+++ b/test/controllers/v1/bundles_controller_test.exs
@@ -142,6 +142,17 @@ defmodule Cog.V1.BundlesControllerTest do
     assert conn.status == 400
   end
 
+  test "fails to install the same version twice", %{authed: requestor} do
+    config = config(:map)
+    conn = api_request(requestor, :post, "/v1/bundles", body: %{"bundle" => %{"config" => config}})
+    assert response(conn, 201)
+
+    # Now try to do the same thing again
+    conn = api_request(requestor, :post, "/v1/bundles", body: %{"bundle" => %{"config" => config}})
+    assert ["Could not save bundle.",
+            "The bundle version already exists."] = json_response(conn, 422)["errors"] # TODO: want it to be 409 in this case
+  end
+
   test "shows disabled bundle", %{authed: requestor} do
     {:ok, _version3} = Bundles.install(%{"name" => "foo", "version" => "3.0.0", "config_file" => %{}})
     {:ok, _version2} = Bundles.install(%{"name" => "foo", "version" => "2.0.0", "config_file" => %{}})

--- a/web/controllers/v1/bundles_controller.ex
+++ b/web/controllers/v1/bundles_controller.ex
@@ -78,7 +78,7 @@ defmodule Cog.V1.BundlesController do
     with {:ok, config}                 <- parse_config(params),
          {:ok, valid_config, warnings} <- validate_config(config),
          {:ok, params}                 <- merge_config(params, valid_config),
-         {:ok, bundle}                 <- persist(params) do
+         {:ok, bundle}                 <- Repository.Bundles.install(params) do
            {:ok, bundle, warnings}
     end
   end
@@ -133,16 +133,6 @@ defmodule Cog.V1.BundlesController do
     {:ok, merged_params}
   end
 
-  # Create a new record in the DB for the deploy
-  defp persist(params) do
-    try do
-      Cog.Repository.Bundles.install(params)
-    rescue
-      err in [Ecto.InvalidChangesetError] ->
-        {:error, {:db_error, err.changeset.errors}}
-    end
-  end
-
   # Helper functions
 
   defp send_failure(conn, err) do
@@ -171,7 +161,7 @@ defmodule Cog.V1.BundlesController do
     warnings = Enum.map(warnings, fn({msg, meta}) -> ~s(Warning near #{meta}: #{msg}) end)
     {:unprocessable_entity, %{errors: msg ++ errors, warnings: warnings}}
   end
-  defp error({:db_error, errors}) do
+  defp error({:db_errors, errors}) do
     msg = ["Could not save bundle."]
     errors = Enum.map(errors, fn({_, message}) -> message end)
     {:unprocessable_entity, %{errors: msg ++ errors}}

--- a/web/controllers/v1/bundles_controller.ex
+++ b/web/controllers/v1/bundles_controller.ex
@@ -161,6 +161,14 @@ defmodule Cog.V1.BundlesController do
     warnings = Enum.map(warnings, fn({msg, meta}) -> ~s(Warning near #{meta}: #{msg}) end)
     {:unprocessable_entity, %{errors: msg ++ errors, warnings: warnings}}
   end
+  defp error({:db_errors, [{_, "has already been taken"}]=errors}) do
+    # A bit fragile, relying as it does on the specific message that
+    # Ecto uses by default for unique constraint violations, but
+    # allows us to fail with a more appropriate HTTP 409
+    msg = ["Could not save bundle."]
+    errors = Enum.map(errors, fn({field, message}) -> "#{Atom.to_string(field)} #{message}" end)
+    {:conflict, %{errors: msg ++ errors}}
+  end
   defp error({:db_errors, errors}) do
     msg = ["Could not save bundle."]
     errors = Enum.map(errors, fn({_, message}) -> message end)


### PR DESCRIPTION
This prevents crashes when attempting to install the same bundle version
twice (as determined by bundle name and version string _only_; it
doesn't care if the contents of the bundle configuration file are
identical between versions).

We wrap all the bundle installation logic in a try/rescue block, and
trigger a transaction rollback if any `Ecto.InvalidChangesetError`s are
raised. Thus, this will actually protect against _any_ error raised in
the installation process.