### PR TITLE
Formally define contract for parser metadata

### DIFF
--- a/lib/cog/audit_message.ex
+++ b/lib/cog/audit_message.ex
@@ -17,8 +17,8 @@ defmodule Cog.AuditMessage do
   end
   def render({:denied, {_rule, current_invocation}}, request),
     do: "User #{request["sender"]["handle"]} denied access to '#{current_invocation}'"
-  def render({:no_relays, bundle}, _request),
-    do: ErrorResponse.render({:no_relays, bundle}) # Uses same user message for now
+  def render({:no_relays, bundle_name}, _request),
+    do: ErrorResponse.render({:no_relays, bundle_name}) # Uses same user message for now
   def render({:disabled_bundle, %Bundle{name: name}}, _request),
     do: "The #{name} bundle is currently disabled"
   def render({:command_error, response}, _request),

--- a/lib/cog/command/option_interpreter.ex
+++ b/lib/cog/command/option_interpreter.ex
@@ -5,8 +5,8 @@ defmodule Cog.Command.OptionInterpreter do
 
   @truthy_values ["true", "t", "y", "yes", "on"]
 
-  def initialize(%Ast.Invocation{args: args, meta: command_model}=invocation) do
-    defs = Enum.reduce(command_model.options, %{}, &prepare_option/2)
+  def initialize(%Ast.Invocation{args: args, meta: parser_meta}=invocation) do
+    defs = Enum.reduce(parser_meta.options, %{}, &prepare_option/2)
     with({:ok, options, args} <- interpret(defs, args, [], %{}),
          :ok <- check_required_options(defs, options)) do
       options = set_defaults(invocation, options)

--- a/lib/cog/command/permission_interpreter.ex
+++ b/lib/cog/command/permission_interpreter.ex
@@ -1,16 +1,15 @@
 defmodule Cog.Command.PermissionInterpreter do
 
   alias Piper.Permissions.Parser
+  alias Cog.Command.Pipeline.ParserMeta
   alias Cog.Permissions
-  alias Cog.Models.CommandVersion
 
-  def check(%CommandVersion{}=command_version, options, args, perms) do
+  def check(%ParserMeta{}=meta, options, args, perms) do
     context = Permissions.Context.new(permissions: perms,
-                                      command: CommandVersion.full_name(command_version),
+                                      command: meta.full_command_name,
                                       options: options,
                                       args: args)
-    results = command_version.command.rules
-    |> Enum.filter(&(&1.enabled))
+    results = meta.rules
     |> Enum.map(&(evaluate(&1, context)))
     |> Enum.reject(&(&1 == :nomatch))
     |> Enum.sort(&by_score/2)

--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -5,6 +5,7 @@ defmodule Cog.Command.Pipeline.Executor do
   alias Cog.Command.CommandResolver
   alias Cog.Command.PermissionsCache
   alias Cog.Command.Pipeline.Destination
+  alias Cog.Command.Pipeline.ParserMeta
   alias Cog.Command.Pipeline.Plan
   alias Cog.ErrorResponse
   alias Cog.Events.PipelineEvent
@@ -185,9 +186,9 @@ defmodule Cog.Command.Pipeline.Executor do
     do: succeed_with_response(state)
 
   def execute_plan(:timeout, %__MODULE__{plans: [current_plan|remaining_plans], request: request, user: user}=state) do
-    bundle  = current_plan.command_version.command.bundle
-    name    = current_plan.command_version.command.name
-    version = current_plan.command_version.bundle_version.version
+    bundle_name  = current_plan.parser_meta.bundle_name
+    command_name = current_plan.parser_meta.command_name
+    version      = current_plan.parser_meta.version
 
     # TODO: Previously, we'd do a test here for whether the bundle was
     # enabled or not. Now, we'll never make it this far if the bundle's not
@@ -197,11 +198,11 @@ defmodule Cog.Command.Pipeline.Executor do
     #   fail_pipeline_with_error({:disabled_bundle, bundle}, state)
     #
 
-    case Cog.Relay.Relays.pick_one(bundle.name, version) do
+    case Cog.Relay.Relays.pick_one(bundle_name, version) do
       nil ->
-        fail_pipeline_with_error({:no_relays, bundle}, state)
+        fail_pipeline_with_error({:no_relays, bundle_name}, state)
       relay ->
-        topic = "/bot/commands/#{relay}/#{bundle.name}/#{name}"
+        topic = "/bot/commands/#{relay}/#{bundle_name}/#{command_name}"
         reply_to_topic = "#{state.topic}/reply"
         req = request_for_plan(current_plan, request, user, reply_to_topic, state.service_token)
         updated_state =  %{state | current_plan: current_plan, plans: remaining_plans}
@@ -217,7 +218,7 @@ defmodule Cog.Command.Pipeline.Executor do
     do: {:next_state, :plan_next_invocation, state, 0}
 
   def wait_for_command(:timeout, state),
-    do: fail_pipeline_with_error({:timeout, state.current_plan.command_version}, state)
+    do: fail_pipeline_with_error({:timeout, state.current_plan.parser_meta.full_command_name}, state)
 
   def handle_info({:publish, topic, message}, :wait_for_command, state) do
     reply_topic = "#{state.topic}/reply" # TODO: bake this into state for easier pattern-matching?
@@ -286,14 +287,14 @@ defmodule Cog.Command.Pipeline.Executor do
   # adapter/destination it is to be sent to, and send it to each.
   defp respond(%__MODULE__{}=state) do
     output = state.output
-    bundle_version = state.current_plan.command_version.bundle_version
+    parser_meta = state.current_plan.parser_meta
     by_output_level = Enum.group_by(state.destinations, &(&1.output_level))
 
     # Render full output first
     full = Map.get(by_output_level, :full, [])
     adapters = full |> Enum.map(&(&1.adapter)) |> Enum.uniq
 
-    case render_for_adapters(adapters, bundle_version, output) do
+    case render_for_adapters(adapters, parser_meta, output) do
       {:error, {error, template, adapter}} ->
         # TODO: need to send error, THEN fail at the end, since we may
         # need to do it for status-only destinations
@@ -348,12 +349,12 @@ defmodule Cog.Command.Pipeline.Executor do
   end
 
   # Return a map of adapter -> rendered message
-  @spec render_for_adapters([adapter_name], %Cog.Models.BundleVersion{}, List.t) ::
+  @spec render_for_adapters([adapter_name], %ParserMeta{}, List.t) ::
                            %{adapter_name => String.t} |
                            {:error, {term, term, term}} # {error, template, adapter}
-  defp render_for_adapters(adapters, bundle_version, output) do
+  defp render_for_adapters(adapters, parser_meta, output) do
     Enum.reduce_while(adapters, %{}, fn(adapter, acc) ->
-      case render_templates(adapter, bundle_version, output) do
+      case render_templates(adapter, parser_meta, output) do
         {:error, _}=error ->
           {:halt, error}
         message ->
@@ -364,9 +365,9 @@ defmodule Cog.Command.Pipeline.Executor do
 
   # For a specific adapter, render each output, concatenating all
   # results into a single response string
-  defp render_templates(adapter, bundle_version, output) do
+  defp render_templates(adapter, parser_meta, output) do
     rendered_templates = Enum.reduce_while(output, [], fn({context, template}, acc) ->
-      case render_template(adapter, bundle_version, template, context) do
+      case render_template(adapter, parser_meta, template, context) do
         {:ok, result} ->
           {:cont, [result|acc]}
         {:error, error} ->
@@ -384,12 +385,12 @@ defmodule Cog.Command.Pipeline.Executor do
     end
   end
 
-  defp render_template(adapter, bundle_version, template, context) do
-    case Template.render(adapter, bundle_version.id, template, context) do
+  defp render_template(adapter, parser_meta, template, context) do
+    case Template.render(adapter, parser_meta.bundle_version_id, template, context) do
       {:ok, output} ->
         {:ok, output}
       {:error, :template_not_found} ->
-        Logger.warn("The template `#{template}` was not found for adapter `#{adapter}` in bundle `#{bundle_version.bundle.name} #{bundle_version.version}`; falling back to the json template")
+        Logger.warn("The template `#{template}` was not found for adapter `#{adapter}` in bundle `#{parser_meta.bundle_name} #{parser_meta.version}`; falling back to the json template")
         Template.render(adapter, "json", context)
       {:error, error} ->
         {:error, error}
@@ -614,7 +615,7 @@ defmodule Cog.Command.Pipeline.Executor do
     user      = Cog.Models.EctoJson.render(user)
 
     %Cog.Command.Request{
-      command:         Cog.Models.CommandVersion.full_name(plan.command_version),
+      command:         plan.parser_meta.full_command_name,
       options:         plan.options,
       args:            plan.args,
       cog_env:         plan.cog_env,

--- a/lib/cog/command/pipeline/parser_meta.ex
+++ b/lib/cog/command/pipeline/parser_meta.ex
@@ -1,0 +1,32 @@
+defmodule Cog.Command.Pipeline.ParserMeta do
+  @moduledoc """
+  Metadata accumulated during command parsing that is of use in
+  downstream processing.
+  """
+
+  @type t :: %__MODULE__{bundle_name: String.t,
+                         command_name: String.t,
+                         version: Version.t,
+                         bundle_version_id: String.t, # UUID, really
+                         full_command_name: String.t,
+                         options: [%Cog.Models.CommandOption{}],
+                         rules: [%Cog.Models.Rule{}]}
+  defstruct [bundle_name: nil,
+             command_name: nil,
+             version: nil,
+             bundle_version_id: nil,
+             full_command_name: nil,
+             options: [],
+             rules: []]
+
+  def new(bundle_name, command_name, version, bundle_version_id, options, rules) do
+    %__MODULE__{bundle_name: bundle_name,
+                command_name: command_name,
+                version: version,
+                bundle_version_id: bundle_version_id,
+                full_command_name: "#{bundle_name}:#{command_name}",
+                options: options,
+                rules: rules}
+  end
+
+end

--- a/lib/cog/command/pipeline/plan.ex
+++ b/lib/cog/command/pipeline/plan.ex
@@ -1,6 +1,6 @@
 defmodule Cog.Command.Pipeline.Plan do
 
-  @type t :: %__MODULE__{command_version: %Cog.Models.CommandVersion{},
+  @type t :: %__MODULE__{parser_meta: %Cog.Command.Pipeline.ParserMeta{},
                          invocation_id: String.t,
                          invocation_text: String.t,
                          invocation_step: String.t,
@@ -8,7 +8,7 @@ defmodule Cog.Command.Pipeline.Plan do
                          args: [term],
                          cog_env: Map.t | [Map.t]}
   defstruct [
-    command_version: nil,
+    parser_meta: nil,
     invocation_id: nil,
     invocation_text: nil,
     invocation_step: nil,

--- a/lib/cog/command/pipeline/planner.ex
+++ b/lib/cog/command/pipeline/planner.ex
@@ -35,7 +35,7 @@ defmodule Cog.Command.Pipeline.Planner do
     with {:ok, bound} <- Binder.bind(invocation, binding_map),
          {:ok, options, args} <- OptionInterpreter.initialize(bound),
          :allowed <- PermissionInterpreter.check(invocation.meta, options, args, permissions),
-      do: %Plan{command_version: invocation.meta,
+      do: %Plan{parser_meta: invocation.meta,
                 options: options,
                 args: args,
                 cog_env: cog_env,

--- a/lib/cog/error_response.ex
+++ b/lib/cog/error_response.ex
@@ -1,7 +1,6 @@
 defmodule Cog.ErrorResponse do
   alias Piper.Permissions.Ast
   alias Cog.Models.Bundle
-  alias Cog.Models.CommandVersion
 
   def render({:parse_error, msg}) when is_binary(msg),
     do: "Whoops! An error occurred. " <> msg
@@ -15,14 +14,12 @@ defmodule Cog.ErrorResponse do
     do: "No rules match the supplied invocation of '#{current_invocation}'. Check your args and options, then confirm that the proper rules are in place."
   def render({:denied, {%Ast.Rule{}=rule, current_invocation}}),
     do: "Sorry, you aren't allowed to execute '#{current_invocation}' :(\n You will need the '#{rule.permission_selector.perms.value}' permission to run this command."
-  def render({:no_relays, %Bundle{name: name}}),
-    do: "Whoops! An error occurred. No Cog Relays supporting the `#{name}` bundle are currently online"
+  def render({:no_relays, bundle_name}), # TODO: Add version, too?
+    do: "Whoops! An error occurred. No Cog Relays supporting the `#{bundle_name}` bundle are currently online"
   def render({:disabled_bundle, %Bundle{name: name}}),
     do: "Whoops! An error occurred. The #{name} bundle is currently disabled"
-  def render({:timeout, %CommandVersion{}=command_version}) do
-    name = CommandVersion.full_name(command_version)
-    "The #{name} command timed out"
-  end
+  def render({:timeout, full_command_name}),
+    do: "The #{full_command_name} command timed out"
   def render({:template_rendering_error, {error, template, adapter}}),
     do: "Whoops! An error occurred. There was an error rendering the template '#{template}' for the adapter '#{adapter}': #{inspect error}"
   def render({:command_error, response}) do

--- a/lib/cog/repository/bundles.ex
+++ b/lib/cog/repository/bundles.ex
@@ -415,7 +415,7 @@ defmodule Cog.Repository.Bundles do
              # TODO: Do we need bundle on bundle_version?
              preload: [:bundle_version,
                        options: :option_type,
-                       command: [:bundle, :rules]])
+                       command: [:bundle]])
     Repo.one(query)
   end
 

--- a/test/cog/command/pipeline/binder_test.exs
+++ b/test/cog/command/pipeline/binder_test.exs
@@ -2,8 +2,7 @@ defmodule Cog.Command.Pipeline.Binder.Test do
   use ExUnit.Case
 
   alias Cog.Command.Pipeline.Binder
-  alias Cog.Models.Command
-  alias Cog.Models.CommandVersion
+  alias Cog.Command.Pipeline.ParserMeta
   alias Piper.Command.Ast
 
   import Cog.ExecutorHelpers, only: [unbound_invocation: 1]
@@ -13,7 +12,7 @@ defmodule Cog.Command.Pipeline.Binder.Test do
     invocation =  unbound_invocation("ec2 --tags=foo")
     {:ok, bound} = Binder.bind(invocation, %{})
     assert %Piper.Command.Ast.Invocation{args: [%Piper.Command.Ast.Option{name: %Piper.Command.Ast.String{col: 7, line: 1, value: "tags"}, opt_type: :long, value: "foo"}],
-                                         meta: %CommandVersion{command: %Command{name: "ec2"}},
+                                         meta: %ParserMeta{command_name: "ec2"},
                                          name: %Piper.Command.Ast.Name{bundle: %Piper.Command.Ast.String{col: 1, line: 1, value: "test-bundle"},
                                                                        entity: %Piper.Command.Ast.String{col: 1, line: 1, value: "ec2"}}, redir: nil} = bound
   end
@@ -28,7 +27,7 @@ defmodule Cog.Command.Pipeline.Binder.Test do
                                           opt_type: :long,
                                           value: %Ast.Variable{col: 12, line: 1 , name: 'tag', value: "monkey"}}
                             ],
-                           meta: %CommandVersion{command: %Command{name: "ec2"}},
+                           meta: %ParserMeta{command_name: "ec2"},
                            name: %Piper.Command.Ast.Name{bundle: %Piper.Command.Ast.String{col: 1, line: 1, value: "test-bundle"},
                                                          entity: %Piper.Command.Ast.String{col: 1, line: 1, value: "ec2"}},
                            redir: nil} = bound

--- a/test/cog/command/pipeline/planner_test.exs
+++ b/test/cog/command/pipeline/planner_test.exs
@@ -15,8 +15,8 @@ defmodule Cog.Command.Pipeline.Planner.Test do
                                     rules: ["when command is test:test must have test:admin"])
     plans = Planner.plan(invocation, [%{"var" => "stuff"}], ["test:admin"])
 
-    command_version = invocation.meta
-    assert {:ok, [%Plan{command_version: ^command_version,
+    parser_meta = invocation.meta
+    assert {:ok, [%Plan{parser_meta: ^parser_meta,
                         options: %{"foo" => "stuff"},
                         args: [],
                         cog_env: %{"var" => "stuff"}}]} = plans
@@ -32,16 +32,16 @@ defmodule Cog.Command.Pipeline.Planner.Test do
                                       %{"var" => "thingies"}],
                          ["test:admin"])
 
-    command_version = invocation.meta
-    assert {:ok, [%Plan{command_version: ^command_version,
+    parser_meta = invocation.meta
+    assert {:ok, [%Plan{parser_meta: ^parser_meta,
                         options: %{"foo" => "stuff"},
                         args: [],
                         cog_env: %{"var" => "stuff"}},
-                  %Plan{command_version: ^command_version,
+                  %Plan{parser_meta: ^parser_meta,
                         options: %{"foo" => "other"},
                         args: [],
                         cog_env: %{"var" => "other"}},
-                  %Plan{command_version: ^command_version,
+                  %Plan{parser_meta: ^parser_meta,
                         options: %{"foo" => "thingies"},
                         args: [],
                         cog_env: %{"var" => "thingies"}}

--- a/test/support/executor_helpers.ex
+++ b/test/support/executor_helpers.ex
@@ -3,8 +3,7 @@ defmodule Cog.ExecutorHelpers do
   require Logger
 
   alias Cog.Command.Pipeline.Binder
-  alias Cog.Models.Command
-  alias Cog.Models.CommandVersion
+  alias Cog.Command.Pipeline.ParserMeta
   alias Cog.Models.CommandOption
   alias Cog.Models.CommandOptionType
   alias Piper.Command.Parser
@@ -40,18 +39,19 @@ defmodule Cog.ExecutorHelpers do
                  _ ->
                    bundle
                end
-      {:command, {bundle, name, command_from_spec([name: name,
-                                                   bundle: bundle] ++ command_spec)}}
+      {:command, {bundle, name, parser_meta_from_spec([name: name,
+                                                       bundle: bundle] ++ command_spec)}}
     end
   end
 
-  defp command_from_spec(spec) do
-    %CommandVersion{
-      command: %Command{name: Keyword.fetch!(spec, :name),
-                        rules: Enum.map(Keyword.get(spec, :rules, []), &rule_from_text/1),
-                        bundle: %Cog.Models.Bundle{name: Keyword.fetch!(spec, :bundle)}},
-      bundle_version: %Cog.Models.BundleVersion{version: "1.0.0"},
-      options: Enum.map(Keyword.get(spec, :options, []), &option_from_spec/1)}
+  defp parser_meta_from_spec(spec) do
+    {:ok, version} = Version.parse("1.0.0")
+    ParserMeta.new(Keyword.fetch!(spec, :bundle),
+                   Keyword.fetch!(spec, :name),
+                   version,
+                   "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                   Enum.map(Keyword.get(spec, :options, []), &option_from_spec/1),
+                   Enum.map(Keyword.get(spec, :rules, []), &rule_from_text/1))
   end
 
   defp option_from_spec(spec) do


### PR DESCRIPTION
Previously, during parsing, we would return a `CommandVersion` model
corresponding to the specific command details for the appropriate
enabled bundle; this "metadata" was then utilized in several places in
the pipeline execution flow. In particular, this is the mechanism by
which we retrieved the rules to evaluate to determine if a user was
authorized to execute a given command.

With the introduction of bundle versions, the association of
user-entered rules with the "site" bundle, and the internal
enabling/disabling of rules, retrieval of rules for a given command
became more complicated, particularly since such requirements cannot
currently be expressed as an Ecto association. A minimal solution would
be to retrieve the appropriate rules "out of band" and then replace the
"wrong" `command_version.command.rules` data in the model with
them. While this works, it would mean that the same model field would
have two different meanings, depending on where it was used. That way
lies madness, though.

As an alternative, this commit concretely defines what we need from our
parser metadata. A new `Cog.Command.Pipeline.ParserMeta` struct is
introduced, with fields determined by tracing the flow of the parser
metadata through the executor. Instead of abusing a `CommandVersion`
struct, we now generate a `ParserMeta` struct in the `CommandResolver`.

A test was added to verify that the appropriate site rules and bundle
rules are retrieved, and that enabled status of rules is respected.