### PR TITLE
Do not assign special bundles to relay groups

### DIFF
--- a/lib/cog/models/bundle.ex
+++ b/lib/cog/models/bundle.ex
@@ -36,9 +36,13 @@ end
 
 defimpl Groupable, for: Cog.Models.Bundle do
 
-  def add_to(bundle, relay_group),
-    do: Cog.Models.JoinTable.associate(bundle, relay_group)
-
+  def add_to(bundle, relay_group) do
+    if bundle.name in [Cog.embedded_bundle, Cog.site_namespace] do
+      raise Cog.ProtectedBundleError, {:protected_bundle, bundle.name}
+    else
+      Cog.Models.JoinTable.associate(bundle, relay_group)
+    end
+  end
   def remove_from(bundle, relay_group),
     do: Cog.Models.JoinTable.dissociate(bundle, relay_group)
 

--- a/lib/cog/models/bundle.ex
+++ b/lib/cog/models/bundle.ex
@@ -38,7 +38,7 @@ defimpl Groupable, for: Cog.Models.Bundle do
 
   def add_to(bundle, relay_group) do
     if bundle.name in [Cog.embedded_bundle, Cog.site_namespace] do
-      raise Cog.ProtectedBundleError, {:protected_bundle, bundle.name}
+      raise Cog.ProtectedBundleError, bundle.name
     else
       Cog.Models.JoinTable.associate(bundle, relay_group)
     end

--- a/lib/cog/protected_bundle_error.ex
+++ b/lib/cog/protected_bundle_error.ex
@@ -1,8 +1,8 @@
 defmodule Cog.ProtectedBundleError do
-  defexception [:message, :reason]
+  defexception [:message, :bundle]
 
-  def exception(reason),
-    do: %__MODULE__{message: "Operation not permitted on a protected bundle: #{inspect reason}",
-                    reason: reason}
+  def exception(bundle_name),
+    do: %__MODULE__{message: "Operation not permitted on a protected bundle #{inspect bundle_name}",
+                    bundle: bundle_name}
 
 end

--- a/lib/cog/protected_bundle_error.ex
+++ b/lib/cog/protected_bundle_error.ex
@@ -1,0 +1,8 @@
+defmodule Cog.ProtectedBundleError do
+  defexception [:message, :reason]
+
+  def exception(reason),
+    do: %__MODULE__{message: "Operation not permitted on a protected bundle: #{inspect reason}",
+                    reason: reason}
+
+end

--- a/lib/cog/repository/relay_groups.ex
+++ b/lib/cog/repository/relay_groups.ex
@@ -54,7 +54,7 @@ defmodule Cog.Repository.RelayGroups do
     with :ok <- valid_uuid(id) do
       case Repo.get(RelayGroup, id) do
         %RelayGroup{} = relay_group ->
-          {:ok, Repo.preload(relay_group, [:bundles, :relays])}
+          {:ok, Repo.preload(relay_group, [[bundles: :versions], :relays])}
         nil ->
           {:error, :not_found}
       end
@@ -68,7 +68,7 @@ defmodule Cog.Repository.RelayGroups do
   def by_id!(id) do
     valid_uuid!(id)
     Repo.get!(RelayGroup, id)
-    |> Repo.preload([:bundles, :relays])
+    |> Repo.preload([[bundles: :versions], :relays])
   end
 
   @doc """

--- a/lib/cog/repository/relay_groups.ex
+++ b/lib/cog/repository/relay_groups.ex
@@ -149,7 +149,7 @@ defmodule Cog.Repository.RelayGroups do
         by_id!(relay_group.id)
       rescue
         e in Cog.ProtectedBundleError ->
-          Repo.rollback(e.reason)
+          Repo.rollback({:protected_bundle, e.bundle})
       end
     end)
   end

--- a/test/controllers/v1/relay_group_membership_controller_test.exs
+++ b/test/controllers/v1/relay_group_membership_controller_test.exs
@@ -3,6 +3,8 @@ defmodule Cog.V1.RelayGroupMembershipControllerTest do
   use Cog.ModelCase
   use Cog.ConnCase
 
+  alias Cog.Models.Bundle
+
   @relay_create_attrs %{name: "test-relay-1", token: "foo"}
   @relay_group_create_attrs %{name: "test-relay-group-1"}
 
@@ -251,6 +253,18 @@ defmodule Cog.V1.RelayGroupMembershipControllerTest do
       |> Enum.sort
     assert bundle_ids == sorted_response
   end
+
+  Enum.each([Cog.embedded_bundle, Cog.site_namespace], fn(bundle_name)->
+    test "cannot assign protected bundle #{bundle_name} to a relay", %{authed: requestor} do
+      relay_group = relay_group("test-group")
+
+      %Bundle{id: id} = Cog.Repo.get_by!(Bundle, name: unquote(bundle_name))
+      conn = api_request(requestor, :post, "/v1/relay_groups/#{relay_group.id}/bundles",
+                         body: %{"bundles" => %{"add" => [id]}})
+
+      assert json_response(conn, 422)
+    end
+  end)
 
   test "adding bundles fails if a bundle does not exist", %{authed: requestor} do
     relay_group = relay_group("test-relay-group-3")

--- a/test/controllers/v1/relay_group_membership_controller_test.exs
+++ b/test/controllers/v1/relay_group_membership_controller_test.exs
@@ -262,7 +262,7 @@ defmodule Cog.V1.RelayGroupMembershipControllerTest do
       conn = api_request(requestor, :post, "/v1/relay_groups/#{relay_group.id}/bundles",
                          body: %{"bundles" => %{"add" => [id]}})
 
-      assert json_response(conn, 422)
+      assert %{"protected_bundle" => unquote(bundle_name)} = json_response(conn, 422)["errors"]
     end
   end)
 

--- a/web/controllers/v1/relay_group_membership_controller.ex
+++ b/web/controllers/v1/relay_group_membership_controller.ex
@@ -44,6 +44,10 @@ defmodule Cog.V1.RelayGroupMembershipController do
         conn
         |> put_status(:unprocessable_entity)
         |> json(%{"errors" => %{"bad_id" => %{type => ids}}})
+      {:error, {:protected_bundle, bundle_name}} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{"errors" => %{"protected_bundle" => bundle_name}})
     end
   end
 

--- a/web/controllers/v1/relay_group_membership_controller.ex
+++ b/web/controllers/v1/relay_group_membership_controller.ex
@@ -2,8 +2,7 @@ defmodule Cog.V1.RelayGroupMembershipController do
   use Cog.Web, :controller
 
   alias Cog.Models.RelayGroup
-  alias Cog.Models.Bundle
-  alias Cog.Models.Relay
+  alias Cog.Repository.RelayGroups
 
   plug Cog.Plug.Authentication
   plug Cog.Plug.Authorization, permission: "#{Cog.embedded_bundle}:manage_relays"
@@ -23,32 +22,17 @@ defmodule Cog.V1.RelayGroupMembershipController do
   end
 
   def manage_relay_membership(conn, %{"id" => id, "relays" => member_spec}),
-  do: manage_association(conn, %{"id" => id, "members" => %{"relays" => member_spec}})
+    do: manage_association(conn, %{"id" => id, "members" => %{"relays" => member_spec}})
 
   def manage_bundle_assignment(conn, %{"id" => id, "bundles" => member_spec}),
-  do: manage_association(conn, %{"id" => id, "members" => %{"bundles" => member_spec}})
+    do: manage_association(conn, %{"id" => id, "members" => %{"bundles" => member_spec}})
 
   # Manage membership of a relay group. Adds and deletes can be submitted and
   # processed in a single request.
-  # TODO:
-  # The bulk of this was actually copied from `Cog.V1.GroupMembershipController`
-  # we may want to think about consolidating the code at some point.
   def manage_association(conn, %{"id" => id, "members" => member_spec}) do
-    result = Repo.transaction(fn() ->
-      relay_group = Repo.get!(RelayGroup, id)
+    relay_group = Repo.get!(RelayGroup, id)
 
-      member_keys = Map.keys(member_spec)
-
-      members_to_add = Enum.flat_map(member_keys, &lookup_or_fail(member_spec, [&1, "add"]))
-      members_to_remove = Enum.flat_map(member_keys, &lookup_or_fail(member_spec, [&1, "remove"]))
-
-      relay_group
-      |> add(members_to_add)
-      |> remove(members_to_remove)
-      |> Repo.preload([[bundles: :versions], :relays])
-    end)
-
-    case result do
+    case RelayGroups.manage_association(relay_group, member_spec) do
       {:ok, relay_group} ->
         conn
         |> render("show.json", relay_group: relay_group)
@@ -63,72 +47,4 @@ defmodule Cog.V1.RelayGroupMembershipController do
     end
   end
 
-  defp lookup_or_fail(member_spec, [kind, _operation]=path) do
-    names = get_in(member_spec, path) || []
-    case lookup_all(kind, names) do
-      {:ok, structs} -> structs
-      {:error, reason} ->
-        Repo.rollback(reason)
-    end
-  end
-
-  defp lookup_all(_, []), do: {:ok, []} # Don't bother with a DB lookup
-  defp lookup_all(kind, ids) when kind in ["relays", "bundles"] do
-
-    type = kind_to_type(kind) # e.g. "relays" -> Relay
-
-    # Since we are using ids we need to make sure that they are all valid UUIDs
-    # before we query the db. Otherwise Ecto with crash with a CastError
-    case good_ids?(ids) do
-      true ->
-        results = Repo.all(from t in type, where: t.id in ^ids)
-
-        # make sure we got a result for each id given
-        case length(results) == length(ids) do
-          true ->
-            # Each name corresponds to an entity in the database
-            {:ok, results}
-          false ->
-            # We got at least one name that doesn't map to any existing
-            # user or group. Find out what's missing and report back
-            retrieved_ids = Enum.map(results, &Map.get(&1, :id))
-            bad_ids = ids -- retrieved_ids
-            {:error, {:not_found, {kind, bad_ids}}}
-        end
-      {false, bad_ids} ->
-        {:error, {:bad_id, {kind, bad_ids}}}
-    end
-  end
-
-  defp good_ids?(ids) do
-    bad_ids = Enum.reduce(ids, [], fn(id, acc) ->
-      case Ecto.UUID.cast(id) do
-        {:ok, _id} ->
-          acc
-        :error ->
-          [id | acc]
-      end
-    end)
-
-    if length(bad_ids) > 0 do
-      {false, bad_ids}
-    else
-      true
-    end
-  end
-
-  defp add(relay_group, members) do
-    Enum.each(members, &Groupable.add_to(&1, relay_group))
-    relay_group
-  end
-
-  defp remove(relay_group, members) do
-    Enum.each(members, &Groupable.remove_from(&1, relay_group))
-    relay_group
-  end
-
-
-  # Given a member_spec key, return the underlying type
-  defp kind_to_type("relays"), do: Relay
-  defp kind_to_type("bundles"), do: Bundle
 end


### PR DESCRIPTION
We shouldn't be able to assign the `operable` or `site` bundles to a relay group. Assigning the latter should be harmless, though confusing; assigning the former would probably break everything, since it's an Elixir bundle and Relay doesn't know anything about those.