### PR TITLE
Be more accepting in what we consider a "version"

### DIFF
--- a/lib/cog/models/types/version_triple.ex
+++ b/lib/cog/models/types/version_triple.ex
@@ -24,8 +24,15 @@ defmodule Cog.Models.Types.VersionTriple do
         # Major and minor version; e.g. "1.0" == "1.0.0"
         Version.parse(text <> ".0")
       true ->
-        # Treat it like semver
-        Version.parse(text)
+        # Treat it like semver, but only if it's just
+        # major.minor.patch... we don't handle prerelease or build
+        # metadata at the moment
+        case Version.parse(text) do
+          {:ok, %Version{pre: [], build: nil}=v} ->
+            {:ok, v}
+          _ ->
+            :error
+        end
     end
   end
   def cast(%Version{}=v),

--- a/lib/cog/models/types/version_triple.ex
+++ b/lib/cog/models/types/version_triple.ex
@@ -13,8 +13,21 @@ defmodule Cog.Models.Types.VersionTriple do
   def type,
     do: :array
 
-  def cast(text) when is_binary(text),
-    do: Version.parse(text)
+  def cast(num) when is_integer(num) or is_float(num),
+    do: cast(to_string(num))
+  def cast(text) when is_binary(text) do
+    cond do
+      Regex.match?(~r/\A\d+\z/, text) ->
+        # Just a major version; e.g. "1" == "1.0.0"
+        Version.parse(text <> ".0.0")
+      Regex.match?(~r/\A\d+\.\d+\z/, text) ->
+        # Major and minor version; e.g. "1.0" == "1.0.0"
+        Version.parse(text <> ".0")
+      true ->
+        # Treat it like semver
+        Version.parse(text)
+    end
+  end
   def cast(%Version{}=v),
     do: {:ok, v}
   def cast(_),

--- a/test/cog/models/types/version_triple_test.exs
+++ b/test/cog/models/types/version_triple_test.exs
@@ -11,6 +11,18 @@ defmodule Cog.Models.Types.VersionTripleTest do
     assert_version_casts_to("1.0.0", "1.0.0")
   end
 
+  test "prerelease metadata are not allowed" do
+    assert :error = VersionTriple.cast("1.0.0-pre1")
+  end
+
+  test "build metadata are not allowed" do
+    assert :error = VersionTriple.cast("1.0.0+0123")
+  end
+
+  test "prerelease and build metadata together are not allowed" do
+    assert :error = VersionTriple.cast("1.0.0-pre1+0123")
+  end
+
   ########################################################################
 
   defp assert_version_casts_to(input, expected_string),

--- a/test/cog/models/types/version_triple_test.exs
+++ b/test/cog/models/types/version_triple_test.exs
@@ -1,0 +1,19 @@
+defmodule Cog.Models.Types.VersionTripleTest do
+  use ExUnit.Case, async: true
+
+  alias Cog.Models.Types.VersionTriple
+
+  test "things that are not strictly semver still cast" do
+    assert_version_casts_to(1, "1.0.0")
+    assert_version_casts_to(1.0, "1.0.0")
+    assert_version_casts_to("1", "1.0.0")
+    assert_version_casts_to("1.0", "1.0.0")
+    assert_version_casts_to("1.0.0", "1.0.0")
+  end
+
+  ########################################################################
+
+  defp assert_version_casts_to(input, expected_string),
+    do: assert Version.parse(expected_string) == VersionTriple.cast(input)
+
+end

--- a/test/cog/repository/bundles_test.exs
+++ b/test/cog/repository/bundles_test.exs
@@ -325,6 +325,38 @@ defmodule Cog.Repository.BundlesTest do
 
   end
 
+  test "providing only a major version works" do
+    {:ok, new_version} = Bundles.install(%{"name" => "bundle-testing",
+                                           "version" => "1",
+                                           "config_file" => %{"name" => "bundle-testing",
+                                                              "version" => "1"}})
+    assert new_version.version == version("1.0.0")
+  end
+
+  test "providing only a major and minor version works" do
+    {:ok, new_version} = Bundles.install(%{"name" => "bundle-testing",
+                                           "version" => "1.0",
+                                           "config_file" => %{"name" => "bundle-testing",
+                                                              "version" => "1.0"}})
+    assert new_version.version == version("1.0.0")
+  end
+
+  test "providing an integer major version works" do
+    {:ok, new_version} = Bundles.install(%{"name" => "bundle-testing",
+                                           "version" => 1,
+                                           "config_file" => %{"name" => "bundle-testing",
+                                                              "version" => 1}})
+    assert new_version.version == version("1.0.0")
+  end
+
+  test "providing a float for major and minor version works" do
+    {:ok, new_version} = Bundles.install(%{"name" => "bundle-testing",
+                                           "version" => 1.0,
+                                           "config_file" => %{"name" => "bundle-testing",
+                                                              "version" => 1.0}})
+    assert new_version.version == version("1.0.0")
+  end
+
   ########################################################################
 
   defp bundle_named(name),

--- a/test/cog/repository/bundles_test.exs
+++ b/test/cog/repository/bundles_test.exs
@@ -357,6 +357,14 @@ defmodule Cog.Repository.BundlesTest do
     assert new_version.version == version("1.0.0")
   end
 
+  test "prerelease metadata on versions are not allowed" do
+    assert {:error, {:db_errors, [version: "is invalid"]}} = Bundles.install(%{"name" => "bundle-testing",
+                                                                               "version" => "1.0.0-pre1",
+                                                                               "config_file" => %{"name" => "bundle-testing",
+                                                                                                  "version" => "1.0.0-pre1"}})
+  end
+
+
   ########################################################################
 
   defp bundle_named(name),


### PR DESCRIPTION
Previously, we strictly required a String in `"major.minor.patch"`
format for a version. Now, we'll accept any of the following:

* major version, as integer
* major.minor version as float
* "major" version as string
* "major.minor" version as string
* "major.minor.patch" version as string (previous behavior)

That is, `1`, `1.0`, `"1"`, `"1.0"`, and `"1.0.0"` are all equivalent
now.