### PR TITLE
Migrate enabled bundle state from older installations

### DIFF
--- a/priv/repo/migrations/20160531183124_carry_over_enabled_bundle_state.exs
+++ b/priv/repo/migrations/20160531183124_carry_over_enabled_bundle_state.exs
@@ -1,0 +1,19 @@
+defmodule Cog.Repo.Migrations.CarryOverEnabledBundleState do
+  use Ecto.Migration
+
+  def change do
+
+    execute """
+    INSERT INTO enabled_bundle_versions
+    SELECT b_v2.id, bv.version
+    FROM bundle_versions_v2 AS bv
+    JOIN bundles_v2 AS b_v2
+      ON b_v2.id = bv.bundle_id
+    JOIN bundles AS old_bundles
+      ON old_bundles.name = b_v2.name
+     AND string_to_array(old_bundles.version, '.')::int[] = bv.version
+    WHERE old_bundles.enabled IS TRUE
+    """
+
+  end
+end


### PR DESCRIPTION
This will ensure that everything that was enabled in a 0.6.0 system
remains enabled in a 0.7.0 system. Relies on the old bundle data still
being around.