### PR TITLE
Find enabled and disabled commands to print helpful error

### DIFF
--- a/lib/cog/models/command_version.ex
+++ b/lib/cog/models/command_version.ex
@@ -6,6 +6,7 @@ defmodule Cog.Models.CommandVersion do
 
   schema "command_versions_v2" do
     field :documentation, :string
+    field :status, :string, virtual: true
 
     belongs_to :command, Command
     belongs_to :bundle_version, BundleVersion


### PR DESCRIPTION
If you call help on a disabled command you will now receive the following:

```
Command "mist:ec2-find" is disabled. Run "bundle enable mist" to enable it.
```