### PR TITLE
Allow Triggers to receive x-www-form-urlencoded payloads as well as JSON

### DIFF
--- a/web/controllers/v1/trigger_execution_controller.ex
+++ b/web/controllers/v1/trigger_execution_controller.ex
@@ -135,7 +135,12 @@ defmodule Cog.V1.TriggerExecutionController do
                     "" ->
                       {:ok, %{}}
                     _ ->
-                      Poison.decode(raw_body)
+                      case :proplists.get_value("content-type", conn.req_headers) do
+                        :undefined ->
+                          {:error, "missing content-type"}
+                        type ->
+                          parse_type(type, raw_body)
+                      end
                   end
 
     case parsed_body do
@@ -148,6 +153,15 @@ defmodule Cog.V1.TriggerExecutionController do
         |> put_status(:unsupported_media_type)
         |> halt
     end
+  end
+
+  defp parse_type("application/x-www-form-urlencoded", body) do
+    Plug.Conn.Utils.validate_utf8!(body, Plug.Parsers.BadEncodingError, "urlencoded body")
+    {:ok, Plug.Conn.Query.decode(body)}
+  end
+
+  defp parse_type("application/json", body) do
+    Poison.decode(body)
   end
 
   defp set_raw_body(conn, raw_body),

--- a/web/controllers/v1/trigger_execution_controller.ex
+++ b/web/controllers/v1/trigger_execution_controller.ex
@@ -164,6 +164,10 @@ defmodule Cog.V1.TriggerExecutionController do
     Poison.decode(body)
   end
 
+  defp parse_type(type, _body) do
+    {:error, "invalid trigger content-type: #{type}"}
+  end
+
   defp set_raw_body(conn, raw_body),
     do: assign(conn, :raw_body, raw_body)
 


### PR DESCRIPTION
This PR will allow triggers to accept and decode POST bodies that are encoded as `x-www-form-urlencoded` with the key/value pairs mapped to `cog_env.body` in the same was as JSON payloads. This allows triggers to serve as an endpoint for webhooks like Slack's slash commands that do not encode the body as JSON.

### Example:

Simply sends the text after the slash command to @imbriaco via DM:

```
 $ cogctl triggers create --name cog_register --pipeline 'echo $body.text > chat://@imbriaco' --as-user admin --enabled
ID              f9d362a5-910a-4941-bafb-3a277015bf6b
Name            cog_register
Pipeline        echo $body.text > chat://@imbriaco
Enabled         true
As User         admin
Timeout (sec)   30
Description
Invocation URL  http://localhost:4001/v1/triggers/f9d362a5-910a-4941-bafb-3a277015bf6b
```

### Slack Setup:

![slash commands operable slack 2016-06-02 11-22-04](https://cloud.githubusercontent.com/assets/1198/15750383/4363f918-28b4-11e6-9642-b4b12ebfee51.png)

### Result:

The following was generated in response to `/cog testing, 123` being sent via the Slack client.

![slack 2016-06-02 11-23-14](https://cloud.githubusercontent.com/assets/1198/15750466/90eb175c-28b4-11e6-93a5-584ce30667a5.png)

