### PR TITLE
Protect admin group memberships

### DIFF
--- a/lib/cog/repository/groups.ex
+++ b/lib/cog/repository/groups.ex
@@ -175,16 +175,18 @@ defmodule Cog.Repository.Groups do
       {user_models_to_add, role_models_to_add} = get_models("add", member_spec)
       {user_models_to_remove, role_models_to_remove} = get_models("remove", member_spec)
 
-      group
-      |> add(users_to_add ++ user_models_to_add)
-      |> grant(roles_to_add ++ role_models_to_add)
-      |> remove(users_to_remove ++ user_models_to_remove)
-      |> revoke(roles_to_remove ++ role_models_to_remove)
+      result = with :ok <- add(group, users_to_add ++ user_models_to_add),
+                    :ok <- grant(group, roles_to_add ++ role_models_to_add),
+                    :ok <- remove(group, users_to_remove ++ user_models_to_remove),
+                    :ok <- revoke(group, roles_to_remove ++ role_models_to_remove),
+                    do: by_id(group.id) # refetch group with updates
 
-
-      # We have to refetch the group here, otherwise the updates
-      # aren't loaded
-      by_id!(group.id)
+      case result do
+        {:ok, group} ->
+          group
+        {:error, error} ->
+          Repo.rollback(error)
+      end
     end)
   end
 
@@ -256,31 +258,55 @@ defmodule Cog.Repository.Groups do
   end
 
   # Add multiple `%User{}` or `%Group{}` members to `group`, returning
-  # `group`.
+  # `:ok` or the first error tuple encountered.
   #
   # Note that `members` can be a mix of types.
   defp add(group, members) do
-    Enum.each(members, &Groupable.add_to(&1, group))
-    group
+    Enum.reduce_while(members, :ok, fn member, :ok ->
+      case Groupable.add_to(member, group) do
+        :ok ->
+          {:cont, :ok}
+        error ->
+          {:halt, error}
+      end
+    end)
   end
 
   defp grant(group, members) do
-    Enum.each(members, &Permittable.grant_to(group, &1))
-    group
+    Enum.reduce_while(members, :ok, fn member, :ok ->
+      case Permittable.grant_to(group, member) do
+        :ok ->
+          {:cont, :ok}
+        error ->
+          {:halt, error}
+      end
+    end)
   end
 
   # Remove multiple `%User{}` or `%Group{}` members from `group`, returning
-  # `group`.
+  # `:ok` or the first error tuple encountered.
   #
   # Note that `members` can be a mix of types.
   defp remove(group, members) do
-    Enum.each(members, &Groupable.remove_from(&1, group))
-    group
+    Enum.reduce_while(members, :ok, fn member, :ok ->
+      case Groupable.remove_from(member, group) do
+        :ok ->
+          {:cont, :ok}
+        error ->
+          {:halt, error}
+      end
+    end)
   end
 
   defp revoke(group, members) do
-    Enum.each(members, &Permittable.revoke_from(group, &1))
-    group
+    Enum.reduce_while(members, :ok, fn member, :ok ->
+      case Permittable.revoke_from(group, member) do
+        :ok ->
+          {:cont, :ok}
+        error ->
+          {:halt, error}
+      end
+    end)
   end
 
   # Given a member_spec key, return the underlying type

--- a/lib/cog/repository/groups.ex
+++ b/lib/cog/repository/groups.ex
@@ -166,9 +166,9 @@ defmodule Cog.Repository.Groups do
 
   def manage_membership(%Group{}=group, %{"members" => member_spec}) do
     Repo.transaction(fn() ->
-      users_to_add     = lookup_or_fail(member_spec, ["users", "add"])
+      users_to_add    = lookup_or_fail(member_spec, ["users", "add"])
       roles_to_add    = lookup_or_fail(member_spec, ["roles", "add"])
-      users_to_remove  = lookup_or_fail(member_spec, ["users", "remove"])
+      users_to_remove = lookup_or_fail(member_spec, ["users", "remove"])
       roles_to_remove = lookup_or_fail(member_spec, ["roles", "remove"])
 
       # If we already have a model, there is no need to look it up again

--- a/priv/repo/migrations/20160617190613_protect_admin_group_membership.exs
+++ b/priv/repo/migrations/20160617190613_protect_admin_group_membership.exs
@@ -1,0 +1,48 @@
+defmodule Cog.Repo.Migrations.ProtectAdminGroupMembership do
+  use Ecto.Migration
+
+  def up do
+    execute """
+    CREATE OR REPLACE FUNCTION protect_admin_group_membership()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+    AS $$
+    DECLARE
+      admin_member_id     uuid;
+      cog_admin_group_id  uuid;
+    BEGIN
+      SELECT id INTO admin_member_id
+      FROM users
+      WHERE username = 'admin';
+
+      SELECT id INTO cog_admin_group_id
+      FROM groups
+      WHERE name = 'cog-admin';
+
+      IF OLD.member_id = admin_member_id AND OLD.group_id = cog_admin_group_id THEN
+        RAISE EXCEPTION 'cannot remove admin user from cog-admin group';
+      END IF;
+      RETURN NULL;
+    END;
+    $$;
+    """
+
+    execute """
+    CREATE CONSTRAINT TRIGGER protect_admin_group_membership
+    AFTER UPDATE OR DELETE
+    ON user_group_membership
+    FOR EACH ROW
+    EXECUTE PROCEDURE protect_admin_group_membership();
+    """
+  end
+
+  def down do
+    execute """
+    DROP TRIGGER protect_admin_group_membership ON user_group_membership;
+    """
+
+    execute """
+    DROP FUNCTION protect_admin_group_membership();
+    """
+  end
+end

--- a/web/controllers/v1/group_membership_controller.ex
+++ b/web/controllers/v1/group_membership_controller.ex
@@ -47,6 +47,10 @@ defmodule Cog.V1.GroupMembershipController do
         conn
         |> put_status(:unprocessable_entity)
         |> json(%{"errors" => %{"not_found" => %{key => names}}})
+      {:error, :cannot_remove_admin_user} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{errors: "The admin user cannot be removed from the cog-admin group"})
     end
   end
 


### PR DESCRIPTION
We now protect the admin's membership to the cog-admin group via a db trigger. If deleted via the API we return a descriptive error message.

![remove-admin](https://cloud.githubusercontent.com/assets/228734/16164896/eade2854-349d-11e6-931d-8d631dfb2b73.gif)

It turns out the admin user and cog-admin group are both already protected from name changes.