### PR TITLE
Bring `operable:bundle` command to parity with cogctl

### DIFF
--- a/lib/cog/commands/bundle.ex
+++ b/lib/cog/commands/bundle.ex
@@ -3,189 +3,84 @@ defmodule Cog.Commands.Bundle do
     bundle: Cog.embedded_bundle
 
   alias Cog.Models.{Bundle, BundleVersion}
-  alias Cog.Repository.Bundles
+  alias Cog.Commands.Bundle.{List, Versions, Info, Enable, Disable}
 
-  @moduledoc """
-  Manipulate and interrogate command bundle status.
+  require Cog.Commands.Helpers, as: Helpers
+  require Logger
 
-  A bundle may be either `enabled` or `disabled`. If a bundle is
-  enabled, chat invocations of commands contained within the bundle
-  will be executed. If the bundle is disabled, on the other hand, no
-  such commands will be run.
+  Helpers.usage :root, """
+  Manage bundles.
 
-  Bundles may be enabled or disabled independently of whether or not
-  any Relays are currently _running_ the bundles. The status of a
-  bundle is managed centrally; when a Relay serving the bundle comes
-  online, the status of the bundle is respected. Thus a bundle may be
-  enabled, but not running on any Relays, just as it can be disabled,
-  but running on _every_ Relay.
-
-  This can be used to either quickly disable a bundle, or as the first
-  step in deleting a bundle from the bot.
-
-  Note that the `#{Cog.embedded_bundle}` bundle is a protected bundle;
-  this bundle is always enabled and is in fact embedded in the bot
-  itself. Core pieces of bot functionality would not work (including
-  this very command itself!) if this bundle were ever disabled (though
-  many functions would remain available via the REST API). As a
-  result, calling either of the mutator subcommands `enable` or
-  `disable` (see below) on the `#{Cog.embedded_bundle}` bundle is an
-  error.
+  Note that installation and uninstallation of bundles cannot
+  currently be done via chat; please use `cogctl` for this
+  functionality.
 
   USAGE
-    bundle <subcommand>
 
+    bundle [subcommand]
+
+  FLAGS
+    -h, --help  Display this usage info
 
   SUBCOMMANDS
-    status
+    disable   Disable an installed bundle
+    enable    Enable a specific version of an installed bundle
+    info      Detailed information on an installed bundle
+    list      List all installed bundles (default)
+    versions  List all installed versions for a given bundle
 
-            bundle status <bundle_name>
-
-       Shows the current status of the bundle, whether `enabled` or
-       `disabled`. Additionally shows which Relays (if any) are running
-       the code for the bundle.
-
-       The `enable` and `disable` subcommands (see below) also return
-       this information.
-
-       Can be called on any bundle, including `#{Cog.embedded_bundle}`.
-
-    enable
-
-            bundle enable <bundle_name> [version]
-
-      Enabling a bundle allows chat commands to be routed to it. Running
-      this subcommand has no effect if a bundle is already enabled.
-
-      Cannot be used on the `#{Cog.embedded_bundle}` bundle.
-
-    disable
-
-            bundle disable <bundle_name>
-
-       Disabling a bundle prevents commands from being routed to it. The
-       bundle is not uninstalled, and all custom rules remain
-       intact. The bundle still exists, but commands in it will not be
-       executed.
-
-       A disabled bundle can be re-enabled using this the `enable`
-       sub-command; see above.
-
-       Running this subcommand has no effect if a bundle is already
-       disabled.
-
-       Cannot be used on the `#{Cog.embedded_bundle}` bundle.
   """
 
   permission "manage_commands"
 
   rule "when command is #{Cog.embedded_bundle}:bundle must have #{Cog.embedded_bundle}:manage_commands"
 
-  def handle_message(%{args: ["status", bundle_name]} = req, state) do
-    case Bundles.with_status_by_name(bundle_name) do
-      nil ->
-        {:error, req.reply_to, error_message({:not_found, bundle_name}), state}
-      bundle ->
-        {:reply, req.reply_to, "bundle-status", bundle, state}
-    end
-  end
-
-  def handle_message(%{args: ["enable", bundle_name|args]} = req, state) do
-    result = with {:ok, bundle_version}  <- parse_and_find_version(bundle_name, args),
-                  {:ok, bundle_version}  <- enable_bundle_version(bundle_version),
-                  do: {:ok, bundle_version}
-
-    case result do
-      {:ok, bundle} ->
-        {:reply, req.reply_to, "bundle-enable", Map.put(bundle, :status, :enabled), state}
-      {:error, error} ->
-        {:error, req.reply_to, error_message(error), state}
-    end
-  end
-
-  def handle_message(%{args: ["disable", bundle_name]} = req, state) do
-    result = with {:ok, bundle} <- find_enabled_bundle(bundle_name),
-                  {:ok, bundle} <- disable_bundle(bundle),
-                  do: {:ok, bundle}
-
-    case result do
-      {:ok, bundle} ->
-        {:reply, req.reply_to, "bundle-disable", Map.put(bundle, :status, :disabled), state}
-      {:error, error} ->
-        {:error, req.reply_to, error_message(error), state}
-    end
-  end
-
   def handle_message(req, state) do
-    {:error, req.reply_to, error_message(:invalid_invocation), state}
+    {subcommand, args} = Helpers.get_subcommand(req.args)
+
+    result = case subcommand do
+               "list"     -> List.list(req, args)
+               "versions" -> Versions.versions(req, args)
+               "info"     -> Info.info(req, args)
+               "disable"  -> Disable.disable(req, args)
+               "enable"   -> Enable.enable(req, args)
+               nil ->
+                 if Helpers.flag?(req.options, "help") do
+                   show_usage
+                 else
+                   List.list(req, args)
+                 end
+             end
+
+     case result do
+       {:ok, template, data} ->
+         {:reply, req.reply_to, template, data, state}
+       {:ok, data} ->
+         {:reply, req.reply_to, data, state}
+       {:error, err} ->
+         {:error, req.reply_to, error(err), state}
+     end
   end
 
-  defp enable_bundle_version(%BundleVersion{}=bundle_version) do
-    case Bundles.set_bundle_version_status(bundle_version, :enabled) do
-      :ok ->
-        {:ok, bundle_version}
-      error ->
-        error
-    end
-  end
+  ########################################################################
 
-  defp disable_bundle(%BundleVersion{}=bundle_version) do
-    case Bundles.set_bundle_version_status(bundle_version, :disabled) do
-      :ok ->
-        {:ok, bundle_version}
-      error ->
-        error
-    end
-  end
-
-  defp parse_and_find_version(bundle_name, []) do
-    case Bundles.highest_version_by_name(bundle_name) do
-      nil ->
-        {:error, {:not_found, bundle_name}}
-      bundle ->
-        {:ok, bundle}
-    end
-  end
-
-  defp parse_and_find_version(bundle_name, [version]) do
-    case Version.parse(version) do
-      {:ok, version} ->
-        case Bundles.with_name_and_version(bundle_name, version) do
-          nil ->
-            {:error, {:not_found, bundle_name, version}}
-          bundle ->
-            {:ok, bundle}
-        end
-      :error ->
-        {:error, {:invalid_version, version}}
-    end
-  end
-
-  def find_enabled_bundle(bundle_name) do
-    case Bundles.enabled_version_by_name(bundle_name) do
-      {:error, {:not_found, bundle_name}} ->
-        {:error, {:not_found, bundle_name}}
-      {:error, {:disabled, bundle_version}} ->
-        {:error, {:already_disabled, bundle_version}}
-      {:ok, bundle_version} ->
-        {:ok, bundle_version}
-    end
-  end
-
-  defp error_message({:not_found, name}),
+  defp error({:not_found, name}),
     do: "Bundle #{inspect name} cannot be found."
-  defp error_message({:not_found, name, version}),
+  defp error({:not_found, name, version}),
     do: "Bundle #{inspect name} with version #{inspect to_string(version)} cannot be found."
-  defp error_message({:protected_bundle, unquote(Cog.embedded_bundle)}),
+  defp error({:protected_bundle, unquote(Cog.embedded_bundle)}),
     do: "Bundle #{inspect Cog.embedded_bundle} is protected and cannot be disabled."
-  defp error_message({:protected_bundle, unquote(Cog.site_namespace)}),
+  defp error({:protected_bundle, unquote(Cog.site_namespace)}),
     do: "Bundle #{inspect Cog.site_namespace} is protected and cannot be enabled."
-  defp error_message({:protected_bundle, bundle_name}),
+  defp error({:protected_bundle, bundle_name}),
     do: "Bundle #{inspect bundle_name} is protected and cannot be enabled or disabled."
-  defp error_message({:invalid_version, version}),
+  defp error({:invalid_version, version}),
     do: "Version #{inspect version} could not be parsed."
-  defp error_message({:already_disabled, %BundleVersion{bundle: %Bundle{name: bundle_name}}}),
+  defp error({:already_disabled, %BundleVersion{bundle: %Bundle{name: bundle_name}}}),
     do: "Bundle #{inspect bundle_name} is already disabled."
-  defp error_message(:invalid_invocation),
+  defp error(:invalid_invocation),
     do: "That is not a valid invocation of the bundle command"
+  defp error(error),
+    do: Helpers.error(error)
+
 end

--- a/lib/cog/commands/bundle/disable.ex
+++ b/lib/cog/commands/bundle/disable.ex
@@ -1,0 +1,68 @@
+defmodule Cog.Commands.Bundle.Disable do
+  require Cog.Commands.Helpers, as: Helpers
+
+  alias Cog.Repository.Bundles
+  alias Cog.Models.BundleVersion
+
+  Helpers.usage """
+  Disable a bundle.
+
+  Disabling a bundle prevents commands from being routed to it. The
+  bundle is not uninstalled, and all custom rules remain intact. The
+  bundle still exists, but commands in it will not be executed.
+
+  A disabled bundle can be re-enabled using this the `enable`
+  sub-command.
+
+  Cannot be used on the `#{Cog.embedded_bundle}` bundle.
+
+  USAGE
+    bundle disable [FLAGS] <name>
+
+  ARGS
+    name  Specifies the bundle to disable.
+
+  FLAGS
+    -h, --help  Display this usage info
+
+  EXAMPLES
+
+    bundle disable my-bundle
+  """
+
+  def disable(%{options: %{"help" => true}}, _args),
+    do: show_usage
+  def disable(_req, [bundle_name]) do
+    with({:ok, bundle} <- find_enabled_bundle(bundle_name),
+         {:ok, bundle} <- disable_bundle(bundle)) do
+      {:ok, "bundle-disable", Map.put(bundle, :status, :disabled)}
+    end
+  end
+  def disable(_req, []),
+    do: {:error, {:not_enough_args, 1}}
+  def disable(_req, _),
+    do: {:error, {:too_many_args, 1}}
+
+  ########################################################################
+
+  defp find_enabled_bundle(bundle_name) do
+    case Bundles.enabled_version_by_name(bundle_name) do
+      {:error, {:not_found, bundle_name}} ->
+        {:error, {:not_found, bundle_name}}
+      {:error, {:disabled, bundle_version}} ->
+        {:error, {:already_disabled, bundle_version}}
+      {:ok, bundle_version} ->
+        {:ok, bundle_version}
+    end
+  end
+
+  defp disable_bundle(%BundleVersion{}=bundle_version) do
+    case Bundles.set_bundle_version_status(bundle_version, :disabled) do
+      :ok ->
+        {:ok, bundle_version}
+      error ->
+        error
+    end
+  end
+
+end

--- a/lib/cog/commands/bundle/enable.ex
+++ b/lib/cog/commands/bundle/enable.ex
@@ -1,0 +1,80 @@
+defmodule Cog.Commands.Bundle.Enable do
+  require Cog.Commands.Helpers, as: Helpers
+
+  alias Cog.Models.BundleVersion
+  alias Cog.Repository.Bundles
+
+  Helpers.usage """
+  Enable the specified version of a bundle, or the
+  latest installed version if no version is given.
+
+  Enabling a bundle allows chat commands to be routed to it. Running
+  this subcommand has no effect if a bundle is already enabled.
+
+  Cannot be used on the `#{Cog.embedded_bundle}` bundle.
+
+  USAGE
+    bundle enable [FLAGS] <name> [<version>]
+
+  ARGS
+    name     Specifies the bundle to enable.
+    version  The specific version of the bundle to enable. Defaults to latest installed version.
+
+  FLAGS
+    -h, --help  Display this usage info
+
+  EXAMPLES
+
+    bundle enable my-bundle 1.0.0
+    bundle enable my-bundle
+  """
+
+  def enable(%{options: %{"help" => true}}, _args),
+    do: show_usage
+  def enable(_req, []),
+    do: {:error, {:invalid_args, 1, 2}}
+  def enable(_req, [_,_,_|_]),
+    do: {:error, {:invalid_args, 1, 2}}
+  def enable(_req, [bundle_name|maybe_version]) do
+    with({:ok, bundle_version} <- parse_and_find_version(bundle_name, maybe_version),
+         {:ok, bundle_version} <- enable_bundle_version(bundle_version)) do
+      {:ok, "bundle-enable", Map.put(bundle_version, :status, :enabled)}
+    end
+  end
+
+  ########################################################################
+
+  defp parse_and_find_version(bundle_name, []) do
+    case Bundles.highest_version_by_name(bundle_name) do
+      nil ->
+        {:error, {:not_found, bundle_name}}
+      bundle ->
+        {:ok, bundle}
+    end
+  end
+
+  defp parse_and_find_version(bundle_name, [version]) do
+    case Version.parse(version) do
+      {:ok, version} ->
+        case Bundles.with_name_and_version(bundle_name, version) do
+          nil ->
+            {:error, {:not_found, bundle_name, version}}
+          bundle ->
+            {:ok, bundle}
+        end
+      :error ->
+        {:error, {:invalid_version, version}}
+    end
+  end
+
+  defp enable_bundle_version(%BundleVersion{}=bundle_version) do
+    case Bundles.set_bundle_version_status(bundle_version, :enabled) do
+      :ok ->
+        {:ok, bundle_version}
+      error ->
+        error
+    end
+  end
+
+
+end

--- a/lib/cog/commands/bundle/info.ex
+++ b/lib/cog/commands/bundle/info.ex
@@ -1,0 +1,33 @@
+defmodule Cog.Commands.Bundle.Info do
+  alias Cog.Repository.Bundles
+  require Cog.Commands.Helpers, as: Helpers
+
+  Helpers.usage """
+  Show detailed information about a specific bundle.
+
+  USAGE
+    bundle info [FLAGS] <bundle>
+
+  ARGS
+    bundle   The name of a bundle
+
+  FLAGS
+    -h, --help  Display this usage info
+  """
+
+  def info(%{options: %{"help" => true}}, _args) do
+    show_usage
+  end
+  def info(_req, [bundle_name]) do
+    case Bundles.bundle_by_name(bundle_name) do
+      nil ->
+        {:error, {:resource_not_found, "bundle", bundle_name}}
+      bundle ->
+        rendered = Cog.V1.BundlesView.render("show.json", %{bundle: bundle})
+        {:ok, "bundle-info", rendered[:bundle]}
+    end
+  end
+  def info(_req, []),
+    do: {:error, {:not_enough_args, 1}}
+
+end

--- a/lib/cog/commands/bundle/list.ex
+++ b/lib/cog/commands/bundle/list.ex
@@ -1,0 +1,23 @@
+defmodule Cog.Commands.Bundle.List do
+  alias Cog.Repository.Bundles
+  require Cog.Commands.Helpers, as: Helpers
+
+  Helpers.usage """
+  List all bundles.
+
+  USAGE
+    bundle list [FLAGS]
+
+  FLAGS
+    -h, --help  Display this usage info
+  """
+
+  def list(%{options: %{"help" => true}}, _args) do
+    show_usage
+  end
+  def list(_req, _args) do
+    rendered = Cog.V1.BundlesView.render("index.json", %{bundles: Bundles.bundles})
+    {:ok, "bundle-list", rendered[:bundles]}
+  end
+
+end

--- a/lib/cog/commands/bundle/versions.ex
+++ b/lib/cog/commands/bundle/versions.ex
@@ -1,0 +1,36 @@
+defmodule Cog.Commands.Bundle.Versions do
+  alias Cog.Repository.Bundles
+  require Cog.Commands.Helpers, as: Helpers
+
+  Helpers.usage """
+  Lists currently installed versions of a given bundle.
+
+  USAGE
+    bundle versions [FLAGS] <bundle>
+
+  ARGS
+    bundle   The name of a bundle
+
+  FLAGS
+    -h, --help  Display this usage info
+  """
+
+  def versions(%{options: %{"help" => true}}, _args) do
+    show_usage
+  end
+  def versions(_req, [bundle_name]) do
+    case Bundles.bundle_by_name(bundle_name) do
+      nil ->
+        {:error, {:resource_not_found, "bundle", bundle_name}}
+      bundle ->
+        versions = Bundles.versions(bundle)
+        rendered = Cog.V1.BundleVersionView.render("index.json", %{bundle_versions: versions})
+        {:ok, "bundle-versions", rendered[:bundle_versions]}
+    end
+  end
+  def versions(_req, []),
+    do: {:error, {:not_enough_args, 1}}
+  def versions(_req, _),
+    do: {:error, {:too_many_args, 1}}
+
+end

--- a/lib/cog/repository/bundles.ex
+++ b/lib/cog/repository/bundles.ex
@@ -107,6 +107,15 @@ defmodule Cog.Repository.Bundles do
     end
   end
 
+  def bundle_by_name(name) do
+    case Repo.get_by(Bundle, name: name) do
+      nil ->
+        nil
+      bundle ->
+        preload(bundle)
+    end
+  end
+
   @doc """
   Delete a bundle version, or an entire bundle (i.e., all versions for
   that bundle). You can only delete versions that are not currently

--- a/lib/cog/templates/slack/bundle-info.mustache
+++ b/lib/cog/templates/slack/bundle-info.mustache
@@ -1,0 +1,18 @@
+```
+ID: {{id}}
+Name: {{name}}
+Versions:
+{{#versions}}
+  {{version}}
+{{/versions}}
+{{^enabled_version}}
+Enabled Version: (disabled)
+{{/enabled_version}}
+{{#enabled_version}}
+Enabled Version: {{enabled_version.version}}
+{{/enabled_version}}
+Relay Groups:
+{{#relay_groups}}
+  {{name}}
+{{/relay_groups}}
+```

--- a/lib/cog/templates/slack/bundle-list.mustache
+++ b/lib/cog/templates/slack/bundle-list.mustache
@@ -1,0 +1,10 @@
+```
+ID: {{id}}
+Name: {{name}}
+{{^enabled_version}}
+Enabled Version: (disabled)
+{{/enabled_version}}
+{{#enabled_version}}
+Enabled Version: {{enabled_version.version}}
+{{/enabled_version}}
+```

--- a/lib/cog/templates/slack/bundle-versions.mustache
+++ b/lib/cog/templates/slack/bundle-versions.mustache
@@ -1,0 +1,6 @@
+```
+ID: {{id}}
+Name: {{name}}
+Version: {{version}}
+Enabled?: {{enabled}}
+```

--- a/test/integration/commands/bundle_test.exs
+++ b/test/integration/commands/bundle_test.exs
@@ -13,9 +13,36 @@ defmodule Integration.Commands.BundleTest do
     {:ok, %{user: user, bundle_version: bundle_version}}
   end
 
-  test "checking bundle status", %{user: user} do
-    response = send_message(user, "@bot: bundle status test_bundle")
-    assert_payload(response, %{name: "test_bundle", status: "disabled", version: "0.1.0"})
+  test "listing bundles", %{user: user} do
+    payload = user
+    |> send_message("@bot: operable:bundle list")
+    |> decode_payload
+    |> Enum.sort_by(fn(b) -> b[:name] end)
+
+    assert [%{name: "operable"},
+            %{name: "test_bundle"}] = payload
+  end
+
+  test "information about a single bundle", %{user: user} do
+    [payload] = user
+    |> send_message("@bot: operable:bundle info operable")
+    |> decode_payload
+
+    version = Application.spec(:cog, :vsn) |> IO.chardata_to_string
+
+    assert %{name: "operable",
+             enabled_version: %{version: ^version}} = payload
+  end
+
+  test "list versions for a bundle", %{user: user} do
+    payload = user
+    |> send_message("@bot: operable:bundle versions operable")
+    |> decode_payload
+
+    version = Application.spec(:cog, :vsn) |> IO.chardata_to_string
+
+    assert [%{name: "operable",
+              version: ^version}] = payload
   end
 
   test "enable a bundle", %{user: user, bundle_version: bundle_version} do


### PR DESCRIPTION
for the most part, anyway... we're not dealing with bundle install /
uninstall from chat right now.

`list`, `info`, and `versions` subcommands were added, so we can now
see what's actually installed. The `status` command was removed, since
`info` does its job now.

Existing subcommands were refactored to the subcommand-per-module
pattern.

Fixes #776