### PR TITLE
Add an `operable:user` command

### DIFF
--- a/lib/cog/commands/user.ex
+++ b/lib/cog/commands/user.ex
@@ -1,0 +1,58 @@
+defmodule Cog.Commands.User do
+  use Cog.Command.GenCommand.Base,
+    bundle: Cog.embedded_bundle
+
+  alias Cog.Commands.User.{Info, List}
+
+  require Cog.Commands.Helpers, as: Helpers
+  require Logger
+
+  Helpers.usage :root, """
+  View information on Cog users
+
+  USAGE
+
+    user [subcommand]
+
+  FLAGS
+    -h, --help  Display this usage info
+
+  SUBCOMMANDS
+    info      Show detailed information on a given user
+    list      List all users (default)
+  """
+
+  permission "manage_users"
+
+  rule "when command is #{Cog.embedded_bundle}:user must have #{Cog.embedded_bundle}:manage_users"
+
+  def handle_message(req, state) do
+    {subcommand, args} = Helpers.get_subcommand(req.args)
+
+    result = case subcommand do
+               "list" -> List.list(req, args)
+               "info" -> Info.info(req, args)
+               nil ->
+                 if Helpers.flag?(req.options, "help") do
+                   show_usage
+                 else
+                   List.list(req, args)
+                 end
+             end
+
+     case result do
+       {:ok, template, data} ->
+         {:reply, req.reply_to, template, data, state}
+       {:ok, data} ->
+         {:reply, req.reply_to, data, state}
+       {:error, err} ->
+         {:error, req.reply_to, error(err), state}
+     end
+  end
+
+  ########################################################################
+
+  defp error(error),
+    do: Helpers.error(error)
+
+end

--- a/lib/cog/commands/user/info.ex
+++ b/lib/cog/commands/user/info.ex
@@ -1,0 +1,35 @@
+defmodule Cog.Commands.User.Info do
+  alias Cog.Repository.Users
+  require Cog.Commands.Helpers, as: Helpers
+
+  Helpers.usage """
+  Show detailed information about a specific user.
+
+  USAGE
+    user info [FLAGS] <username>
+
+  ARGS
+    username   The name of a user
+
+  FLAGS
+    -h, --help  Display this usage info
+  """
+
+  def info(%{options: %{"help" => true}}, _args) do
+    show_usage
+  end
+  def info(_req, [user_name]) do
+    case Users.by_username(user_name) do
+      {:error, :not_found} ->
+        {:error, {:resource_not_found, "user", user_name}}
+      {:ok, user} ->
+        rendered = Cog.V1.UserView.render("show.json", %{user: user})
+        {:ok, "user-info", rendered[:user]}
+    end
+  end
+  def info(_req, []),
+    do: {:error, {:not_enough_args, 1}}
+  def info(_req, _),
+    do: {:error, {:too_many_args, 1}}
+
+end

--- a/lib/cog/commands/user/list.ex
+++ b/lib/cog/commands/user/list.ex
@@ -1,0 +1,23 @@
+defmodule Cog.Commands.User.List do
+  alias Cog.Repository.Users
+  require Cog.Commands.Helpers, as: Helpers
+
+  Helpers.usage """
+  List all users.
+
+  USAGE
+    user list [FLAGS]
+
+  FLAGS
+    -h, --help  Display this usage info
+  """
+
+  def list(%{options: %{"help" => true}}, _args) do
+    show_usage
+  end
+  def list(_req, _args) do
+    rendered = Cog.V1.UserView.render("index.json", %{users: Users.all})
+    {:ok, "user-list", rendered[:users]}
+  end
+
+end

--- a/lib/cog/templates/slack/user-info.mustache
+++ b/lib/cog/templates/slack/user-info.mustache
@@ -1,0 +1,14 @@
+```
+Username: {{username}}
+First Name: {{first_name}}
+Last Name: {{last_name}}
+Email Address: {{email_address}}
+Groups:
+{{#groups}}
+  {{name}}
+{{/groups}}
+Chat Handles:
+{{#chat_handles}}
+  {{chat_provider.name}}: {{handle}}
+{{/chat_handles}}
+```

--- a/lib/cog/templates/slack/user-list.mustache
+++ b/lib/cog/templates/slack/user-list.mustache
@@ -1,0 +1,6 @@
+```
+Username: {{username}}
+First Name: {{first_name}}
+Last Name: {{last_name}}
+Email Address: {{email_address}}
+```


### PR DESCRIPTION
Currently provides `list` and `info` subcommands.

Fixes #147 

<img width="367" alt="slack" src="https://cloud.githubusercontent.com/assets/207178/16232978/b37e3f52-379a-11e6-9831-3b8ee7903722.png">
