### PR TITLE
Cache and reuse relay assignments

### DIFF
--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -10,6 +10,7 @@ defmodule Cog.Command.Pipeline.Executor do
   alias Cog.ErrorResponse
   alias Cog.Events.PipelineEvent
   alias Cog.Queries
+  alias Cog.Relay.Relays
   alias Cog.Repo
   alias Cog.ServiceEndpoint
   alias Cog.Template
@@ -56,6 +57,7 @@ defmodule Cog.Command.Pipeline.Executor do
     mq_conn: Carrier.Messaging.Connection.connection(),
     request: %Cog.Command.Request{}, # TODO: needs to be a type
     destinations: [Destination.t],
+    relays: Map.t,
     invocations: [%Piper.Command.Ast.Invocation{}], # TODO: needs to be a type
     current_plan: Cog.Command.Pipeline.Plan.t,
     plans: [Cog.Command.Pipeline.Plan.t],
@@ -72,6 +74,7 @@ defmodule Cog.Command.Pipeline.Executor do
     mq_conn: nil,
     request: nil,
     destinations: [],
+    relays: %{},
     invocations: [],
     current_plan: nil,
     plans: [],
@@ -185,7 +188,7 @@ defmodule Cog.Command.Pipeline.Executor do
   def plan_next_invocation(:timeout, %__MODULE__{invocations: []}=state),
     do: succeed_with_response(state)
 
-  def execute_plan(:timeout, %__MODULE__{plans: [current_plan|remaining_plans], request: request, user: user}=state) do
+  def execute_plan(:timeout, %__MODULE__{plans: [current_plan|remaining_plans], relays: relays, request: request, user: user}=state) do
     bundle_name  = current_plan.parser_meta.bundle_name
     command_name = current_plan.parser_meta.command_name
     version      = current_plan.parser_meta.version
@@ -197,15 +200,14 @@ defmodule Cog.Command.Pipeline.Executor do
     #
     #   fail_pipeline_with_error({:disabled_bundle, bundle}, state)
     #
-
-    case Cog.Relay.Relays.pick_one(bundle_name, version) do
-      nil ->
+    case assign_relay(relays, bundle_name, version) do
+      {nil, _} ->
         fail_pipeline_with_error({:no_relays, bundle_name}, state)
-      relay ->
+      {relay, relays} ->
         topic = "/bot/commands/#{relay}/#{bundle_name}/#{command_name}"
         reply_to_topic = "#{state.topic}/reply"
         req = request_for_plan(current_plan, request, user, reply_to_topic, state.service_token)
-        updated_state =  %{state | current_plan: current_plan, plans: remaining_plans}
+        updated_state =  %{state | current_plan: current_plan, plans: remaining_plans, relays: relays}
 
         dispatch_event(updated_state, relay)
         Connection.publish(updated_state.mq_conn, Cog.Command.Request.encode!(req), routed_by: topic)
@@ -652,6 +654,31 @@ defmodule Cog.Command.Pipeline.Executor do
       |> HtmlEntities.decode                # Decode html entities
     end)
   end
+
+  defp assign_relay(relays, bundle_name, bundle_version) do
+    case Map.get(relays, bundle_name) do
+      # No assignment so let's pick one
+      nil ->
+        case Relays.pick_one(bundle_name, bundle_version) do
+          # No relays available
+          nil ->
+            {nil, relays}
+          # Store the selected relay in the relay cache
+          relay ->
+            {relay, Map.put(relays, bundle_name, relay)}
+        end
+      # Relay was previously assigned
+      relay ->
+        # Is the bundle still available on the relay? If not, remove the current assignment from the cache
+        # and select a new relay
+        if Relays.relay_available?(relay, bundle_name, bundle_version) == false do
+          relays = Map.delete(relays, bundle_name)
+          assign_relay(relays, bundle_name, bundle_version)
+        else
+          {relay, relays}
+        end
+    end
+ end
 
   def fetch_user_from_request(request) do
     adapter_module = request["module"] |> String.to_existing_atom

--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -671,11 +671,11 @@ defmodule Cog.Command.Pipeline.Executor do
       relay ->
         # Is the bundle still available on the relay? If not, remove the current assignment from the cache
         # and select a new relay
-        if Relays.relay_available?(relay, bundle_name, bundle_version) == false do
+        if Relays.relay_available?(relay, bundle_name, bundle_version) do
+          {relay, relays}
+        else
           relays = Map.delete(relays, bundle_name)
           assign_relay(relays, bundle_name, bundle_version)
-        else
-          {relay, relays}
         end
     end
  end

--- a/lib/cog/relay/relays.ex
+++ b/lib/cog/relay/relays.ex
@@ -30,6 +30,13 @@ defmodule Cog.Relay.Relays do
   def pick_one(bundle, version),
     do: GenServer.call(__MODULE__, {:random_relay, bundle, version}, :infinity)
 
+  @doc """
+  Answers the question "can this relay run this bundle?"
+  """
+  @spec relay_available?(String.t, String.t, String.t) :: boolean()
+  def relay_available?(relay, bundle, version),
+    do: GenServer.call(__MODULE__, {:relay_available, relay, bundle, version}, :infinity)
+
   def drop_bundle(bundle) do
     GenServer.call(__MODULE__, {:drop_bundle, bundle}, :infinity)
   end
@@ -90,6 +97,9 @@ defmodule Cog.Relay.Relays do
   end
   def handle_call({:random_relay, bundle, version}, _from, state),
     do: {:reply, random_relay(state.tracker, bundle, version), state}
+  def handle_call({:relay_available, relay, bundle, version}, _from, state) do
+    {:reply, Tracker.is_bundle_available?(state.tracker, relay, bundle, version), state}
+  end
   def handle_call({:drop_bundle, bundle}, _from, state) do
     tracker = Tracker.drop_bundle(state.tracker, bundle)
     {:reply, :ok, %{state | tracker: tracker}}

--- a/lib/cog/relay/tracker.ex
+++ b/lib/cog/relay/tracker.ex
@@ -14,6 +14,7 @@ defmodule Cog.Relay.Tracker do
   available.
   """
 
+  @type relay_id :: String.t
   @type bundle_name :: String.t
   @type version :: String.t # e.g. "1.0.0"
   @type version_spec :: {bundle_name, version}
@@ -128,6 +129,16 @@ defmodule Cog.Relay.Tracker do
     |> Map.get({bundle_name, bundle_version}, MapSet.new)
     |> MapSet.difference(tracker.disabled)
     |> MapSet.to_list
+  end
+
+  @doc """
+  Return true/false indicating whether or not the specified bundle version is available
+  on the selected relay.
+  """
+  @spec is_bundle_available?(t, relay_id, bundle_name, version) :: boolean()
+  def is_bundle_available?(tracker, relay, bundle_name, bundle_version) do
+    available_relays = relays(tracker, bundle_name, bundle_version)
+    Enum.member?(available_relays, relay)
   end
 
   defp in_tracker?(tracker, relay_id) do


### PR DESCRIPTION
This commit modifies Cog.Command.Pipeline.Executor to remember and reuse the Relay chosen to run an invocation for a bundle version. The memory persists between plans and stages allowing Cog to take maximum advantage of Relay's container reuse for a given pipeline.

The Executor also performs a safety check when it uses a cached Relay assignment. Before executing `current_plan`, the Executor double checks the selected Relay is still valid for the bundle version. If the Relay assignment is invalid (Relay is offline or the bundle version has been disabled/uninstalled) the Executor will attempt to select another Relay once before giving up and returning an error to the user.

Fixes #777 