### PR TITLE
Improve command prefix handling

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -53,7 +53,7 @@ config :httpotion, :default_timeout, 30000
 # ========================================================================
 # Commands, Bundles, and Services
 
-config :cog, :command_prefix, "!"
+config :cog, :command_prefix, System.get_env("COG_COMMAND_PREFIX") || "!"
 
 config :cog, Cog.Bundle.BundleSup,
   bundle_root: Path.join([File.cwd!, "bundles"])

--- a/lib/cog/adapters/hipchat/connection.ex
+++ b/lib/cog/adapters/hipchat/connection.ex
@@ -101,7 +101,7 @@ defmodule Cog.Adapters.HipChat.Connection do
   end
 
   defp compile_command_pattern(mention_name) do
-    ~r/\A(@?#{mention_name}:?\s*)|(#{command_prefix})/i
+    ~r/\A(@?#{mention_name}:?\s*)|(#{Regex.escape(command_prefix)})/i
   end
 
   defp command_prefix() do

--- a/lib/cog/adapters/irc/connection.ex
+++ b/lib/cog/adapters/irc/connection.ex
@@ -152,7 +152,7 @@ defmodule Cog.Adapters.IRC.Connection do
   end
 
   defp spoken?(message) do
-    regex = ~r/^#{command_prefix}\s*/
+    regex = ~r/^#{Regex.escape(command_prefix)}\s*/
 
     case {enable_spoken_commands?, Regex.split(regex, message, parts: 2)} do
       {true, ["", message]} ->

--- a/lib/cog/adapters/slack/rtm_connector.ex
+++ b/lib/cog/adapters/slack/rtm_connector.ex
@@ -170,7 +170,7 @@ defmodule Cog.Adapters.Slack.RTMConnector do
       false ->
         {:ok, state}
       true ->
-        text = Regex.replace(~r/^#{command_prefix}/, text, "")
+        text = Regex.replace(~r/^#{Regex.escape(command_prefix)}/, text, "")
         forward_command(room, user_id, text, state)
     end
   end

--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -647,7 +647,7 @@ defmodule Cog.Command.Pipeline.Executor do
 
     Map.update!(request, "text", fn text ->
       text
-      |> String.replace(~r/^#{prefix}/, "") # Remove command prefix
+      |> String.replace(~r/^#{Regex.escape(prefix)}/, "") # Remove command prefix
       |> String.replace(~r/“|”/, "\"")      # Replace OS X's smart quotes and dashes with ascii equivalent
       |> String.replace(~r/‘|’/, "'")
       |> String.replace(~r/—/, "--")


### PR DESCRIPTION
* Allow command prefix to be configured via `$COG_COMMAND_PREFIX`
* `Regex.escape` the prefix when we strip it from spoken commands