### PR TITLE
allow self updates takes a list of actions

### DIFF
--- a/test/controllers/v1/chat_handle_controller_test.exs
+++ b/test/controllers/v1/chat_handle_controller_test.exs
@@ -49,6 +49,12 @@ defmodule Cog.V1.ChatHandleControllerTest do
     end
   end
 
+  test "users can update their own chat handles even if they aren't authorized", params do
+    conn = api_request(params.unauthed, :post, "/v1/users/#{params.unauthed.id}/chat_handles", body: %{"chat_handle" => @valid_attrs})
+    id = json_response(conn, 201)["chat_handle"]["id"]
+    assert Repo.get_by(ChatHandle, id: id)
+  end
+
   test "creates and renders resource when data is valid", params do
     conn = api_request(params.authed, :post, "/v1/users/#{params.authed.id}/chat_handles", body: %{"chat_handle" => @valid_attrs})
     id = json_response(conn, 201)["chat_handle"]["id"]

--- a/test/plugs/authorization_test.exs
+++ b/test/plugs/authorization_test.exs
@@ -18,7 +18,7 @@ defmodule Cog.Plug.Authorization.Test do
   test "errors if :user assigns is missing", %{granted_name: permission} do
     # Seeing this error in real life means we've miscoded the
     # application and are calling this plug before the Authentication one.
-    error = catch_error(conn(:get, "/") |> Authorization.call(permission: permission))
+    error = catch_error(conn(:get, "/") |> Authorization.call(Authorization.init(permission: permission)))
     assert :function_clause = error
   end
 
@@ -39,20 +39,20 @@ defmodule Cog.Plug.Authorization.Test do
   end
 
   test "init returns the permission name when it is nominally valid", %{granted_name: name} do
-    assert [permission: ^name] = Authorization.init(permission: name)
+    assert [self_updates_on: [], permission: ^name] = Authorization.init(permission: name)
   end
 
   # TODO: we might want to rescue this error, log the problem, and
   # still return 403
   test "plug fails when passing an unrecognized permission" do
-    error = catch_error(conn(:get, "/") |> Authorization.call(permission: "#{Cog.embedded_bundle}:do_stuff"))
+    error = catch_error(conn(:get, "/") |> Authorization.call(Authorization.init(permission: "#{Cog.embedded_bundle}:do_stuff")))
     assert %Ecto.NoResultsError{} = error
   end
 
   test "plug halts with forbidden if user does not have the required permission",
   %{user: user, ungranted_name: permission} do
 
-    conn = conn(:get, "/") |> assign(:user, user) |> Authorization.call(permission: permission)
+    conn = conn(:get, "/") |> assign(:user, user) |> Authorization.call(Authorization.init(permission: permission))
 
     assert conn.halted
     assert conn.status == 403 # forbidden
@@ -62,7 +62,7 @@ defmodule Cog.Plug.Authorization.Test do
   test "plug does not halt if user has the required permission",
   %{user: user, granted_name: permission} do
 
-    conn = conn(:get, "/") |> assign(:user, user) |> Authorization.call(permission: permission)
+    conn = conn(:get, "/") |> assign(:user, user) |> Authorization.call(Authorization.init(permission: permission))
 
     refute conn.halted
     refute conn.status

--- a/web/controllers/v1/chat_handle_controller.ex
+++ b/web/controllers/v1/chat_handle_controller.ex
@@ -7,7 +7,7 @@ defmodule Cog.V1.ChatHandleController do
 
   plug Cog.Plug.Authentication
   plug Cog.Plug.Authorization, [permission: "#{Cog.embedded_bundle}:manage_users",
-                                allow_self_updates: true]
+                                allow_self_updates: [:upsert]]
 
   plug :scrub_params, "chat_handle" when action in [:create, :update]
 

--- a/web/controllers/v1/chat_handle_controller.ex
+++ b/web/controllers/v1/chat_handle_controller.ex
@@ -7,7 +7,7 @@ defmodule Cog.V1.ChatHandleController do
 
   plug Cog.Plug.Authentication
   plug Cog.Plug.Authorization, [permission: "#{Cog.embedded_bundle}:manage_users",
-                                allow_self_updates: [:upsert]]
+                                self_updates_on: :upsert]
 
   plug :scrub_params, "chat_handle" when action in [:create, :update]
 

--- a/web/controllers/v1/user_controller.ex
+++ b/web/controllers/v1/user_controller.ex
@@ -5,7 +5,7 @@ defmodule Cog.V1.UserController do
 
   plug Cog.Plug.Authentication
   plug Cog.Plug.Authorization, [permission: "#{Cog.embedded_bundle}:manage_users",
-                                allow_self_updates: true]
+                                allow_self_updates: [:update, :show]]
 
   plug :scrub_params, "user" when action in [:create, :update]
 

--- a/web/controllers/v1/user_controller.ex
+++ b/web/controllers/v1/user_controller.ex
@@ -5,7 +5,7 @@ defmodule Cog.V1.UserController do
 
   plug Cog.Plug.Authentication
   plug Cog.Plug.Authorization, [permission: "#{Cog.embedded_bundle}:manage_users",
-                                allow_self_updates: [:update, :show]]
+                                self_updates_on: [:update, :show]]
 
   plug :scrub_params, "user" when action in [:create, :update]
 

--- a/web/plugs/authorization.ex
+++ b/web/plugs/authorization.ex
@@ -42,11 +42,13 @@ defmodule Cog.Plug.Authorization do
       raise ":permission key must be a string, but was '#{inspect permission}' instead"
     end
     {_,_} = Permission.split_name(permission) # error if can't be split
-    self_updates = Keyword.get(opts, :allow_self_updates, [])
-    unless is_list(self_updates) do
-      raise ":allow_self_updates must be a list, but was '#{inspect self_updates}' instead"
+    self_updates = Keyword.get(opts, :self_updates_on, [])
+    |> List.wrap
+
+    unless Enum.all?(self_updates, &is_atom/1) do
+      raise ":allow_self_updates must be a list of atoms, but was '#{inspect self_updates}' instead"
     end
-    opts
+    Keyword.put(opts, :self_updates_on, self_updates)
   end
 
   # Expects to be called after the `Cog.Plug.Authentication` plug
@@ -75,7 +77,7 @@ defmodule Cog.Plug.Authorization do
   # in the future. For example, this would allow users to update
   # related data with paths such as `/v1/users/:user_id/profiles/:id`.
   defp self_updating?(opts, conn) do
-    case Keyword.get(opts, :allow_self_updates, []) do
+    case Keyword.get(opts, :self_updates_on) do
       [] -> false
       actions ->
         conn.private.phoenix_action in actions and

--- a/web/plugs/authorization.ex
+++ b/web/plugs/authorization.ex
@@ -42,9 +42,9 @@ defmodule Cog.Plug.Authorization do
       raise ":permission key must be a string, but was '#{inspect permission}' instead"
     end
     {_,_} = Permission.split_name(permission) # error if can't be split
-    self_updates = Keyword.get(opts, :allow_self_updates, false)
-    unless self_updates == true || self_updates == false do
-      raise ":allow_self_updates must be a boolean, but was '#{inspect self_updates}' instead"
+    self_updates = Keyword.get(opts, :allow_self_updates, [])
+    unless is_list(self_updates) do
+      raise ":allow_self_updates must be a list, but was '#{inspect self_updates}' instead"
     end
     opts
   end
@@ -75,12 +75,12 @@ defmodule Cog.Plug.Authorization do
   # in the future. For example, this would allow users to update
   # related data with paths such as `/v1/users/:user_id/profiles/:id`.
   defp self_updating?(opts, conn) do
-    if Keyword.get(opts, :allow_self_updates, false) == true do
-      conn.private.phoenix_action in [:update, :show] and
-      (conn.assigns.user.id == conn.params["id"] or
-       conn.params["id"] == "me")
-    else
-      false
+    case Keyword.get(opts, :allow_self_updates, []) do
+      [] -> false
+      actions ->
+        conn.private.phoenix_action in actions and
+        (conn.assigns.user.id == conn.params["id"] or
+         conn.params["id"] == "me")
     end
   end
 

--- a/web/plugs/authorization.ex
+++ b/web/plugs/authorization.ex
@@ -46,7 +46,7 @@ defmodule Cog.Plug.Authorization do
     |> List.wrap
 
     unless Enum.all?(self_updates, &is_atom/1) do
-      raise ":allow_self_updates must be a list of atoms, but was '#{inspect self_updates}' instead"
+      raise ":self_updates_on must be an atom or a list of atoms, but was '#{inspect self_updates}' instead"
     end
     Keyword.put(opts, :self_updates_on, self_updates)
   end
@@ -77,7 +77,7 @@ defmodule Cog.Plug.Authorization do
   # in the future. For example, this would allow users to update
   # related data with paths such as `/v1/users/:user_id/profiles/:id`.
   defp self_updating?(opts, conn) do
-    case Keyword.get(opts, :self_updates_on) do
+    case Keyword.fetch!(opts, :self_updates_on) do
       [] -> false
       actions ->
         conn.private.phoenix_action in actions and


### PR DESCRIPTION
Since allow_self_updates was hardcoded to only work with :update and :show, chat_handle :upserts would fail if the user didn't have the `manage_users` permission. This fixes the problem by allowing a list of actions to be passed to `allow_self_updates`. We also now have a test to make sure that even users without `mange_users` permission can update their own chat_handle.

This partially resolves https://github.com/operable/flywheel/issues/362