### PR TITLE
Unrecognized subcommands are failures

### DIFF
--- a/lib/cog/commands/alias.ex
+++ b/lib/cog/commands/alias.ex
@@ -53,8 +53,8 @@ defmodule Cog.Commands.Alias do
         Alias.List.list_command_aliases(req, args)
       nil ->
         Alias.List.list_command_aliases(req, args)
-      invalid ->
-        {:error, {:unknown_subcommand, invalid}}
+      other ->
+        {:error, {:unknown_subcommand, other}}
     end
 
     case result do

--- a/lib/cog/commands/bundle.ex
+++ b/lib/cog/commands/bundle.ex
@@ -52,6 +52,8 @@ defmodule Cog.Commands.Bundle do
                  else
                    List.list(req, args)
                  end
+               other ->
+                 {:error, {:unknown_subcommand, other}}
              end
 
      case result do

--- a/lib/cog/commands/group.ex
+++ b/lib/cog/commands/group.ex
@@ -57,10 +57,8 @@ defmodule Cog.Commands.Group do
         else
           Group.List.list_groups(req, args)
         end
-      invalid ->
-        suggestion = Enum.max_by(["list", "create", "delete", "member", "role", "info"],
-                                 &String.jaro_distance(&1, invalid))
-        show_usage(error({:unknown_subcommand, invalid, suggestion}))
+      other ->
+        {:error, {:unknown_subcommand, other}}
     end
 
     case result do

--- a/lib/cog/commands/relay.ex
+++ b/lib/cog/commands/relay.ex
@@ -43,8 +43,8 @@ defmodule Cog.Commands.Relay do
         Relay.Update.update_relay(req, args)
       nil ->
         show_usage
-      invalid ->
-        {:error, {:unknown_subcommand, invalid}}
+      other ->
+        {:error, {:unknown_subcommand, other}}
     end
 
     case result do

--- a/lib/cog/commands/relay_group.ex
+++ b/lib/cog/commands/relay_group.ex
@@ -55,8 +55,8 @@ defmodule Cog.Commands.RelayGroup do
         else
           RelayGroup.List.list(req, args)
         end
-      invalid ->
-        show_usage(error({:unknown_subcommand, invalid}))
+      other ->
+        {:error, {:unknown_subcommand, other}}
     end
 
     case result do
@@ -91,11 +91,6 @@ defmodule Cog.Commands.RelayGroup do
   #   do: :enabled
   # defp bundle_status(%{enabled: false}),
   #   do: :disabled
-
-  defp error(:required_subcommand),
-    do: "You are required to specify a subcommand. Please specify one of, 'info', 'create', 'rename', 'delete' or 'member'"
-  defp error({:unknown_subcommand, subcommand}),
-    do: "Unknown subcommand '#{subcommand}'. Please specify one of, 'info', 'create', 'rename', 'delete' or 'member'"
 
   defp show_usage(error \\ nil) do
     {:ok, "usage", %{usage: @moduledoc, error: error}}

--- a/lib/cog/commands/rule.ex
+++ b/lib/cog/commands/rule.ex
@@ -48,8 +48,8 @@ defmodule Cog.Commands.Rule do
         else
           List.list(req, args)
         end
-      invalid ->
-        show_usage(error({:unknown_subcommand, invalid}))
+      other ->
+        {:error, {:unknown_subcommand, other}}
     end
 
     case result do

--- a/lib/cog/commands/trigger.ex
+++ b/lib/cog/commands/trigger.ex
@@ -54,6 +54,8 @@ defmodule Cog.Commands.Trigger do
                  else
                    List.list(req, args)
                  end
+               other ->
+                 {:error, {:unknown_subcommand, other}}
              end
 
     case result do

--- a/lib/cog/commands/user.ex
+++ b/lib/cog/commands/user.ex
@@ -49,6 +49,8 @@ defmodule Cog.Commands.User do
                  else
                    List.list(req, args)
                  end
+               other ->
+                 {:error, {:unknown_subcommand, other}}
              end
 
      case result do

--- a/test/integration/commands/bundle_test.exs
+++ b/test/integration/commands/bundle_test.exs
@@ -58,4 +58,10 @@ defmodule Integration.Commands.BundleTest do
     assert_payload(response, %{name: "test_bundle", status: "disabled", version: "0.1.0"})
     refute Bundles.enabled?(bundle_version)
   end
+
+  test "passing an unknown subcommand fails", %{user: user} do
+    response = send_message(user, "@bot: operable:bundle not-a-subcommand")
+    assert_error_message_contains(response, "Whoops! An error occurred. Unknown subcommand 'not-a-subcommand'")
+  end
+
 end

--- a/test/integration/commands/group_test.exs
+++ b/test/integration/commands/group_test.exs
@@ -182,4 +182,9 @@ defmodule Integration.Commands.GroupTest do
     assert_error_message_contains(response , "Arguments must be strings")
   end
 
+  test "passing an unknown subcommand fails", %{user: user} do
+    response = send_message(user, "@bot: operable:group not-a-subcommand")
+    assert_error_message_contains(response, "Whoops! An error occurred. Unknown subcommand 'not-a-subcommand'")
+  end
+
 end

--- a/test/integration/commands/relay_group_test.exs
+++ b/test/integration/commands/relay_group_test.exs
@@ -154,4 +154,10 @@ defmodule Integration.Commands.RelayGroupTest do
     assert fetched_relay_group.name == "relay_group"
     assert length(fetched_relay_group.bundles) == 0
   end
+
+  test "passing an unknown subcommand fails", %{user: user} do
+    response = send_message(user, "@bot: operable:relay-group not-a-subcommand")
+    assert_error_message_contains(response, "Whoops! An error occurred. Unknown subcommand 'not-a-subcommand'")
+  end
+
 end

--- a/test/integration/commands/relay_test.exs
+++ b/test/integration/commands/relay_test.exs
@@ -83,4 +83,9 @@ defmodule Integration.Commands.RelayTest do
     assert_error_message_contains(response, "Arguments must be strings")
   end
 
+  test "passing an unknown subcommand fails", %{user: user} do
+    response = send_message(user, "@bot: operable:relay not-a-subcommand")
+    assert_error_message_contains(response, "Whoops! An error occurred. Unknown subcommand 'not-a-subcommand'")
+  end
+
 end

--- a/test/integration/commands/role_test.exs
+++ b/test/integration/commands/role_test.exs
@@ -330,6 +330,11 @@ defmodule Integration.Commands.RoleTest do
     assert_error_message_contains(response , "Arguments must be strings")
   end
 
+  test "passing an unknown subcommand fails", %{user: user} do
+    response = send_message(user, "@bot: operable:role not-a-subcommand")
+    assert_error_message_contains(response, "Whoops! An error occurred. Unknown subcommand 'not-a-subcommand'")
+  end
+
   ########################################################################
 
   # TODO: pull this out to adapter test

--- a/test/integration/commands/rule_test.exs
+++ b/test/integration/commands/rule_test.exs
@@ -152,6 +152,13 @@ defmodule Integration.Commands.RuleTest do
   end
 
   ########################################################################
+
+  test "passing an unknown subcommand fails", %{user: user} do
+    response = send_message(user, "@bot: operable:rule not-a-subcommand")
+    assert_error_message_contains(response, "Whoops! An error occurred. Unknown subcommand 'not-a-subcommand'")
+  end
+
+  ########################################################################
   # Helper Functions
 
   # If the command succeeded, the response should be valid JSON; if

--- a/test/integration/commands/trigger_test.exs
+++ b/test/integration/commands/trigger_test.exs
@@ -173,4 +173,9 @@ defmodule Integration.Commands.TriggerTest do
       do: refute Cog.Repo.get(Trigger, id)
   end
 
+  test "passing an unknown subcommand fails", %{user: user} do
+    response = send_message(user, "@bot: operable:trigger not-a-subcommand")
+    assert_error_message_contains(response, "Whoops! An error occurred. Unknown subcommand 'not-a-subcommand'")
+  end
+
 end

--- a/test/integration/commands/user_test.exs
+++ b/test/integration/commands/user_test.exs
@@ -118,4 +118,9 @@ defmodule Integration.Commands.UserTest do
               handle: "tester"}] = payload
   end
 
+  test "passing an unknown subcommand fails", %{user: user} do
+    response = send_message(user, "@bot: operable:user not-a-subcommand")
+    assert_error_message_contains(response, "Whoops! An error occurred. Unknown subcommand 'not-a-subcommand'")
+  end
+
 end


### PR DESCRIPTION
Previously, a few commands would actually display an error message,
but not create a formal error, which would allow a pipeline to
continue.

Now, each command behaves similarly, and appropriately.