### PR TITLE
Squat on certain bundle names

### DIFF
--- a/lib/cog/repository/bundles.ex
+++ b/lib/cog/repository/bundles.ex
@@ -17,7 +17,8 @@ defmodule Cog.Repository.Bundles do
   @reserved_bundle_names [
     Cog.embedded_bundle,
     Cog.site_namespace,
-    "user" # a bundle named "user" would break alias resolution
+    "user", # a bundle named "user" would break alias resolution
+    "cog"   # we're going to squat on this for now to prevent potential confusion
   ]
 
   @permanent_site_bundle_version "0.0.0"

--- a/lib/cog/support/model_utilities.ex
+++ b/lib/cog/support/model_utilities.ex
@@ -192,7 +192,7 @@ defmodule Cog.Support.ModelUtilities do
   Create a command with the given name
   """
   def command(name) do
-    bundle_version = bundle_version("cog")
+    bundle_version = bundle_version("test-bundle")
     bundle = bundle_version.bundle
 
     command = %Command{}

--- a/test/cog/repository/bundles_test.exs
+++ b/test/cog/repository/bundles_test.exs
@@ -364,6 +364,26 @@ defmodule Cog.Repository.BundlesTest do
                                                                                                   "version" => "1.0.0-pre1"}})
   end
 
+  for bad_name <- ["operable", "cog", "site", "user"] do
+    test "cannot install a bundle named #{bad_name}" do
+      result = Bundles.install(%{"name" => unquote(bad_name),
+                                 "version" => "1.0.0",
+                                 "config_file" => %{"name" => unquote(bad_name),
+                                                    "version" => "1.0.0"}})
+      assert {:error, {:reserved_bundle, unquote(bad_name)}} = result
+    end
+  end
+
+  for ok_name <- ["operable-stuff", "operable_stuff", "operable.stuff", "cogitation", "site-stuff", "user-stuff",
+                  "cog_stuff", "cog.stuff", "cog-stuff"] do
+    test "can install a bundle named #{ok_name}" do
+      result = Bundles.install(%{"name" => unquote(ok_name),
+                                 "version" => "1.0.0",
+                                 "config_file" => %{"name" => unquote(ok_name),
+                                                    "version" => "1.0.0"}})
+      assert {:ok, %BundleVersion{bundle: %Bundle{name: unquote(ok_name)}}} = result
+    end
+  end
 
   ########################################################################
 

--- a/test/controllers/v1/rule_controller_test.exs
+++ b/test/controllers/v1/rule_controller_test.exs
@@ -25,8 +25,8 @@ defmodule Cog.V1.RuleController.Test do
 
   test "creates a new rule when rule is valid", %{authed: requestor} do
     command("s3")
-    permission("cog:delete")
-    rule_text = "when command is cog:s3 with option[op] == 'delete' must have cog:delete"
+    permission("test-bundle:delete")
+    rule_text = "when command is test-bundle:s3 with option[op] == 'delete' must have test-bundle:delete"
 
     conn = api_request(requestor, :post, "/v1/rules",
                        body: %{"rule" => rule_text})
@@ -35,7 +35,7 @@ defmodule Cog.V1.RuleController.Test do
     id = body["id"]
 
     assert %{"id" => id,
-             "command_name" => "cog:s3",
+             "command_name" => "test-bundle:s3",
              "rule" => rule_text} == body
 
     # TODO: we don't provide a GET for rules just yet
@@ -47,20 +47,20 @@ defmodule Cog.V1.RuleController.Test do
 
   test "fails to create a rule if the command does not exist", %{authed: requestor} do
     permission("site:admin")
-    rule_text = "when command is cog:do_stuff must have site:admin"
+    rule_text = "when command is test-bundle:do_stuff must have site:admin"
 
     conn = api_request(requestor, :post, "/v1/rules",
                        body: %{"rule" => rule_text})
 
     assert %{"errors" =>
-              %{"unrecognized_command" => ["cog:do_stuff"]}} == json_response(conn, 422)
+              %{"unrecognized_command" => ["test-bundle:do_stuff"]}} == json_response(conn, 422)
 
     refute_rule_is_persisted(rule_text)
   end
 
   test "fails to create a rule if permissions do not exist", %{authed: requestor} do
     command("do_stuff")
-    rule_text = "when command is cog:do_stuff must have do_stuff:admin"
+    rule_text = "when command is test-bundle:do_stuff must have do_stuff:admin"
 
     conn = api_request(requestor, :post, "/v1/rules",
                        body: %{"rule" => rule_text})
@@ -73,8 +73,8 @@ defmodule Cog.V1.RuleController.Test do
 
   test "cannot create a rule without required permissions", %{unauthed: requestor} do
     command("s3")
-    permission("cog:delete")
-    rule_text = "when command is cog:s3 with option[op] == 'delete' must have cog:delete"
+    permission("test-bundle:delete")
+    rule_text = "when command is test-bundle:s3 with option[op] == 'delete' must have test-bundle:delete"
 
     conn = api_request(requestor, :post, "/v1/rules",
                        body: %{"rule" => rule_text})
@@ -93,8 +93,8 @@ defmodule Cog.V1.RuleController.Test do
     bundle = command.bundle |> Repo.preload(:versions)
     bundle_version = List.first(bundle.versions) |> Repo.preload(:bundle)
 
-    permission("cog:delete")
-    rule_text = "when command is cog:s3 with option[op] == 'delete' must have cog:delete"
+    permission("test-bundle:delete")
+    rule_text = "when command is test-bundle:s3 with option[op] == 'delete' must have test-bundle:delete"
     rule = rule(rule_text, bundle_version)
 
     conn = api_request(requestor, :get, "/v1/rules/#{rule.id}")
@@ -103,7 +103,7 @@ defmodule Cog.V1.RuleController.Test do
     id = body["id"]
 
     assert %{"id" => id,
-             "command_name" => "cog:s3",
+             "command_name" => "test-bundle:s3",
              "rule" => rule_text} == body
   end
 
@@ -115,38 +115,38 @@ defmodule Cog.V1.RuleController.Test do
     bundle = command.bundle |> Repo.preload(:versions)
     bundle_version = List.first(bundle.versions) |> Repo.preload(:bundle)
 
-    permission("cog:delete")
-    permission("cog:admin")
-    rule_text = "when command is cog:s3 with option[op] == 'delete' must have cog:delete"
+    permission("test-bundle:delete")
+    permission("test-bundle:admin")
+    rule_text = "when command is test-bundle:s3 with option[op] == 'delete' must have test-bundle:delete"
     rule = rule(rule_text, bundle_version)
 
     assert_rule_is_persisted(rule.id, rule_text)
 
     conn = api_request(requestor, :patch, "/v1/rules/#{rule.id}",
-                       body: %{"rule" => "when command is cog:s3 with option[op] == 'delete' must have cog:admin"})
+                       body: %{"rule" => "when command is test-bundle:s3 with option[op] == 'delete' must have test-bundle:admin"})
 
     assert conn.status == 200
 
-    assert_rule_is_disabled "when command is cog:s3 with option[op] == 'delete' must have cog:delete"
-    assert_rule_is_enabled  "when command is cog:s3 with option[op] == 'delete' must have cog:admin"
+    assert_rule_is_disabled "when command is test-bundle:s3 with option[op] == 'delete' must have test-bundle:delete"
+    assert_rule_is_enabled  "when command is test-bundle:s3 with option[op] == 'delete' must have test-bundle:admin"
   end
 
   test "updating an existing rule in the site bundle", %{authed: requestor} do
     command("s3")
-    permission("cog:delete")
-    permission("cog:admin")
-    rule_text = "when command is cog:s3 with option[op] == 'delete' must have cog:delete"
+    permission("test-bundle:delete")
+    permission("test-bundle:admin")
+    rule_text = "when command is test-bundle:s3 with option[op] == 'delete' must have test-bundle:delete"
     rule = rule(rule_text)
 
     assert_rule_is_persisted(rule.id, rule_text)
 
     conn = api_request(requestor, :patch, "/v1/rules/#{rule.id}",
-                       body: %{"rule" => "when command is cog:s3 with option[op] == 'delete' must have cog:admin"})
+                       body: %{"rule" => "when command is test-bundle:s3 with option[op] == 'delete' must have test-bundle:admin"})
 
     assert conn.status == 200
 
-    refute_rule_is_persisted "when command is cog:s3 with option[op] == 'delete' must have cog:delete"
-    assert_rule_is_enabled   "when command is cog:s3 with option[op] == 'delete' must have cog:admin"
+    refute_rule_is_persisted "when command is test-bundle:s3 with option[op] == 'delete' must have test-bundle:delete"
+    assert_rule_is_enabled   "when command is test-bundle:s3 with option[op] == 'delete' must have test-bundle:admin"
   end
 
   # Delete
@@ -154,8 +154,8 @@ defmodule Cog.V1.RuleController.Test do
 
   test "delete an existing rule", %{authed: requestor} do
     command("s3")
-    permission("cog:delete")
-    rule_text = "when command is cog:s3 with option[op] == 'delete' must have cog:delete"
+    permission("test-bundle:delete")
+    rule_text = "when command is test-bundle:s3 with option[op] == 'delete' must have test-bundle:delete"
     rule = rule(rule_text)
 
     assert_rule_is_persisted(rule.id, rule_text)
@@ -174,8 +174,8 @@ defmodule Cog.V1.RuleController.Test do
 
   test "cannot delete a rule without required permissions", %{unauthed: requestor} do
     command("s3")
-    permission("cog:delete")
-    rule_text = "when command is cog:s3 with option[op] == 'delete' must have cog:delete"
+    permission("test-bundle:delete")
+    rule_text = "when command is test-bundle:s3 with option[op] == 'delete' must have test-bundle:delete"
     rule = rule(rule_text)
 
     conn = api_request(requestor, :delete, "/v1/rules/#{rule.id}")
@@ -189,46 +189,46 @@ defmodule Cog.V1.RuleController.Test do
   # Show
   ########################################################################
   test "show the rules for a particular command", %{authed: requestor} do
-    rule_text = "when command is cog:hola must have cog:hola"
+    rule_text = "when command is test-bundle:hola must have test-bundle:hola"
     {:ok, version} = Cog.Repository.Bundles.install(
-      %{"name" => "cog",
+      %{"name" => "test-bundle",
         "version" => "1.0.0",
         "config_file" => %{
-          "name" => "cog",
+          "name" => "test-bundle",
           "version" => "1.0.0",
-          "permissions" => ["cog:hola"],
+          "permissions" => ["test-bundle:hola"],
           "commands" => %{"hola" => %{"rules" => [rule_text]}}}})
 
     permission("site:test")
-    site_rule_text = "when command is cog:hola must have site:test"
+    site_rule_text = "when command is test-bundle:hola must have site:test"
     rule(site_rule_text)
 
     # Returns nothing if there isn't an enabled version
-    conn = api_request(requestor, :get, "/v1/rules?for-command=cog:hola")
-    assert "Command cog:hola not currently enabled; try enabling a bundle version first" = json_response(conn, 404)["errors"]
+    conn = api_request(requestor, :get, "/v1/rules?for-command=test-bundle:hola")
+    assert "Command test-bundle:hola not currently enabled; try enabling a bundle version first" = json_response(conn, 404)["errors"]
 
     # If we do enable a version, though, we get rules, including any
     # site rules we've specified
     Cog.Repository.Bundles.set_bundle_version_status(version, :enabled)
-    conn = api_request(requestor, :get, "/v1/rules?for-command=cog:hola")
+    conn = api_request(requestor, :get, "/v1/rules?for-command=test-bundle:hola")
 
     rules = json_response(conn, 200)["rules"] |> Enum.sort_by(&Map.get(&1, "rule"))
     assert [%{"id" => _,
-              "command_name" => "cog:hola",
-              "rule" => ^rule_text},
-            %{"id" => _,
-              "command_name" => "cog:hola",
-              "rule" => ^site_rule_text}] = rules
+              "command_name" => "test-bundle:hola",
+              "rule" => ^site_rule_text},
+           %{"id" => _,
+              "command_name" => "test-bundle:hola",
+              "rule" => ^rule_text}] = rules
   end
 
   test "show error message for a non-existant command", %{authed: requestor} do
     command("hola")
-    permission("cog:hola")
+    permission("test-bundle:hola")
 
-    conn = api_request(requestor, :get, "/v1/rules?for-command=cog:nada")
-    assert %{"errors" => "Command cog:nada not found"} == json_response(conn, 422)
+    conn = api_request(requestor, :get, "/v1/rules?for-command=test-bundle:nada")
+    assert %{"errors" => "Command test-bundle:nada not found"} == json_response(conn, 422)
 
-    conn = api_request(requestor, :get, "/v1/rules?command=cog:hola")
-    assert %{"errors" => "Unknown parameters %{\"command\" => \"cog:hola\"}"} == json_response(conn, 422)
+    conn = api_request(requestor, :get, "/v1/rules?command=test-bundle:hola")
+    assert %{"errors" => "Unknown parameters %{\"command\" => \"test-bundle:hola\"}"} == json_response(conn, 422)
   end
 end

--- a/test/integration/commands/help_test.exs
+++ b/test/integration/commands/help_test.exs
@@ -25,7 +25,7 @@ defmodule Integration.Commands.HelpTest do
     response = send_message(user, "@bot: operable:help --disabled")
     [command] = decode_payload(response)
 
-    assert command.bundle.name == "cog"
+    assert command.bundle.name == "test-bundle"
     assert command.name == "test_command"
   end
 

--- a/test/integration/commands/rule_test.exs
+++ b/test/integration/commands/rule_test.exs
@@ -34,15 +34,15 @@ defmodule Integration.Commands.RuleTest do
   test "listing rules for a disabled command fails", %{user: user} do
     # Create a bundle that we won't enable
     {:ok, _version} = Cog.Repository.Bundles.install(
-      %{"name" => "cog",
+      %{"name" => "test-bundle",
         "version" => "1.0.0",
         "config_file" => %{
-          "name" => "cog",
+          "name" => "test-bundle",
           "version" => "1.0.0",
-          "commands" => %{"hola" => %{"rules" => ["when command is cog:hola allow"]}}}})
+          "commands" => %{"hola" => %{"rules" => ["when command is test-bundle:hola allow"]}}}})
 
-    assert_error(user, "@bot: rule -c cog:hola",
-              ~s(Whoops! An error occurred. cog:hola is not enabled. Enable a bundle version and try again))
+    assert_error(user, "@bot: rule -c test-bundle:hola",
+              ~s(Whoops! An error occurred. test-bundle:hola is not enabled. Enable a bundle version and try again))
   end
 
   ########################################################################


### PR DESCRIPTION
To avoid confusion between "official" Operable-authored bundles and 3rd
party bundles, we'll block the installation of bundles named

* `cog`
* `cog-*`
* `operable-*`

The bundle names `site` and `user` continue to be reserved for internal
usage. The embedded bundle continues to be named "operable", and
continues to be uninstallable by outside sources.

We were using "cog" as a bundle name for testing data; obviously that's
out now, so we'll now call it "test-bundle" instead.

Fixes #817