### PR TITLE
Change pipeline execution to per-stage

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,7 +2,7 @@ use Mix.Config
 import Cog.Config.Helpers
 
 config :logger, :console,
-  level: :debug
+  level: :warn
 
 config :cog, :enable_spoken_commands, ensure_boolean(System.get_env("ENABLE_SPOKEN_COMMANDS")) || false
 

--- a/lib/carrier/messaging/connection.ex
+++ b/lib/carrier/messaging/connection.ex
@@ -109,8 +109,9 @@ defmodule Carrier.Messaging.Connection do
       :error ->
         :ok
     end
-
-    :emqttc.publish(conn, topic, encoded)
+    {:ok, compressed} = :snappy.compress(encoded)
+    Logger.debug("Applied compression: #{:erlang.size(encoded)} / #{:erlang.size(compressed)}")
+    :emqttc.publish(conn, topic, compressed)
   end
 
   defp add_system_config(opts) do

--- a/lib/cog/adapter.ex
+++ b/lib/cog/adapter.ex
@@ -36,8 +36,9 @@ defmodule Cog.Adapter do
         {:reply, :ok, state}
       end
 
-      def handle_info({:publish, topic, message}, state) do
+      def handle_info({:publish, topic, compressed}, state) do
         if topic == reply_topic() do
+          {:ok, message} = :snappy.decompress(compressed)
           payload = Poison.decode!(message)
           send_message(payload["room"], payload["response"])
         end

--- a/lib/cog/command/gen_command.ex
+++ b/lib/cog/command/gen_command.ex
@@ -153,8 +153,9 @@ defmodule Cog.Command.GenCommand do
     end
   end
 
-  def handle_info({:publish, topic, message},
+  def handle_info({:publish, topic, compressed},
                   %__MODULE__{topic: topic, cb_module: cb_module, bundle_name: bundle}=state) do
+    {:ok, message} = :snappy.decompress(compressed)
     payload = Poison.decode!(message)
     case Command.Request.decode(payload) do
       {:ok, req} ->

--- a/lib/cog/command/pipeline/initializer.ex
+++ b/lib/cog/command/pipeline/initializer.ex
@@ -28,7 +28,8 @@ defmodule Cog.Command.Pipeline.Initializer do
     {:ok, %__MODULE__{mq_conn: conn, history_token: "#{cp}#{cp}"}}
   end
 
-  def handle_info({:publish, "/bot/commands", message}, state) do
+  def handle_info({:publish, "/bot/commands", compressed}, state) do
+    {:ok, message} = :snappy.decompress(compressed)
     payload = Poison.decode!(message)
     case check_history(payload, state) do
       {true, payload, state} ->

--- a/lib/cog/command/request.ex
+++ b/lib/cog/command/request.ex
@@ -1,81 +1,21 @@
 defmodule Cog.Command.Request do
 
   use Cog.Marshalled
-  alias Spanner.Config
 
   require Logger
 
-  defmarshalled [:room, :requestor, :user, :command, :args, :options,
-                 :command_config, :reply_to, :cog_env, :invocation_id,
-                 :invocation_step, :service_token, :services_root]
+  # defmarshalled [:room, :requestor, :user, :command, :args, :options,
+  #                :command_config, :reply_to, :cog_env, :invocation_id,
+  #                :invocation_step, :service_token, :services_root]
+
+  defmarshalled [:options, :args, :cog_env, :invocation_step]
 
   defp validate(request) do
     cond do
-      request.room == nil ->
-        {:error, {:empty_field, :room}}
-      request.requestor == nil ->
-        {:error, {:empty_field, :requestor}}
-      request.command == nil ->
-        {:error, {:empty_field, :command}}
-      request.reply_to == nil ->
-        {:error, {:empty_field, :reply_to}}
-      true -> populate_config(request)
-    end
-  end
-
-  defp populate_config(request) do
-    case get_config(request) do
-      {:ok, command_config} -> {:ok, %{request | command_config: command_config}}
-      error -> error
-    end
-  end
-
-  defp get_config(request) do
-    case open_config(request) do
-      :dir_not_found -> {:ok, %{}}
-      {:ok, config} -> {:ok, config}
-      {:not_found, cmd_config_dir} ->
-        msg = "A directory exists for dynamic config, '#{cmd_config_dir}', but it contains no configs."
-        Logger.warn(msg)
-        {:ok, %{}}
-      {:multiple_configs, config, config_path} ->
-        msg = "Multiple dynamic config files exist. Using '#{config_path}'."
-        Logger.warn(msg)
-        {:ok, config}
-      {:error, error} ->
-        err = "Unable to read the command config file for the command '#{request.command}'. #{inspect error}"
-        Logger.error(err)
-        {:error, err}
-    end
-  end
-
-  defp open_config(request) do
-    case Application.get_env(:spanner, :command_config_root) do
-      nil -> {:ok, ""}
-      path -> read_config(request, path)
-    end
-  end
-
-  defp read_config(request, config_path) do
-    [bundle, _cmd] = String.split(request.command, ":", parts: 2)
-    cmd_config_dir = Path.join([config_path, bundle])
-
-    case File.dir?(cmd_config_dir) do
-      true ->
-        case Config.find_configs(cmd_config_dir) do
-          [] ->
-            # If a directory for dynamic config exists but there are no config files
-            # we should warn the user
-            {:not_found, cmd_config_dir}
-          [config_path] ->
-            Config.Parser.read_from_file(config_path)
-          [config_path | _] ->
-            # If multiple configs are found we should warn the user
-            with {:ok, config} <- Config.Parser.read_from_file(config_path) do
-              {:multiple_configs, config, config_path}
-            end
-        end
-      false -> :dir_not_found
+      request.invocation_step == nil ->
+        {:error, {:empty_field, :invocation_step}}
+      request.cog_env == nil ->
+        {:error, {:empty_field, :cog_env}}
     end
   end
 

--- a/lib/cog/command/request.ex
+++ b/lib/cog/command/request.ex
@@ -4,18 +4,16 @@ defmodule Cog.Command.Request do
 
   require Logger
 
-  # defmarshalled [:room, :requestor, :user, :command, :args, :options,
-  #                :command_config, :reply_to, :cog_env, :invocation_id,
-  #                :invocation_step, :service_token, :services_root]
-
   defmarshalled [:options, :args, :cog_env, :invocation_step]
 
   defp validate(request) do
-    cond do
+    case do
       request.invocation_step == nil ->
         {:error, {:empty_field, :invocation_step}}
       request.cog_env == nil ->
         {:error, {:empty_field, :cog_env}}
+      true ->
+        request
     end
   end
 

--- a/lib/cog/relay/info.ex
+++ b/lib/cog/relay/info.ex
@@ -39,7 +39,8 @@ defmodule Cog.Relay.Info do
     end
   end
 
-  def handle_info({:publish, @relay_info_topic, message}, state) do
+  def handle_info({:publish, @relay_info_topic, compressed}, state) do
+    {:ok, message} = :snappy.decompress(compressed)
     case Poison.decode(message) do
       {:ok, %{"list_bundles" => message}} ->
         info(message, state)

--- a/mix.exs
+++ b/mix.exs
@@ -78,6 +78,7 @@ defmodule Cog.Mixfile do
      {:fumanchu, github: "operable/fumanchu"},
      {:exirc, "~> 0.9.2"},
      {:exjsx, "~> 3.2", override: true},
+     {:snappy, github: "fdmanana/snappy-erlang-nif", ref: "76417d16a8d39e04d66114d8f8a3c75df19474f0"},
 
      {:credo, "~> 0.3", only: [:dev, :test]},
      {:phoenix_live_reload, "~> 1.0.3", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -56,6 +56,7 @@
   "probe": {:git, "https://github.com/operable/probe.git", "e3dc4f425e6c8de803fe53c0731cbfc31c7a33c8", []},
   "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []},
   "slack": {:hex, :slack, "0.5.0", "06390cc75eb54bf716f7ffce5020711cfef5dd0c43d5d917162c007feef20162", [:mix], [{:httpoison, "~> 0.8.0", [hex: :httpoison, optional: false]}, {:exjsx, "~> 3.2.0", [hex: :exjsx, optional: false]}]},
+  "snappy": {:git, "https://github.com/fdmanana/snappy-erlang-nif.git", "76417d16a8d39e04d66114d8f8a3c75df19474f0", [ref: "76417d16a8d39e04d66114d8f8a3c75df19474f0"]},
   "spanner": {:git, "https://github.com/operable/spanner.git", "9b282ad8fe5acf73eaed02da3a5b9c4bc8617174", []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
   "uuid": {:hex, :uuid, "1.1.3", "06ca38801a1a95b751701ca40716bb97ddf76dfe7e26da0eec7dba636740d57a", [:mix], []},


### PR DESCRIPTION
This commit does two things:

1. Changes pipeline execution to a per-stage model. This means Cog sends
an entire stage down to a target Relay and, in turn, receives an entire
stage of output when the Relay completes execution.

2. Adds snappy compression to all bus traffic. This is meant to address
the increased message sizes caused by executing an entire stage at a time.