### PR TITLE
remove one empty line from the end of the template body if present

### DIFF
--- a/lib/cog/repository/bundles.ex
+++ b/lib/cog/repository/bundles.ex
@@ -708,6 +708,7 @@ defmodule Cog.Repository.Bundles do
 
   defp create_template!(bundle_version, {name, template}) do
     Enum.each(template, fn({provider, contents}) ->
+      contents = String.replace(contents, ~r{\n\z}, "")
       params = %{
         adapter: provider,
         name: name,


### PR DESCRIPTION
Many of our templates have a trailing newline that is helpfully added by our editors which is causing template output to be unnecessarily double spaced. This PR will remove a single newline from the end of the template body.

Note that this intentionally only removes _one_ trailing newline to allow users to include empty lines at the end of their template intentionally if they want.