### PR TITLE
Disable Ecto query logging

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -104,7 +104,8 @@ config :cog, Cog.Repo,
   pool_size: ensure_integer(System.get_env("COG_DB_POOL_SIZE")) || 10,
   pool_timeout: ensure_integer(System.get_env("COG_DB_POOL_TIMEOUT")) || 15000,
   timeout: ensure_integer(System.get_env("COG_DB_TIMEOUT")) || 15000,
-  parameters: [timezone: 'UTC']
+  parameters: [timezone: 'UTC'],
+  log: false
 
 # ========================================================================
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -105,7 +105,7 @@ config :cog, Cog.Repo,
   pool_timeout: ensure_integer(System.get_env("COG_DB_POOL_TIMEOUT")) || 15000,
   timeout: ensure_integer(System.get_env("COG_DB_TIMEOUT")) || 15000,
   parameters: [timezone: 'UTC'],
-  log: false
+  loggers: [{Cog.LogHelper, :log, []}]
 
 # ========================================================================
 

--- a/lib/cog/log_helper.ex
+++ b/lib/cog/log_helper.ex
@@ -1,0 +1,9 @@
+defmodule Cog.LogHelper do
+
+  @moduledoc """
+  This module exists solely to tame Ecto's prodigious and unhelpful log output.
+  """
+
+  def log(entry), do: entry
+
+end


### PR DESCRIPTION
Disable Ecto query logging "noise" since almost (all?) of the output isn't helpful.

Lines logged during startup:
Before: 1552
After: 115

Fixes #841