### PR TITLE
Allow commands to set a format pipeline

### DIFF
--- a/lib/cog/command/response.ex
+++ b/lib/cog/command/response.ex
@@ -2,6 +2,6 @@ defmodule Cog.Command.Response do
 
   use Cog.Marshalled
 
-  defmarshalled [:room, :status, :status_message, :body, :bundle, :template]
+  defmarshalled [:room, :status, :status_message, :body, :bundle, :template, :format_pipeline]
 
 end


### PR DESCRIPTION
⚠️ This was some late night hackery and isn't ready to be merged yet. ⚠️ 

Templates are nice for some things, but we've run into issues rendering tables and chat provider specific features. Probably drinking too much koolaid here, but instead of making templates this separate special thing, I figured it'd be nice to see if we could instead use what I'm calling "format pipelines". They're basically a pipeline string that commands emit (ex: "COG_FORMAT_PIPELINE: table name desc") that is then appended to the end of the command that was run if it was run at the end of a pipeline (sorta like we use templates current). This way, you can run simple formatting commands to print some nice output.

An example:

`heroku:apps list` returns a list of json and prints `COG_FORMAT_PIPELINE: table name owner_email`. If you were to run `heroku:apps list | table name website_url` you'd see the table you expect with the name and website url. But if you just ran `heroku:apps list` you'd see the table specified in the format pipeline from the command.

Interesting ideas as a result:
* Formatting can be more than just "display this other text on the screen", for instance we could render and upload a graph, returning an image from the format pipeline for a command with a data heavy response.
* Templates aren't really special and rendering them could be moved into a command
* Any templating library could easily be used by a command provided along with a bundle (bundles written in ruby could use an `erb` command for templating)

Tricky things I haven't solved yet:
* It would be a bad idea to let any command run any other command with the user's permissions. We could do something like whitelist any command from its own bundle and maybe the `operable:format` bundle?
* Returning parsing errors of the pipeline could be kinda tricky (we'd want to return the data, but also display an error if formatting failed ideally)

Companion relay branch - https://github.com/operable/go-relay/tree/vanstee/format-pipeline