### PR TITLE
Bump spanner to pick up changes for docker bind mounts

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -56,7 +56,7 @@
   "probe": {:git, "https://github.com/operable/probe.git", "950ed26bf4a8c3899e310e4414e06724a50cfbb8", []},
   "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []},
   "slack": {:git, "https://github.com/BlakeWilliams/Elixir-Slack.git", "555d6cfba9fe1f3b21e9d26dbc1738b2f3165185", []},
-  "spanner": {:git, "https://github.com/operable/spanner.git", "e60306a7a8756e4c1bc5aacf2c16d412e48e91cd", []},
+  "spanner": {:git, "https://github.com/operable/spanner.git", "41e7844f10578ae76bb7d7d6deaf507462967516", []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
   "uuid": {:hex, :uuid, "1.1.3", "06ca38801a1a95b751701ca40716bb97ddf76dfe7e26da0eec7dba636740d57a", [:mix], []},
   "websocket_client": {:git, "https://github.com/jeremyong/websocket_client.git", "f6892c8b55004008ce2d52be7d98b156f3e34569", []},


### PR DESCRIPTION
See also
* https://github.com/operable/spanner/pull/73
* https://github.com/operable/go-relay/pull/31
* https://github.com/operable/circuit/pull/1

Fixes #838 