### PR TITLE
bundle.name -> bundle_name

### DIFF
--- a/lib/cog/relay/info.ex
+++ b/lib/cog/relay/info.ex
@@ -104,7 +104,7 @@ defmodule Cog.Relay.Info do
 
   defp calculate_signature(configs) do
     configs
-    |> Enum.sort(&(&1.bundle.name <= &2.bundle.name))
+    |> Enum.sort(&(&1.bundle_name <= &2.bundle_name))
     |> Enum.map(&(&1.hash))
     |> Hash.compute_hash
   end


### PR DESCRIPTION
Typo caused Cog to crash when calculating dynamic config
signatures. Since it would recover quickly the crash would give the
appearance of Relay hanging.

Fixes #861