### PR TITLE
update version requirement for Postgres

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -6,7 +6,7 @@
 
 Cog depends on a few things to run locally:
 
-    * Postgres
+    * Postgres (9.4+)
     * A `SLACK_API_TOKEN` environment variable (with a valid token)
 
 With those installed, setup your computer with:


### PR DESCRIPTION
Prior to this commit the enumerated requirement was simply `Postgres`; however,
`priv/repo/migrations/20160524190528_parse_tree_is_json.exs` attempts to use
the `jsonb` type, which is not available until Postgres 9.4 and later.