### PR TITLE
Only checksum embedded bundle when MIX_ENV=dev

### DIFF
--- a/config/embedded_bundle_version.exs
+++ b/config/embedded_bundle_version.exs
@@ -1,4 +1,4 @@
 use Mix.Config
 
-config :cog, :embedded_bundle_checksum, "b3e4a4abf156e04cf2172de2b32d3a91"
 config :cog, :embedded_bundle_version, "0.11.2"
+config :cog, :embedded_bundle_checksum, "ca42693fc2af94732b7cf2afda294f61"


### PR DESCRIPTION
TL;DR - checksums can change with different MIX_ENV, a detail that is
irrelevant for our purposes. Read the code comments for details.

Also changes the stored checksum for the embedded bundle; the old value
was actually computed under MIX_ENV=test. This change returns it to the
MIX_ENV=dev checksum that it originally was (but the version will stay
the same, because that's how this stuff works....)