### PR TITLE
Support layered dynamic bundle configuration

### DIFF
--- a/lib/cog/models/bundle_dynamic_config.ex
+++ b/lib/cog/models/bundle_dynamic_config.ex
@@ -5,6 +5,8 @@ defmodule Cog.Models.BundleDynamicConfig do
   alias Cog.Models.Bundle
 
   schema "bundle_dynamic_configs" do
+    field :layer, :string
+    field :name, :string
     field :config, :map
     field :hash, :string
 
@@ -14,12 +16,13 @@ defmodule Cog.Models.BundleDynamicConfig do
 
   end
 
-  @required_fields ~w(bundle_id config)
+  @required_fields ~w(bundle_id layer name config)
   @optional_fields ~w()
 
   def changeset(model, params \\ :empty) do
     model
     |> cast(params, @required_fields, @optional_fields)
+    |> validate_inclusion(:layer, ["base", "room", "user"])
     |> unique_constraint(:bundle_id, name: :bundle_dynamic_configs_bundle_id_index)
     |> calculate_hash
   end

--- a/priv/repo/migrations/20160725170913_layered_dynamic_config.exs
+++ b/priv/repo/migrations/20160725170913_layered_dynamic_config.exs
@@ -1,0 +1,28 @@
+defmodule Cog.Repo.Migrations.LayeredDynamicConfig do
+  use Ecto.Migration
+
+  def change do
+
+    # Add layer and name columns; all configs present now are base
+    # configs, by definition.
+    alter table(:bundle_dynamic_configs) do
+      add :layer, :text, null: false, default: "base"
+      add :name, :text, null: false, default: "config"
+    end
+
+    # Ensure that if layer is "base", name must be "config"; there's
+    # only ever one "base" layer for a bundle
+    create constraint(:bundle_dynamic_configs, "base_name_must_be_config", check: "CASE WHEN layer = 'base' THEN name = 'config' END")
+
+    # bundle / layer / name must be unique
+    drop unique_index(:bundle_dynamic_configs, [:bundle_id])
+    create unique_index(:bundle_dynamic_configs, [:bundle_id, :layer, :name])
+
+    # Remove defaults now that everything has been moved
+    alter table(:bundle_dynamic_configs) do
+      modify :layer, :text, default: nil
+      modify :name, :text, default: nil
+    end
+
+  end
+end

--- a/test/controllers/v1/dynamic_config_controller_test.exs
+++ b/test/controllers/v1/dynamic_config_controller_test.exs
@@ -40,90 +40,280 @@ defmodule Cog.V1.DynamicConfigControllerTest do
     assert conn.status == 403
   end
 
-  test "request missing dynamic config returns 404", %{authed: requestor, bundle: bundle} do
-    conn = api_request(requestor, :get, "/v1/bundles/#{bundle.id}/dynamic_config")
-    assert conn.status == 404
-  end
-
   test "cannot add dynamic config without managed_commands permission", %{unauthed: requestor, bundle: bundle} do
-    conn = api_request(requestor, :post, "/v1/bundles/#{bundle.id}/dynamic_config", body: %{"config": %{"test1" => "abc"}})
+    conn = api_request(requestor, :post, "/v1/bundles/#{bundle.id}/dynamic_config/base", body: %{"config": %{"test1" => "abc"}})
     assert conn.halted
     assert conn.status == 403
   end
 
-  test "write dynamic config", %{authed: requestor, bundle: bundle} do
-    conn = api_request(requestor, :post, "/v1/bundles/#{bundle.id}/dynamic_config", body: %{"config": %{"test1" => "abc"}})
-    assert conn.status == 201
-    conn = api_request(requestor, :get, "/v1/bundles/#{bundle.id}/dynamic_config")
-    assert conn.status == 200
-    body = Poison.decode!(conn.resp_body)
-    assert Map.has_key?(body, "dynamic_configuration")
-    config = Map.get(body, "dynamic_configuration")
-    assert Map.equal?(config, %{"bundle_name" => bundle.name,
-                                "bundle_id" => bundle.id,
-                                "config" => %{"test1" => "abc"}})
+  test "write base dynamic config", %{authed: requestor, bundle: bundle} do
+    conn = api_request(requestor, :post,
+                       "/v1/bundles/#{bundle.id}/dynamic_config/base",
+                       body: %{"config": %{"test1" => "abc"}})
+    body = json_response(conn, 201)
+    assert %{"dynamic_configuration" => %{
+              "bundle_name" => bundle.name,
+              "bundle_id" => bundle.id,
+              "layer" => "base",
+              "name" => "config",
+              "config" => %{"test1" => "abc"}}} == body
+
+    expected_location = "/v1/bundles/#{bundle.id}/dynamic_config/base"
+    assert expected_location == redirected_to(conn, 201)
+  end
+
+  test "write room layer dynamic config", %{authed: requestor, bundle: bundle} do
+    conn = api_request(requestor, :post,
+                       "/v1/bundles/#{bundle.id}/dynamic_config/room/ops",
+                       body: %{"config": %{"ops" => "4life"}})
+    body = json_response(conn, 201)
+
+    assert %{"dynamic_configuration" => %{
+              "bundle_name" => bundle.name,
+              "bundle_id" => bundle.id,
+              "layer" => "room",
+              "name" => "ops",
+              "config" => %{"ops" => "4life"}}} == body
+
+    expected_location = "/v1/bundles/#{bundle.id}/dynamic_config/room/ops"
+    assert expected_location == redirected_to(conn, 201)
+  end
+
+  test "write user layer dynamic config", %{authed: requestor, bundle: bundle} do
+    conn = api_request(requestor, :post,
+                       "/v1/bundles/#{bundle.id}/dynamic_config/user/alice",
+                       body: %{"config": %{"hello" => "world"}})
+    body = json_response(conn, 201)
+    assert %{"dynamic_configuration" => %{
+              "bundle_name" => bundle.name,
+              "bundle_id" => bundle.id,
+              "layer" => "user",
+              "name" => "alice",
+              "config" => %{"hello" => "world"}}} == body
+
+    expected_location = "/v1/bundles/#{bundle.id}/dynamic_config/user/alice"
+    assert expected_location == redirected_to(conn, 201)
+  end
+
+  test "retrieve base dynamic config", %{authed: requestor, bundle: bundle} do
+    set_config(bundle, "base", "config", %{"test1" => "abc"})
+
+    conn = api_request(requestor, :get,
+                       "/v1/bundles/#{bundle.id}/dynamic_config/base")
+    body = json_response(conn, 200)
+    assert %{"dynamic_configuration" => %{
+              "bundle_name" => bundle.name,
+              "bundle_id" => bundle.id,
+              "layer" => "base",
+              "name" => "config",
+              "config" => %{"test1" => "abc"}}} == body
+
+  end
+
+  test "retrieve room layer dynamic config", %{authed: requestor, bundle: bundle} do
+    set_config(bundle, "room", "ops", %{"ops" => "4life"})
+
+    conn = api_request(requestor, :get,
+                       "/v1/bundles/#{bundle.id}/dynamic_config/room/ops")
+    body = json_response(conn, 200)
+    assert %{"dynamic_configuration" => %{
+              "bundle_name" => bundle.name,
+              "bundle_id" => bundle.id,
+              "layer" => "room",
+              "name" => "ops",
+              "config" => %{"ops" => "4life"}}} == body
+
+  end
+
+  test "retrieve user layer dynamic config", %{authed: requestor, bundle: bundle} do
+    set_config(bundle, "user", "alice", %{"hello" => "world"})
+
+    conn = api_request(requestor, :get,
+                       "/v1/bundles/#{bundle.id}/dynamic_config/user/alice")
+    body = json_response(conn, 200)
+    assert %{"dynamic_configuration" => %{
+              "bundle_name" => bundle.name,
+              "bundle_id" => bundle.id,
+              "layer" => "user",
+              "name" => "alice",
+              "config" => %{"hello" => "world"}}} == body
+  end
+
+  test "can't show a room config that doesn't exist", %{authed: requestor, bundle: bundle} do
+    conn = api_request(requestor, :get, "/v1/bundles/#{bundle.id}/dynamic_config/room/foo")
+    assert json_response(conn, 404)["error"]
+  end
+
+  test "can't show a user config that doesn't exist", %{authed: requestor, bundle: bundle} do
+    conn = api_request(requestor, :get, "/v1/bundles/#{bundle.id}/dynamic_config/user/foo")
+    assert json_response(conn, 404)["error"]
+  end
+
+  test "can't show just the room layer without also specifying a name", %{authed: requestor, bundle: bundle} do
+    conn = api_request(requestor, :get, "/v1/bundles/#{bundle.id}/dynamic_config/room")
+    assert json_response(conn, 404)["error"]
+  end
+
+  test "can't show just the user layer without also specifying a name", %{authed: requestor, bundle: bundle} do
+    conn = api_request(requestor, :get, "/v1/bundles/#{bundle.id}/dynamic_config/user")
+    assert json_response(conn, 404)["error"]
+  end
+
+  test "retrieve all configs for a bundle with no dynamic config set", %{authed: requestor, bundle: bundle} do
+    conn = api_request(requestor, :get,
+                       "/v1/bundles/#{bundle.id}/dynamic_config/")
+    assert [] == json_response(conn, 200)["dynamic_configurations"]
+  end
+
+  test "retrieve all configs for a bundle with only the base layer set", %{authed: requestor, bundle: bundle} do
+    set_config(bundle, "base", "config", %{"base" => "base"})
+
+    conn = api_request(requestor, :get,
+                       "/v1/bundles/#{bundle.id}/dynamic_config/")
+    body = json_response(conn, 200)
+    assert  %{"dynamic_configurations" => [%{
+                                              "bundle_id" => bundle.id,
+                                              "bundle_name" => bundle.name,
+                                              "config" => %{"base" => "base"},
+                                              "layer" => "base",
+                                              "name" => "config"}]} == body
+  end
+
+  test "retrieve all configs for a bundle with only no base layer set", %{authed: requestor, bundle: bundle} do
+    set_config(bundle, "user", "foo", %{"user" => "foo"})
+
+    conn = api_request(requestor, :get,
+                       "/v1/bundles/#{bundle.id}/dynamic_config/")
+    body = json_response(conn, 200)
+    assert  %{"dynamic_configurations" => [%{
+                                              "bundle_id" => bundle.id,
+                                              "bundle_name" => bundle.name,
+                                              "config" => %{"user" => "foo"},
+                                              "layer" => "user",
+                                              "name" => "foo"}]} == body
+  end
+
+
+  test "retrieve all configs for a bundle with multiple layers set", %{authed: requestor, bundle: bundle} do
+    set_config(bundle, "base", "config", %{"base" => "base"})
+    set_config(bundle, "room", "ops", %{"room" => "ops"})
+    set_config(bundle, "room", "dev", %{"room" => "dev"})
+    set_config(bundle, "user", "bob", %{"user" => "bob"})
+    set_config(bundle, "user", "alice", %{"user" => "alice"})
+
+    conn = api_request(requestor, :get,
+                       "/v1/bundles/#{bundle.id}/dynamic_config/")
+    body = json_response(conn, 200)
+    assert  %{"dynamic_configurations" => [%{"bundle_id" => bundle.id,
+                                            "bundle_name" => bundle.name,
+                                            "config" => %{"base" => "base"},
+                                            "layer" => "base",
+                                            "name" => "config"},
+                                          %{"bundle_id" => bundle.id,
+                                            "bundle_name" => bundle.name,
+                                            "config" => %{"room" => "dev"},
+                                            "layer" => "room",
+                                            "name" => "dev"},
+                                          %{"bundle_id" => bundle.id,
+                                            "bundle_name" => bundle.name,
+                                            "config" => %{"room" => "ops"},
+                                            "layer" => "room",
+                                            "name" => "ops"},
+                                          %{"bundle_id" => bundle.id,
+                                            "bundle_name" => bundle.name,
+                                            "config" => %{"user" => "alice"},
+                                            "layer" => "user",
+                                            "name" => "alice"},
+                                          %{"bundle_id" => bundle.id,
+                                            "bundle_name" => bundle.name,
+                                            "config" => %{"user" => "bob"},
+                                            "layer" => "user",
+                                            "name" => "bob"}]} == body
+  end
+
+  test "can't retrieve config for a bundle that doesn't exist", %{authed: requestor} do
+    bad_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    conn = api_request(requestor, :get, "/v1/bundles/#{bad_uuid}/dynamic_config/base")
+    assert json_response(conn, 404)["error"]
+  end
+
+  test "can't save anything to a named base layer (there's only one base layer)", %{authed: requestor, bundle: bundle} do
+    conn = api_request(requestor, :post,
+                       "/v1/bundles/#{bundle.id}/dynamic_config/base/foo",
+                       body: %{"config": %{"test1" => "abc"}})
+    assert json_response(conn, 404)["error"]
+  end
+
+  test "can't save anything to an unrecognized layer", %{authed: requestor, bundle: bundle} do
+    conn = api_request(requestor, :post,
+                       "/v1/bundles/#{bundle.id}/dynamic_config/monkey/foo",
+                       body: %{"config": %{"test1" => "abc"}})
+    assert json_response(conn, 404)["error"]
   end
 
   test "overwrite dynamic config", %{authed: requestor, bundle: bundle} do
-    conn = api_request(requestor, :post, "/v1/bundles/#{bundle.id}/dynamic_config", body: %{"config": %{"test1" => "abc"}})
-    assert conn.status == 201
-    conn = api_request(requestor, :get, "/v1/bundles/#{bundle.id}/dynamic_config")
-    assert conn.status == 200
-    body = Poison.decode!(conn.resp_body)
-    config = Map.fetch!(body, "dynamic_configuration")
-    assert Map.equal?(config, %{"bundle_name" => bundle.name,
-                                "bundle_id" => bundle.id,
-                                "config" => %{"test1" => "abc"}})
-    conn = api_request(requestor, :post, "/v1/bundles/#{bundle.id}/dynamic_config", body: %{"config": %{"test1" => "abc", "test2" => [1,2,3]}})
-    assert conn.status == 201
-    conn = api_request(requestor, :get, "/v1/bundles/#{bundle.id}/dynamic_config")
-    assert conn.status == 200
-    body = Poison.decode!(conn.resp_body)
-    config = Map.fetch!(body, "dynamic_configuration")
-    Logger.debug("#{inspect config}")
-    assert Map.equal?(config, %{"bundle_name" => bundle.name,
-                                "bundle_id" => bundle.id,
-                                "config" => %{"test1" => "abc", "test2" => [1,2,3]}})
-  end
+    set_config(bundle, "base", "config", %{"test1" => "abc"})
 
-  test "cannot request existing dynamic config without manage_commands permission", %{authed: authed, unauthed: unauthed, bundle: bundle} do
-    conn = api_request(authed, :post, "/v1/bundles/#{bundle.id}/dynamic_config", body: %{"config": %{"test1" => "abc"}})
-    assert conn.status == 201
-    conn = api_request(authed, :get, "/v1/bundles/#{bundle.id}/dynamic_config")
-    assert conn.status == 200
-    body = Poison.decode!(conn.resp_body)
-    config = Map.fetch!(body, "dynamic_configuration")
-    assert Map.equal?(config, %{"bundle_name" => bundle.name,
-                                "bundle_id" => bundle.id,
-                                "config" => %{"test1" => "abc"}})
-    conn = api_request(unauthed, :get, "/v1/bundles/#{bundle.id}/dynamic_config")
-    assert conn.status == 403
-  end
-
-  test "delete missing dynamic config returns 404", %{authed: requestor, bundle: bundle} do
-    conn = api_request(requestor, :delete, "/v1/bundles/#{bundle.id}/dynamic_config")
-    assert conn.status == 404
+    conn = api_request(requestor, :post,
+                       "/v1/bundles/#{bundle.id}/dynamic_config/base",
+                       body: %{"config": %{"test1" => "abc", "test2" => [1,2,3]}})
+    body = json_response(conn, 201)
+    assert %{"dynamic_configuration" => %{
+              "bundle_id" => bundle.id,
+              "bundle_name" => bundle.name,
+              "layer" => "base",
+              "name" => "config",
+              "config" => %{
+                "test1" => "abc",
+                "test2" => [1,2,3]
+              }}} == body
   end
 
   test "must have manage_commands permission to delete dynamic config", %{unauthed: requestor, bundle: bundle} do
-    conn = api_request(requestor, :delete, "/v1/bundles/#{bundle.id}/dynamic_config")
+    conn = api_request(requestor, :delete, "/v1/bundles/#{bundle.id}/dynamic_config/base")
     assert conn.status == 403
   end
 
-  test "delete dynamic config", %{authed: requestor, bundle: bundle} do
-    conn = api_request(requestor, :post, "/v1/bundles/#{bundle.id}/dynamic_config", body: %{"config": %{"test1" => "abc"}})
-    assert conn.status == 201
-    conn = api_request(requestor, :delete, "/v1/bundles/#{bundle.id}/dynamic_config")
+  test "delete base dynamic config", %{authed: requestor, bundle: bundle} do
+    set_config(bundle, "base", "config", %{"test1" => "abc"})
+
+    conn = api_request(requestor, :delete, "/v1/bundles/#{bundle.id}/dynamic_config/base")
     assert conn.status == 204
-    conn = api_request(requestor, :get, "/v1/bundles/#{bundle.id}/dynamic_config")
-    assert conn.status == 404
+
+    refute Bundles.dynamic_config_for_bundle(bundle, "base", "config")
   end
 
-  test "must have manage_commands permission to delete existing dynamic config", %{unauthed: unauthed, authed: authed, bundle: bundle} do
-    conn = api_request(authed, :post, "/v1/bundles/#{bundle.id}/dynamic_config", body: %{"config": %{"test1" => "abc"}})
-    assert conn.status == 201
-    conn = api_request(unauthed, :delete, "/v1/bundles/#{bundle.id}/dynamic_config")
-    assert conn.status == 403
+  test "delete room dynamic config", %{authed: requestor, bundle: bundle} do
+    set_config(bundle, "room", "ops", %{"test1" => "abc"})
+
+    conn = api_request(requestor, :delete, "/v1/bundles/#{bundle.id}/dynamic_config/room/ops")
+    assert conn.status == 204
+
+    refute Bundles.dynamic_config_for_bundle(bundle, "room", "ops")
+  end
+
+  test "delete user dynamic config", %{authed: requestor, bundle: bundle} do
+    set_config(bundle, "user", "alice", %{"test1" => "abc"})
+
+    conn = api_request(requestor, :delete, "/v1/bundles/#{bundle.id}/dynamic_config/user/alice")
+    assert conn.status == 204
+
+    refute Bundles.dynamic_config_for_bundle(bundle, "user", "alice")
+  end
+
+  test "deleting non existent config", %{authed: requestor, bundle: bundle} do
+    conn = api_request(requestor , :delete, "/v1/bundles/#{bundle.id}/dynamic_config/user/not_here")
+    assert json_response(conn, 404)["error"]
+  end
+
+  ########################################################################
+
+  defp set_config(bundle, layer, name, config) do
+    {:ok, dynamic_config} = Bundles.create_dynamic_config_for_bundle(bundle, %{"bundle_id" => bundle.id,
+                                                                               "layer" => layer,
+                                                                               "name" => name,
+                                                                               "config" => config})
+    dynamic_config
   end
 
 end

--- a/web/controllers/v1/bundle_dynamic_config_controller.ex
+++ b/web/controllers/v1/bundle_dynamic_config_controller.ex
@@ -4,42 +4,113 @@ defmodule Cog.V1.BundleDynamicConfigController do
   require Logger
 
   alias Cog.Router.Helpers
-  alias Cog.Models.BundleDynamicConfig
   alias Cog.Repository.Bundles
 
   plug Cog.Plug.Authentication
   plug Cog.Plug.Authorization, permission: "#{Cog.embedded_bundle}:manage_commands"
 
-  def show(conn, %{"bundle_id" => id}) do
-    case Bundles.dynamic_config_for_bundle(id) do
+  def show_all(conn, %{"bundle_id" => id}),
+    do: all_config(conn, id)
+
+  def show_layer(conn, %{"layer" => "base", "name" => _name}),
+    do: not_found(conn, "There is only a single base layer") # TODO: Just return it anyway?
+  def show_layer(conn, %{"layer" => "base"}=params),
+    do: show(conn, Map.put(params, "name", "config"))
+  def show_layer(conn, %{"layer" => layer, "name" => _name}=params) when layer in ["room", "user"],
+    do: show(conn, params)
+  def show_layer(conn, _),
+    do: not_found(conn, "Dynamic configuration not found")
+
+  def set_layer(conn, %{"layer" => "base", "name" => _name}),
+    do: not_found(conn, "There is only a single base layer") # TODO: Just return it anyway?
+  def set_layer(conn, %{"layer" => "base"}=params),
+    do: create(conn, Map.put(params, "name", "config"))
+  def set_layer(conn, %{"layer" => layer, "name" => _name}=params) when layer in ["room", "user"],
+    do: create(conn, params)
+  def set_layer(conn, _),
+    do: not_found(conn, "Incorrect dynamic configuration layer specification")
+
+  def delete_layer(conn, %{"layer" => "base", "name" => _name}),
+    do: not_found(conn, "There is only a single base layer") # TODO: Just return it anyway?
+  def delete_layer(conn, %{"layer" => "base"}=params),
+    do: delete(conn, Map.put(params, "name", "config"))
+  def delete_layer(conn, %{"layer" => layer, "name" => _name}=params) when layer in ["room", "user"],
+    do: delete(conn, params)
+  def delete_layer(conn, _),
+    do: not_found(conn, "Dynamic configuration not found")
+
+  ########################################################################
+
+  defp not_found(conn, message) do
+    conn
+    |> put_status(:not_found)
+    |> json(%{error: message})
+  end
+
+  defp all_config(conn, id) do
+    case Bundles.bundle(id) do
       nil ->
-        send_resp(conn, 404, "")
-      config ->
-        render(conn, "show.json", dynamic_config: config)
+        not_found(conn, "Bundle #{id} not found")
+      bundle ->
+        configs = Bundles.dynamic_config_for_bundle(bundle)
+        render(conn, "all.json", dynamic_configs: configs)
     end
   end
 
-  def create(conn, params) do
-    changeset = BundleDynamicConfig.changeset(%BundleDynamicConfig{}, params)
-    case Bundles.create_dynamic_config_for_bundle(Map.get(params, "bundle_id"), changeset) do
-      {:ok, dyn_config} ->
-        conn
-        |> put_status(:created)
-        |> put_resp_header("location", Helpers.bundle_dynamic_config_path(conn, :show, dyn_config.bundle_id))
-        |> render("show.json", dynamic_config: dyn_config)
-      {:error, changeset} ->
-        conn
-        |> put_status(:unprocessable_entity)
-        |> render(Cog.ChangesetView, "error.json", changeset: changeset)
+  defp show(conn, %{"bundle_id" => id, "layer" => layer, "name" => name}) do
+    case Bundles.bundle(id) do
+      nil ->
+        not_found(conn, "Bundle #{id} not found")
+      bundle ->
+        case Bundles.dynamic_config_for_bundle(bundle, layer, name) do
+          nil ->
+            not_found(conn, "Dynamic configuration layer #{layer}/#{name} for bundle #{bundle.name} not found")
+          config ->
+            render(conn, "show.json", dynamic_config: config)
+        end
     end
   end
 
-  def delete(conn, %{"bundle_id" => id}) do
-    if Bundles.delete_dynamic_config_for_bundle(id) do
-      send_resp(conn, 204, "")
-    else
-      send_resp(conn, 404, "")
+  defp create(conn, %{"bundle_id" => bundle_id}=params) do
+    case Bundles.bundle(bundle_id) do
+      nil ->
+        not_found(conn, "Bundle #{bundle_id} not found")
+      bundle ->
+        case Bundles.create_dynamic_config_for_bundle(bundle, params) do
+          {:ok, dyn_config} ->
+            location = case Map.get(params, "layer") do
+                         "base" ->
+                           Helpers.bundle_dynamic_config_path(conn, :show_layer,
+                                                              dyn_config.bundle_id,
+                                                              dyn_config.layer, %{})
+                         _ ->
+                           Helpers.bundle_dynamic_config_path(conn, :show_layer,
+                                                              dyn_config.bundle_id,
+                                                              dyn_config.layer,
+                                                              dyn_config.name, %{})
+                       end
+            conn
+            |> put_status(:created)
+            |> put_resp_header("location", location)
+            |> render("show.json", dynamic_config: dyn_config)
+          {:error, changeset} ->
+            conn
+            |> put_status(:unprocessable_entity)
+            |> render(Cog.ChangesetView, "error.json", changeset: changeset)
+        end
     end
   end
 
+  defp delete(conn, %{"bundle_id" => id, "layer" => layer, "name" => name}) do
+    case Bundles.bundle(id) do
+      nil ->
+        not_found(conn, "Bundle #{id} not found")
+      bundle ->
+        if Bundles.delete_dynamic_config_for_bundle(bundle, layer, name) do
+          send_resp(conn, 204, "")
+        else
+          not_found(conn, "Dynamic configuration layer #{layer}/#{name} for bundle #{bundle.name} not found")
+        end
+    end
+  end
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -46,9 +46,15 @@ defmodule Cog.Router do
     get  "/v1/bundles/:id/status", V1.BundleStatusController, :show
     post "/v1/bundles/:id/versions/:bundle_version_id/status", V1.BundleStatusController, :set_status
 
-    get "/v1/bundles/:bundle_id/dynamic_config", V1.BundleDynamicConfigController, :show
-    post "/v1/bundles/:bundle_id/dynamic_config", V1.BundleDynamicConfigController, :create
-    delete "/v1/bundles/:bundle_id/dynamic_config", V1.BundleDynamicConfigController, :delete
+    get "/v1/bundles/:bundle_id/dynamic_config",                 V1.BundleDynamicConfigController, :show_all
+    get "/v1/bundles/:bundle_id/dynamic_config/:layer",          V1.BundleDynamicConfigController, :show_layer # base
+    get "/v1/bundles/:bundle_id/dynamic_config/:layer/:name",    V1.BundleDynamicConfigController, :show_layer
+
+    post "/v1/bundles/:bundle_id/dynamic_config/:layer",         V1.BundleDynamicConfigController, :set_layer # base
+    post "/v1/bundles/:bundle_id/dynamic_config/:layer/:name",   V1.BundleDynamicConfigController, :set_layer
+
+    delete "/v1/bundles/:bundle_id/dynamic_config/:layer",       V1.BundleDynamicConfigController, :delete_layer # base
+    delete "/v1/bundles/:bundle_id/dynamic_config/:layer/:name", V1.BundleDynamicConfigController, :delete_layer
 
     ########################################################################
 

--- a/web/views/bundle_dynamic_config_view.ex
+++ b/web/views/bundle_dynamic_config_view.ex
@@ -1,10 +1,20 @@
 defmodule Cog.V1.BundleDynamicConfigView do
   use Cog.Web, :view
 
+  def render("config.json", %{dynamic_config: dynamic_config}) do
+    %{bundle_id: dynamic_config.bundle.id,
+      bundle_name: dynamic_config.bundle.name,
+      layer: dynamic_config.layer,
+      name: dynamic_config.name,
+      config: dynamic_config.config}
+  end
+
+  def render("all.json", %{dynamic_configs: configs}) do
+    %{dynamic_configurations: render_many(configs, __MODULE__, "config.json", as: :dynamic_config)}
+  end
+
   def render("show.json", %{dynamic_config: dynamic_config}) do
-    %{dynamic_configuration: %{bundle_id: dynamic_config.bundle.id,
-                               bundle_name: dynamic_config.bundle.name,
-                               config: dynamic_config.config}}
+    %{dynamic_configuration: render_one(dynamic_config, __MODULE__, "config.json", as: :dynamic_config)}
   end
 
 end


### PR DESCRIPTION
Adds the ability to manage "layers" of dynamic bundle configuration. The
previous notion of dynamic configuration is referred to now as the
"base" layer, but now we may add "room" and "user" layers on top. Relay
can apply these in order to override the base layer depending on which
user issues a command, and from which room it is issued.

Layers can have names, indicating which user or room they apply to. The
base layer is always named "config" by convention (it could be named
anything, really).

There can only be one base layer per bundle, but multiple room and user
layers, provided they each have a different name.

A REST API is provided to manipulate each layer of a bundle
individually. Additionally, all layers for a bundle may be retrieved at
once.

Cog now returns all layers for all bundles that a Relay is currently
serving.