### PR TITLE
Fix emqttd mgmt;Refine process tree structure

### DIFF
--- a/lib/cog/core_sup.ex
+++ b/lib/cog/core_sup.ex
@@ -1,0 +1,40 @@
+defmodule Cog.CoreSup do
+  require Logger
+  use Supervisor
+
+  def start_link() do
+    Supervisor.start_link(__MODULE__, [])
+  end
+
+  def init(_) do
+    adapter_supervisor = get_adapter_supervisor!()
+    children = [worker(Cog.TokenReaper, []),
+                supervisor(Cog.Relay.RelaySup, []),
+                supervisor(Cog.Command.CommandSup, []),
+                supervisor(adapter_supervisor, []),
+                supervisor(Cog.Endpoint, []),
+                supervisor(Cog.TriggerEndpoint, []),
+                supervisor(Cog.ServiceEndpoint, []),
+                supervisor(Cog.Adapters.Http.Supervisor,[])]
+    {:ok, {%{strategy: :one_for_one, intensity: 10, period: 60}, children}}
+  end
+
+  defp get_adapter_supervisor!() do
+    case Cog.chat_adapter_module do
+      {:ok, adapter} ->
+        Logger.info "Using #{inspect adapter} chat adapter"
+        supervisor = Module.concat(adapter, "Supervisor")
+
+        case Code.ensure_loaded(supervisor) do
+          {:module, ^supervisor} ->
+            supervisor
+          {:error, _} ->
+            raise RuntimeError, "#{inspect(supervisor)} was not found. Please define a supervisor for the #{inspect(adapter)} adapter"
+        end
+      {:error, {:bad_adapter, bad_adapter}} ->
+        raise RuntimeError, "The adapter is set to #{inspect(bad_adapter)}, but I don't know what that is. Try one of the following values instead: #{Enum.map_join(Map.keys(Cog.chat_adapters), ", ", &inspect/1)}"
+    end
+  end
+
+
+end


### PR DESCRIPTION
- `Cog.BusDriver` now traps exits if it successfully starts
  `emqttd`. This allows Cog to keep the message bus state in sync with
  Cog's overall state. If Cog is up, the message bus is up. If Cog is
  down, the message bus is down.

- Removed the `mnesia` data file deletion logic from
  `Cog.BusDriver. Wound up causing more problems than it solved. We can
  tell users to delete the data dir in the release notes.

- Moved all of Cog core, modulo `Cog.Repo` and `Cog.BusDriver`, to a
  separate supervisor named `Cog.CoreSup` with a restart strategy of
  one-for-one. The top level supervisor is now responsible for
  `Cog.Repo`, `Cog.BusDriver`, and `Cog.CoreSup` and uses the
  one-for-all restart strategy. This should stabilize Cog as all
  processes will be restarted if the database or message bus goes down.

Fixes #897