### PR TITLE
reset password endpoints

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -198,5 +198,6 @@ config :cog, Cog.Mailer,
   retries: (System.get_env("COG_SMTP_RETRIES") || 1)
 
 config :cog, :email_from, System.get_env("COG_EMAIL_FROM")
+config :cog, :password_reset_base_url, System.get_env("COG_PASSWORD_RESET_BASE_URL")
 
 import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -34,3 +34,5 @@ config :comeonin,
 config :phoenix, :generators,
   migration: true,
   binary_id: false
+
+config :cog, Cog.Mailer, adapter: Bamboo.LocalAdapter

--- a/config/test.exs
+++ b/config/test.exs
@@ -44,3 +44,5 @@ config :cog, Cog.Adapters.Slack,
 # Emails
 
 config :cog, Cog.Mailer, adapter: Bamboo.TestAdapter
+config :cog, :email_from, "test@example.com"
+config :cog, :password_reset_base_url, "http://cog.localhost/reset-password"

--- a/lib/cog/email.ex
+++ b/lib/cog/email.ex
@@ -1,0 +1,11 @@
+defmodule Cog.Email do
+  use Bamboo.Phoenix, view: Cog.EmailView
+  alias Bamboo.Email
+
+  def reset_password(email_address, token) do
+    Email.new_email(from: Application.fetch_env!(:cog, :email_from),
+                    subject: "Cog - Password Reset Request",
+                    to: email_address)
+    |> render("reset_password.text", token: token)
+  end
+end

--- a/lib/cog/models.ex
+++ b/lib/cog/models.ex
@@ -45,6 +45,7 @@ defmodule Cog.Models do
       alias Cog.Models.Template
       alias Cog.Models.UserCommandAlias
       alias Cog.Models.SiteCommandAlias
+      alias Cog.Models.PasswordReset
     end
   end
 end

--- a/lib/cog/models/password_reset.ex
+++ b/lib/cog/models/password_reset.ex
@@ -1,0 +1,18 @@
+defmodule Cog.Models.PasswordReset do
+  use Cog.Model
+  alias Cog.Model.User
+
+  schema "password_resets" do
+    belongs_to :user, User
+
+    timestamps
+  end
+
+  @required_fields ~w(user_id)
+  @optional_fields ~w()
+
+  def changeset(model, params) do
+    model
+    |> cast(params, @required_fields, @optional_fields)
+  end
+end

--- a/lib/cog/models/password_reset.ex
+++ b/lib/cog/models/password_reset.ex
@@ -1,6 +1,6 @@
 defmodule Cog.Models.PasswordReset do
   use Cog.Model
-  alias Cog.Model.User
+  alias Cog.Models.User
 
   schema "password_resets" do
     belongs_to :user, User

--- a/mix.exs
+++ b/mix.exs
@@ -50,6 +50,7 @@ defmodule Cog.Mixfile do
             :phoenix_html,
             :comeonin,
             :spanner,
+            :bamboo,
             :exirc]
     if System.get_env("COG_SASL_LOG") != nil do
       [:sasl|apps]

--- a/priv/repo/migrations/20160803163007_password_reset.exs
+++ b/priv/repo/migrations/20160803163007_password_reset.exs
@@ -4,7 +4,7 @@ defmodule Cog.Repo.Migrations.PasswordReset do
   def change do
     create table(:password_resets, primary_key: false) do
       add :id, :uuid, primary_key: true
-      add :user_id, references(:users, type: :uuid), null: false
+      add :user_id, references(:users, type: :uuid, on_delete: :delete_all), null: false
 
       timestamps
     end

--- a/priv/repo/migrations/20160803163007_password_reset.exs
+++ b/priv/repo/migrations/20160803163007_password_reset.exs
@@ -1,0 +1,12 @@
+defmodule Cog.Repo.Migrations.PasswordReset do
+  use Ecto.Migration
+
+  def change do
+    create table(:password_resets, primary_key: false) do
+      add :id, :uuid, primary_key: true
+      add :user_id, references(:users, type: :uuid), null: false
+
+      timestamps
+    end
+  end
+end

--- a/priv/repo/migrations/20160803165909_add_unique_constraint_to_users_email_address.exs
+++ b/priv/repo/migrations/20160803165909_add_unique_constraint_to_users_email_address.exs
@@ -1,0 +1,7 @@
+defmodule Cog.Repo.Migrations.AddUniqueConstraintToUsersEmailAddress do
+  use Ecto.Migration
+
+  def change do
+    create unique_index(:users, [:email_address])
+  end
+end

--- a/test/controllers/v1/password_reset_controller_test.exs
+++ b/test/controllers/v1/password_reset_controller_test.exs
@@ -19,7 +19,7 @@ defmodule Cog.V1.PasswordResetController.Test do
   test "password resets are generated", %{conn: conn, user: user} do
     resp = post(conn, password_reset_path(conn, :create), email_address: user.email_address)
 
-    assert resp.status == 200
+    assert resp.status == 204
     Repo.get_by!(PasswordReset, user_id: user.id)
   end
 

--- a/test/controllers/v1/password_reset_controller_test.exs
+++ b/test/controllers/v1/password_reset_controller_test.exs
@@ -1,0 +1,45 @@
+defmodule Cog.V1.PasswordResetController.Test do
+  use Cog.ConnCase
+
+  alias Cog.Repository.Users
+  alias Cog.Repo
+  alias Cog.Models.PasswordReset
+
+  setup_all context do
+    {:ok, Map.merge(context, %{conn: Phoenix.ConnTest.conn()})}
+  end
+
+  setup context do
+    {:ok, user} = Users.new(%{username: "Bob",
+                              email_address: "bob@example.com",
+                              password: "password"})
+    {:ok, Map.merge(context, %{user: user})}
+  end
+
+  test "password resets are generated", %{conn: conn, user: user} do
+    resp = post(conn, password_reset_path(conn, :create), email_address: user.email_address)
+
+    assert resp.status == 200
+    Repo.get_by!(PasswordReset, user_id: user.id)
+  end
+
+  test "we can reset a password with the proper token", %{conn: conn, user: user} do
+    # Make sure the user can get a token
+    post(conn, token_path(conn, :create), username: user.username, password: user.password)
+    |> json_response(201)
+
+    # Then we'll create the password reset request
+    {:ok, password_reset} = Users.request_password_reset(user)
+
+    # Then update our password with the reset request
+    put(conn, password_reset_path(conn, :update, password_reset.id), password: "new_password")
+
+    # Try to get a token with the old password
+    post(conn, token_path(conn, :create), username: user.username, password: user.password)
+    |> json_response(403)
+
+    # And finally see if we can get a token with the new password
+    post(conn, token_path(conn, :create), username: user.username, password: "new_password")
+    |> json_response(201)
+  end
+end

--- a/test/emails/password_reset_test.exs
+++ b/test/emails/password_reset_test.exs
@@ -1,0 +1,20 @@
+defmodule Cog.Email.PasswordReset.Test do
+  @moduledoc """
+  Email tests for resetting user passwords
+  """
+
+  use Cog.EmailCase
+  #alias Cog.Repo
+  #alias Cog.Models.PasswordReset
+  alias Cog.Repository.Users
+
+  test "password reset emails are sent" do
+    {:ok, user} = Users.new(%{username: "Bob",
+                              email_address: "bob@example.com",
+                              password: "password"})
+
+    {:ok, password_reset} = Users.request_password_reset(user)
+
+    assert_delivered_email(Cog.Email.reset_password(user.email_address, password_reset.id))
+  end
+end

--- a/test/emails/password_reset_test.exs
+++ b/test/emails/password_reset_test.exs
@@ -4,8 +4,6 @@ defmodule Cog.Email.PasswordReset.Test do
   """
 
   use Cog.EmailCase
-  #alias Cog.Repo
-  #alias Cog.Models.PasswordReset
   alias Cog.Repository.Users
 
   test "password reset emails are sent" do

--- a/web/controllers/v1/password_reset_controller.ex
+++ b/web/controllers/v1/password_reset_controller.ex
@@ -7,7 +7,7 @@ defmodule Cog.V1.PasswordResetController do
     case Users.by_email(email_address) do
       {:ok, user} ->
         case Users.request_password_reset(user) do
-          {:ok, _} -> put_status(conn, :ok)
+          {:ok, _} -> put_status(conn, :no_content)
           _ -> put_status(conn, :internal_server_error)
         end
       _ ->

--- a/web/controllers/v1/password_reset_controller.ex
+++ b/web/controllers/v1/password_reset_controller.ex
@@ -1,0 +1,19 @@
+defmodule Cog.V1.PasswordResetController do
+  use Cog.Web, :controller
+
+  alias Cog.Repository.Users
+
+  def create(conn, %{"email_address" => email_address}) do
+    case Users.by_email(email_address) do
+      {:ok, user} ->
+        Users.request_password_reset(user)
+        put_status(conn, :ok)
+      _ ->
+        put_status(conn, :ok)
+    end
+  end
+
+  def update(_conn, _params) do
+  end
+
+end

--- a/web/controllers/v1/password_reset_controller.ex
+++ b/web/controllers/v1/password_reset_controller.ex
@@ -7,11 +7,13 @@ defmodule Cog.V1.PasswordResetController do
     case Users.by_email(email_address) do
       {:ok, user} ->
         case Users.request_password_reset(user) do
-          {:ok, _} -> put_status(conn, :no_content)
-          _ -> put_status(conn, :internal_server_error)
+          {:ok, foo} ->
+            send_resp(conn, :no_content, "")
+          error ->
+            send_resp(conn, :internal_server_error, "")
         end
       _ ->
-        put_status(conn, :ok)
+        send_resp(conn, :ok, "")
     end
   end
 

--- a/web/controllers/v1/password_reset_controller.ex
+++ b/web/controllers/v1/password_reset_controller.ex
@@ -7,9 +7,9 @@ defmodule Cog.V1.PasswordResetController do
     case Users.by_email(email_address) do
       {:ok, user} ->
         case Users.request_password_reset(user) do
-          {:ok, foo} ->
+          {:ok, _} ->
             send_resp(conn, :no_content, "")
-          error ->
+          _ ->
             send_resp(conn, :internal_server_error, "")
         end
       _ ->

--- a/web/router.ex
+++ b/web/router.ex
@@ -18,7 +18,7 @@ defmodule Cog.Router do
     pipe_through :api
 
     resources "/v1/users", V1.UserController
-    resources "/v1/reset-password", V1.PasswordResetController, only: [:create, :update]
+    resources "/v1/users/reset-password", V1.PasswordResetController, only: [:create, :update]
 
     resources "/v1/groups", V1.GroupController
     get "/v1/groups/:id/users", V1.GroupMembershipController, :index

--- a/web/router.ex
+++ b/web/router.ex
@@ -18,6 +18,7 @@ defmodule Cog.Router do
     pipe_through :api
 
     resources "/v1/users", V1.UserController
+    resources "/v1/reset-password", V1.PasswordResetController, only: [:create, :update]
 
     resources "/v1/groups", V1.GroupController
     get "/v1/groups/:id/users", V1.GroupMembershipController, :index

--- a/web/router.ex
+++ b/web/router.ex
@@ -7,6 +7,10 @@ defmodule Cog.Router do
     plug :fetch_flash
     plug :protect_from_forgery
     plug :put_secure_browser_headers
+
+    if Mix.env == :dev do
+      forward "/v1/sent_emails", Bamboo.EmailPreviewPlug
+    end
   end
 
   pipeline :api do

--- a/web/templates/email/reset_password.text.eex
+++ b/web/templates/email/reset_password.text.eex
@@ -1,0 +1,5 @@
+A request to reset your password has been received. To reset your password please follow the link below.
+
+<%= reset_url(@token) %>
+
+If you didn't request this change, please ignore this email.

--- a/web/views/email_view.ex
+++ b/web/views/email_view.ex
@@ -1,0 +1,10 @@
+defmodule Cog.EmailView do
+  use Cog.Web, :view
+
+  def reset_url(token) do
+    Application.fetch_env!(:cog, :password_reset_base_url)
+    |> URI.parse
+    |> Map.put(:query, "token=#{token}")
+    |> URI.to_string
+  end
+end

--- a/web/views/email_view.ex
+++ b/web/views/email_view.ex
@@ -1,9 +1,24 @@
 defmodule Cog.EmailView do
   use Cog.Web, :view
+  require Logger
 
   def reset_url(token) do
-    Application.fetch_env!(:cog, :password_reset_base_url)
-    |> URI.parse
+    base_url = case Application.get_env(:cog, :password_reset_base_url, nil) do
+      nil ->
+        Logger.warn("""
+        Base URL not set for password reset, defaulting to 'localhost'.
+        The base url is the url Cog sends to users when a password reset is requested.
+
+        Please set the env var 'COG_PASSWORD_RESET_BASE_URL'.
+        """)
+
+        "localhost"
+
+      base_url ->
+        base_url
+    end
+
+    URI.parse(base_url)
     |> Map.put(:query, "token=#{token}")
     |> URI.to_string
   end


### PR DESCRIPTION
Adds two endpoint to Cog for resetting passwords, `POST /v1/users/reset-password` and `PUT /v1/users/reset-password/:id`.

In order to work Cog needs to be able to send emails. Email is sent via SMTP and is configured with the following env vars:
- `COG_SMTP_SERVER`
- `COG_SMTP_PORT`
- `COG_SMTP_USERNAME`
- `COG_SMTP_PASSWORD`
- `COG_SMTP_SSL` (default: false)
- `COG_SMTP_RETRIES` (default: 1)

Additionally there are a couple other env vars used to configure Cog for password resets:
- `COG_EMAIL_FROM` - The email address from which Cog will send emails.
- `COG_PASSWORD_RESET_BASE_URL` - This is the base url Cog will use as the password reset link in password reset request emails. The reset url is build by appending `?token=<token>` as a query param to the base url.

resolves #894 
