### PR TITLE
Sync cogctl and cog in the Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,6 @@ erl_crash.dump
 *.swp
 *.pem
 data
-.git
 lib/cog/permissions/bp_lexer.erl
 lib/cog/permissions/bp_parser.erl
 Mnesia*

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -9,14 +9,46 @@ mix hex.info
 
 # build cog
 cd /home/operable/cog
+
+# We do this so we know what branch to build for cogctl later on
+COG_BRANCH=`git symbolic-ref HEAD | sed 's!refs/heads/!!'`
+if [ -z "$COG_BRANCH" ]
+then
+    echo "Looks like cog isn't a git repository! Do you have '.git' in the '.dockerignore' file? If so, remove it and try again."
+    exit 1
+fi
+
+# Get rid of .git now that we know the branch
+rm -Rf .git
+
 mix clean
 mix deps.get
 mix deps.compile
 mix compile
 
 # build cogctl
+#
+# First take a look at what branch / tag we're on in Cog
+# If the same branch / tag exists in cogctl, we should use it.
+# Otherwise, we use master
+echo "cog is currently checked out at ${COG_BRANCH}"
+COGCTL_REPO="https://github.com/operable/cogctl"
+if git ls-remote --exit-code --heads $COGCTL_REPO $COG_BRANCH
+then
+    COGCTL_BRANCH=$COG_BRANCH
+    echo "A '$COGCTL_BRANCH' branch exists for cogctl as well; building from that"
+else
+    COGCTL_BRANCH="master"
+    echo "No '$COG_BRANCH' branch exists for cogctl; building from the '$COGCTL_BRANCH' instead"
+fi
+
 cd /home/operable/cogctl
-git clone https://github.com/operable/cogctl .
+git clone $COGCTL_REPO .
+git checkout $COGCTL_BRANCH
+
+# No need to keep this in the image
+rm -Rf .git
+
 mix deps.get
 mix deps.compile
 mix escript

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -11,7 +11,7 @@ mix hex.info
 cd /home/operable/cog
 
 # We do this so we know what branch to build for cogctl later on
-COG_BRANCH=`git symbolic-ref HEAD | sed 's!refs/heads/!!'`
+COG_BRANCH=`git rev-parse --abbrev-ref HEAD`
 if [ -z "$COG_BRANCH" ]
 then
     echo "Looks like cog isn't a git repository! Do you have '.git' in the '.dockerignore' file? If so, remove it and try again."


### PR DESCRIPTION
Previously, if you didn't edit the `scripts/docker-build` file
beforehand, you could build an image that had the "wrong" version of
`cogctl` included. This version would always be build from `master` of
`cogctl`, and not necessarily the version that corresponded with the
`cog` you were building.

Now, the script figures out what branch `cog` is checked out to, and if
`cogctl` has a branch of the same name, it will check `cogctl` out on
that branch. If it doesn't, then it will fall back to the `master`
branch in `cogctl`.

Previously, we had `.git` in our `.dockerignore` file, but that would
make it impossible to determine `cog`'s current branch. Now, we don't
ignore `.git`, but we do remove it from the image before we finish
building. We also do the same for `cogctl` (which we weren't before).