### PR TITLE
Fix access errors

### DIFF
--- a/lib/cog/command/pipeline/destination.ex
+++ b/lib/cog/command/pipeline/destination.ex
@@ -86,7 +86,7 @@ defmodule Cog.Command.Pipeline.Destination do
     # TODO: handle the pathological case of the sender ID not actually
     # resolving to a destination... also need to handle the case where
     # "me" isn't a recognized destination (e.g., for HTTP adapter)
-    {:ok, room} = Cog.Chat.Adapter.lookup_room(adapter, sender["id"])
+    {:ok, room} = Cog.Chat.Adapter.lookup_room(adapter, sender.id)
     {:ok, %{dest | adapter: adapter, room: room}}
   end
   defp resolve_destination(%__MODULE__{raw: redir}=dest, _sender, _origin_room, origin_adapter) do

--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -435,7 +435,7 @@ defmodule Cog.Command.Pipeline.Executor do
                                         user: user}) do
 
     PipelineEvent.initialized(id, request.text, request.adapter,
-                              user.username, request.sender["handle"])
+                              user.username, request.sender.handle)
     |> Probe.notify
   end
 
@@ -471,7 +471,7 @@ defmodule Cog.Command.Pipeline.Executor do
 
   defp alert_unregistered_user(state) do
     request = state.request
-    handle = request.sender["handle"]
+    handle = request.sender.handle
     creators = user_creator_handles(request)
 
     {:ok, mention_name} = Cog.Chat.Adapter.mention_name(state.request.adapter, handle)
@@ -615,9 +615,9 @@ defmodule Cog.Command.Pipeline.Executor do
 
   defp sender_name(state) do
     if ChatAdapter.is_chat_provider?(state.request.adapter) do
-      "@#{state.request.sender["handle"]}"
+      "@#{state.request.sender.handle}"
     else
-      state.request.sender["id"]
+      state.request.sender.id
     end
   end
 
@@ -691,7 +691,7 @@ defmodule Cog.Command.Pipeline.Executor do
     # TODO: This should happen when we validate the request
     if ChatAdapter.is_chat_provider?(request.adapter) do
       adapter   = request.adapter
-      sender_id = request.sender["id"]
+      sender_id = request.sender.id
 
       user = Queries.User.for_chat_provider_user_id(sender_id, adapter)
       |> Repo.one
@@ -703,7 +703,7 @@ defmodule Cog.Command.Pipeline.Executor do
           {:ok, user}
       end
     else
-      cog_name = request.sender["id"]
+      cog_name = request.sender.id
       case Repo.get_by(Cog.Models.User, username: cog_name) do
         %Cog.Models.User{}=user ->
           {:ok, user}

--- a/lib/cog/command/reply_helper.ex
+++ b/lib/cog/command/reply_helper.ex
@@ -7,7 +7,7 @@ defmodule Cog.Command.ReplyHelper do
   """
   @spec send_template(map, String.t, map, Connection.connection) :: :ok | {:error, any}
   def send_template(request, template_name, context, conn) do
-    case Template.render(request["adapter"], template_name, context) do
+    case Template.render(request.adapter, template_name, context) do
       {:ok, message} ->
         Adapter.send(conn, request.adapter, request.room, message)
       error ->

--- a/lib/cog/commands/user/attach_handle.ex
+++ b/lib/cog/commands/user/attach_handle.ex
@@ -21,12 +21,12 @@ defmodule Cog.Commands.User.AttachHandle do
   def attach(%{options: %{"help" => true}}, _args) do
     show_usage
   end
-  def attach(req, [user_name, handle]) do
+  def attach(%Cog.Messages.Command{}=command, [user_name, handle]) do
     case Users.by_username(user_name) do
       {:error, :not_found} ->
         {:error, {:resource_not_found, "user", user_name}}
       {:ok, user} ->
-        provider_name = req.requestor["provider"]
+        provider_name = command.requestor.provider
         case ChatHandles.set_handle(user, provider_name, handle) do
           {:ok, handle} ->
             {:ok, "user-attach-handle", Cog.V1.ChatHandleView.render("show.json", %{chat_handle: handle})}

--- a/lib/cog/commands/user/detach_handle.ex
+++ b/lib/cog/commands/user/detach_handle.ex
@@ -22,12 +22,12 @@ defmodule Cog.Commands.User.DetachHandle do
   def detach(%{options: %{"help" => true}}, _args) do
     show_usage
   end
-  def detach(req, [user_name]) do
+  def detach(%Cog.Messages.Command{}=command, [user_name]) do
     case Users.by_username(user_name) do
       {:error, :not_found} ->
         {:error, {:resource_not_found, "user", user_name}}
       {:ok, user} ->
-        provider_name = req.requestor["provider"]
+        provider_name = command.requestor.provider
         :ok = ChatHandles.remove_handle(user, provider_name)
         {:ok, "user-detach-handle", %{"username" => user.username,
                                       "chat_provider" => %{"name" => provider_name}}}

--- a/lib/cog/commands/user/list_handles.ex
+++ b/lib/cog/commands/user/list_handles.ex
@@ -14,8 +14,8 @@ defmodule Cog.Commands.User.ListHandles do
 
   def list(%{options: %{"help" => true}}, _args),
     do: show_usage
-  def list(req, _args) do
-    provider_name = req.requestor["provider"]
+  def list(%Cog.Messages.Command{}=command, _args) do
+    provider_name = command.requestor.provider
     handles = ChatHandles.for_provider(provider_name)
     {:ok, "user-list-handles",
      Enum.map(handles,

--- a/lib/cog/messages.ex
+++ b/lib/cog/messages.ex
@@ -30,8 +30,6 @@ defmodule Cog.Messages.AdapterRequest do
   # Short name of adapter, e.g. "slack"
   field :adapter, :string, required: true
 
-  # Name of the Elixir module implementing the adapter
-  field :module, :string, required: false
 end
 
 defmodule Cog.Messages.Command do

--- a/lib/cog/messages.ex
+++ b/lib/cog/messages.ex
@@ -18,11 +18,11 @@ defmodule Cog.Messages.AdapterRequest do
 
   # Adapter-specific information about the user initiating the
   # request (e.g., Slack chat handle, internal Slack user ID, etc.)
-  field :sender, :map, required: true
+  field :sender, Cog.Chat.User, required: true
 
   # Adapter-specific information about the "room" the request was
   # initiated from (e.g., Slack channel, HTTP request, etc.)
-  field :room, :map, required: true
+  field :room, Cog.Chat.Room, required: true
 
   # Message queue topic to send the reply to
   field :reply, :string, required: true
@@ -70,13 +70,13 @@ defmodule Cog.Messages.Command do
   # request (e.g., Slack chat handle, internal Slack user ID, etc.)
   #
   # (see Cog.Messages.AdapterRequest.sender)
-  field :requestor, :map, required: true
+  field :requestor, Cog.Chat.User, required: true
 
   # Adapter-specific information about the "room" the request was
   # initiated from (e.g., Slack channel, HTTP request, etc.)
   #
   # (See Cog.Messages.AdapterRequest.room)
-  field :room, :map, required: true
+  field :room, Cog.Chat.Room, required: true
 
   # Token to access services (e.g. memory)
   field :service_token, :string, required: true
@@ -123,7 +123,7 @@ defmodule Cog.Messages.SendMessage do
   # Adapter-specific information about the "room" the response is
   # targeted to. May or may not be the same as the initial source of
   # the request (e.g., multiple redirect destinations)
-  field :room, :map, required: true
+  field :room, Cog.Chat.Room, required: true
 end
 
 ########################################################################

--- a/lib/cog/support/model_utilities.ex
+++ b/lib/cog/support/model_utilities.ex
@@ -79,7 +79,7 @@ defmodule Cog.Support.ModelUtilities do
     |> User.changeset(%{username: username,
                         first_name: Access.get(options, :first_name, String.capitalize(username)),
                         last_name: Access.get(options, :last_name, "Mc#{String.capitalize(username)}"),
-                        email_address: "#{username}@operable.io",
+                        email_address: Access.get(options, :email_address, "#{username}@operable.io"),
                         password: username})
     |> Repo.insert!
 

--- a/test/cog/command/pipeline/destination_test.exs
+++ b/test/cog/command/pipeline/destination_test.exs
@@ -17,9 +17,9 @@ defmodule Cog.Command.Pipeline.DestinationTest do
 
   test "'me' is resolved to current user" do
     {:ok, resolved} = Destination.process(["me"],
-                                           %{"id" => "user1"},
-                                           :origin_room,
-                                           "test")
+                                          %Cog.Chat.User{id: "user1"},
+                                          :origin_room,
+                                          "test")
 
     assert [%Destination{output_level: :full,
                          raw: "me",

--- a/test/integration/slack_registration_test.exs
+++ b/test/integration/slack_registration_test.exs
@@ -13,14 +13,20 @@ defmodule Integration.SlackRegistrationTest do
   @bot "deckard"
 
   test "executing a command without a registered handle" do
-    message = send_message("@#{@bot}: operable:echo test")
-    assert_edited_response "@#{@user}: I'm terribly sorry, but either I don't have a Cog account for you, or your Slack chat handle has not been registered. Currently, only registered users can interact with me.\n\nYou'll need to ask a Cog administrator to fix this situation and to register your Slack handle. \n", after: message
+    message = send_message("@#{@bot}: operable:echo If only Cog could automatically register me!")
+    assert_response("@#{@user}: I'm terribly sorry, but either I don't have a Cog account for you, or your Slack chat handle has not been registered. Currently, only registered users can interact with me.\n\nYou'll need to ask a Cog administrator to fix this situation and to register your Slack handle. \n",
+                    after: message)
   end
 
   test "autoregistration" do
     enable_autoregistration
-    message = send_message("@#{@bot}: operable:echo test")
-    assert_edited_response "@#{@user}: Hello #{@user}! It's great to meet you! You're the proud owner of a shiny new Cog account named '#{@user}'.\n\ntest", after: message
+    message = send_message("@#{@bot}: operable:echo Yay, I autoregistered!")
+
+    # We should get a confirmation message, as well as the actual
+    # output of the command
+    assert_response("@#{@user}: Hello #{@user}! It's great to meet you! You're the proud owner of a shiny new Cog account named '#{@user}'.\n\nYay, I autoregistered!",
+                    after: message,
+                    count: 2)
   end
 
   test "autoregistration after a few tries" do
@@ -39,8 +45,13 @@ defmodule Integration.SlackRegistrationTest do
     expected_username = "#{@user}_#{max+1}"
     assert {:error, :not_found} = Users.by_username(expected_username)
 
-    message = send_message("@#{@bot}: operable:echo test")
-    assert_edited_response("@#{@user}: Hello #{@user}! It's great to meet you! You're the proud owner of a shiny new Cog account named '#{expected_username}'.\n\ntest", after: message)
+    message = send_message("@#{@bot}: operable:echo I am slow but I get there eventually")
+
+    # We should get a confirmation message, as well as the actual
+    # output of the command
+    assert_response("@#{@user}: Hello #{@user}! It's great to meet you! You're the proud owner of a shiny new Cog account named '#{expected_username}'.\n\nI am slow but I get there eventually",
+                     after: message,
+                     count: 2)
 
     assert {:ok, %User{username: ^expected_username}} = Users.by_username(expected_username)
   end
@@ -59,8 +70,9 @@ defmodule Integration.SlackRegistrationTest do
     user(@user, email_address: "#{@user}_0@operable.io")
     Enum.each(1..max, &user("#{@user}_#{&1}"))
 
-    message = send_message("@#{@bot}: operable:echo test")
-    assert_edited_response("@#{@user}: Unfortunately I was unable to automatically create a Cog account for your Slack chat handle. Only users with Cog accounts can interact with me.\n\nYou'll need to ask a Cog administrator to investigate the situation and set up your account.\n", after: message)
+    message = send_message("@#{@bot}: operable:echo alas it was not meant to be")
+    assert_response("@#{@user}: Unfortunately I was unable to automatically create a Cog account for your Slack chat handle. Only users with Cog accounts can interact with me.\n\nYou'll need to ask a Cog administrator to investigate the situation and set up your account.\n",
+                    after: message)
   end
 
   ########################################################################

--- a/test/integration/slack_registration_test.exs
+++ b/test/integration/slack_registration_test.exs
@@ -1,0 +1,75 @@
+defmodule Integration.SlackRegistrationTest do
+  use Cog.AdapterCase, adapter: "slack"
+
+  alias Cog.Repository.Users
+  alias Cog.Models.User
+
+  @moduletag :slack
+
+  # Name of the Slack user we'll be interacting with the bot as
+  @user "botci"
+
+  # Name of the bot we'll be operating as
+  @bot "deckard"
+
+  test "executing a command without a registered handle" do
+    message = send_message("@#{@bot}: operable:echo test")
+    assert_edited_response "@#{@user}: I'm terribly sorry, but either I don't have a Cog account for you, or your Slack chat handle has not been registered. Currently, only registered users can interact with me.\n\nYou'll need to ask a Cog administrator to fix this situation and to register your Slack handle. \n", after: message
+  end
+
+  test "autoregistration" do
+    enable_autoregistration
+    message = send_message("@#{@bot}: operable:echo test")
+    assert_edited_response "@#{@user}: Hello #{@user}! It's great to meet you! You're the proud owner of a shiny new Cog account named '#{@user}'.\n\ntest", after: message
+  end
+
+  test "autoregistration after a few tries" do
+    enable_autoregistration
+
+    # We'll try to create users up to 20 times. We'll just add a few
+    # dummy users to burn up a few of those tries.
+    max = 5
+
+    # override the email address, because the one coming in from Slack
+    # is actually "#{@user}@operable.io", which would be the default
+    # for this test function
+    user(@user, email_address: "#{@user}_0@operable.io")
+    Enum.each(1..max, &user("#{@user}_#{&1}"))
+
+    expected_username = "#{@user}_#{max+1}"
+    assert {:error, :not_found} = Users.by_username(expected_username)
+
+    message = send_message("@#{@bot}: operable:echo test")
+    assert_edited_response("@#{@user}: Hello #{@user}! It's great to meet you! You're the proud owner of a shiny new Cog account named '#{expected_username}'.\n\ntest", after: message)
+
+    assert {:ok, %User{username: ^expected_username}} = Users.by_username(expected_username)
+  end
+
+  test "autoregistration can eventually fail" do
+    enable_autoregistration
+
+    # This is how many times we'll try to create a new Cog user. We'll
+    # just create this many users to take up all our slack and trigger
+    # the failure
+    max = 20
+
+    # override the email address, because the one coming in from Slack
+    # is actually "#{@user}@operable.io", which would be the default
+    # for this test function
+    user(@user, email_address: "#{@user}_0@operable.io")
+    Enum.each(1..max, &user("#{@user}_#{&1}"))
+
+    message = send_message("@#{@bot}: operable:echo test")
+    assert_edited_response("@#{@user}: Unfortunately I was unable to automatically create a Cog account for your Slack chat handle. Only users with Cog accounts can interact with me.\n\nYou'll need to ask a Cog administrator to investigate the situation and set up your account.\n", after: message)
+  end
+
+  ########################################################################
+
+  defp enable_autoregistration do
+    old_value = Application.get_env(:cog, :self_registration)
+    on_exit(fn() ->
+      Application.put_env(:cog, :self_registration, old_value)
+    end)
+    Application.put_env(:cog, :self_registration, true)
+  end
+end

--- a/test/integration/slack_test.exs
+++ b/test/integration/slack_test.exs
@@ -20,8 +20,6 @@ defmodule Integration.SlackTest do
   end
 
   test "editing a command", %{user: user} do
-    :timer.sleep(5000)
-
     user |> with_permission("operable:st-echo")
 
     message = send_edited_message("@#{@bot}: operable:st-echo test")


### PR DESCRIPTION
There were a handful of places where we were still treating chat rooms and users as plain maps, rather than Conduit-enabled structs, which would cause failures when we tried interacting with them in terms of the `Access` protocol, which structs do not implement by default.

This should flush out all those last remaining calls, as well as finishes the transition to completely validated messages, by ensuring that `Cog.Chat.User` and `Cog.Chat.Room` are used everywhere.

Additionally, tests were added around the autoregistration functionality, which is where this problem surfaced.