### PR TITLE
List-valued Options

### DIFF
--- a/test/cog/command/option_interpreter_test.exs
+++ b/test/cog/command/option_interpreter_test.exs
@@ -261,6 +261,23 @@ defmodule Cog.Command.OptionInterpreter.Test do
     assert {:error, "Looks like you forgot to include some required options: 'needed, really_needed'"} = opt_args
   end
 
+  test "multiple values for a list" do
+    opt_args = options_and_args("test-command --foo=one --foo=two --foo=three",
+                                %{},
+                                options: [[name: "foo", type: "list"]])
+    assert_options_and_args(opt_args,
+                            %{"foo" => ["one", "two", "three"]},
+                            [])
+  end
+
+  test "multiple values for a list with a comma-delimited value all goes into the same list" do
+    opt_args = options_and_args("test-command --foo=one --foo=two,three,four --foo=five",
+                                %{},
+                                options: [[name: "foo", type: "list"]])
+    assert_options_and_args(opt_args,
+                            %{"foo" => ["one", "two", "three", "four","five"]},
+                            [])
+  end
 
   test "complex example" do
     opt_args = options_and_args("test-command --foo=bar --baz=$var --active -z=123 456 true what",

--- a/test/cog/command/option_interpreter_test.exs
+++ b/test/cog/command/option_interpreter_test.exs
@@ -279,6 +279,15 @@ defmodule Cog.Command.OptionInterpreter.Test do
                             [])
   end
 
+  test "commas in list values can be optionally escaped" do
+    opt_args = options_and_args("test-command --foo=one --foo=two\\,three,four --foo=five",
+                                %{},
+                                options: [[name: "foo", type: "list"]])
+    assert_options_and_args(opt_args,
+                            %{"foo" => ["one", "two,three", "four","five"]},
+                            [])
+  end
+
   test "complex example" do
     opt_args = options_and_args("test-command --foo=bar --baz=$var --active -z=123 456 true what",
                                 %{"var" => "one,two,three",


### PR DESCRIPTION
Allows list-valued options to be specified one-value-at-a-time:

    do:something --foo=one --foo=two --foo=three

In service of #919 