### PR TITLE
Break compile-time dep cycle on lib/cog.ex

### DIFF
--- a/lib/cog.ex
+++ b/lib/cog.ex
@@ -36,37 +36,6 @@ defmodule Cog do
     end
   end
 
-  @doc "The name of the embedded command bundle."
-  def embedded_bundle, do: "operable"
-
-  @doc "The name of the site namespace."
-  def site_namespace, do: "site"
-
-  @doc "The name of the admin role."
-  def admin_role, do: "cog-admin"
-
-  @doc "The name of the admin group."
-  def admin_group, do: "cog-admin"
-
-  ########################################################################
-  # Adapter Resolution Functions
-
-  @doc """
-  Returns the name of the currently configured chat provider module, if found
-  """
-  def chat_adapter_module do
-    # TODO: really "chat provider name"
-    config = Application.fetch_env!(:cog, Cog.Chat.Adapter)
-    case Keyword.fetch(config, :chat) do
-      {:ok, name} when is_atom(name) ->
-        {:ok, Atom.to_string(name)}
-      :error ->
-        {:error, :no_chat_provider_declared}
-    end
-  end
-
-  ########################################################################
-
   defp verify_schema_migration! do
     case migration_status do
       :ok ->
@@ -84,7 +53,7 @@ defmodule Cog do
   # Determine if the database has had all migrations applied. If not,
   # return the currently applied version and the latest unapplied version
   @spec migration_status :: :ok | {:error, have, want} when have: pos_integer,
-                                                            want: pos_integer
+    want: pos_integer
   defp migration_status do
     # Migration file names are like `20150923192906_create_users.exs`;
     # take the leading date portion of the most recent migration as

--- a/lib/cog/bootstrap.ex
+++ b/lib/cog/bootstrap.ex
@@ -34,7 +34,7 @@ defmodule Cog.Bootstrap do
   Returns `true` if the system has been bootstrapped, `false` if not.
   """
   def is_bootstrapped? do
-    case Repo.get_by(Group, name: Cog.admin_group) do
+    case Repo.get_by(Group, name: Cog.Util.Misc.admin_group) do
       %Group{} -> true
       nil -> false
     end
@@ -58,8 +58,8 @@ defmodule Cog.Bootstrap do
   def bootstrap(params) do
     Repo.transaction(fn() ->
       user  = create_admin(params)
-      role  = create_by_name(Role, Cog.admin_role)
-      group = create_by_name(Group, Cog.admin_group)
+      role  = create_by_name(Role, Cog.Util.Misc.admin_role)
+      group = create_by_name(Group, Cog.Util.Misc.admin_group)
 
       grant_embedded_permissions_to(role)
       Permittable.grant_to(group, role)
@@ -156,7 +156,7 @@ defmodule Cog.Bootstrap do
   end
 
   defp grant_embedded_permissions_to(role) do
-    Cog.embedded_bundle
+    Cog.Util.Misc.embedded_bundle
     |> Cog.Queries.Permission.from_bundle_name
     |> Repo.all
     |> Enum.each(&Permittable.grant_to(role, &1))

--- a/lib/cog/bundle/embedded.ex
+++ b/lib/cog/bundle/embedded.ex
@@ -10,7 +10,7 @@ defmodule Cog.Bundle.Embedded do
   alias Cog.Repository
 
   @doc """
-  Start up a supervisor for the embedded `#{Cog.embedded_bundle}` bundle.
+  Start up a supervisor for the embedded `#{Cog.Util.Misc.embedded_bundle}` bundle.
 
   If the bundle is not present in the database (because the system has
   not been bootstrapped yet, for instance), no supervisor will be
@@ -29,7 +29,7 @@ defmodule Cog.Bundle.Embedded do
     announce_embedded_bundle(bundle_version)
     Logger.info("Embedded bundle announced; starting bundle supervision tree")
 
-    Logger.info("Loading embedded `#{Cog.embedded_bundle}` bundle")
+    Logger.info("Loading embedded `#{Cog.Util.Misc.embedded_bundle}` bundle")
     config = bundle_version.config_file
     children = Enum.map(config["commands"], fn({command_name, command}) ->
       name = command_name
@@ -60,7 +60,7 @@ defmodule Cog.Bundle.Embedded do
     version = Application.fetch_env!(:cog, :embedded_bundle_version)
     modules = Application.spec(:cog, :modules)
 
-    Config.gen_config(Cog.embedded_bundle,
+    Config.gen_config(Cog.Util.Misc.embedded_bundle,
                       "Core chat commands for Cog",
                       version,
                       modules,

--- a/lib/cog/command/pipeline/destination.ex
+++ b/lib/cog/command/pipeline/destination.ex
@@ -111,10 +111,11 @@ defmodule Cog.Command.Pipeline.Destination do
   # the adapter that initially serviced the request.
   @spec adapter_destination(String.t, String.t) :: {String.t, String.t}
   defp adapter_destination("chat://" <> destination, _origin_adapter) do
-    {:ok, adapter} = Cog.chat_adapter_module
+    {:ok, adapter} = Cog.Util.Misc.chat_adapter_module
     {adapter, destination}
   end
   defp adapter_destination(destination, origin_adapter),
     do: {origin_adapter, destination}
+
 
 end

--- a/lib/cog/commands/alias.ex
+++ b/lib/cog/commands/alias.ex
@@ -1,5 +1,5 @@
 defmodule Cog.Commands.Alias do
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle
+  use Cog.Command.GenCommand.Base, bundle: Cog.Util.Misc.embedded_bundle
   alias Cog.Commands.Alias
   require Cog.Commands.Helpers, as: Helpers
 
@@ -40,7 +40,7 @@ defmodule Cog.Commands.Alias do
       Pipeline: 'echo my-other-awesome-alias'
   """
 
-  rule "when command is #{Cog.embedded_bundle}:alias allow"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:alias allow"
 
   def handle_message(req, state) do
     {subcommand, args} = Helpers.get_subcommand(req.args)

--- a/lib/cog/commands/bundle.ex
+++ b/lib/cog/commands/bundle.ex
@@ -1,6 +1,6 @@
 defmodule Cog.Commands.Bundle do
   use Cog.Command.GenCommand.Base,
-    bundle: Cog.embedded_bundle
+    bundle: Cog.Util.Misc.embedded_bundle
 
   alias Cog.Models.{Bundle, BundleVersion}
   alias Cog.Commands.Bundle.{List, Versions, Info, Enable, Disable}
@@ -35,7 +35,7 @@ defmodule Cog.Commands.Bundle do
 
   permission "manage_commands"
 
-  rule "when command is #{Cog.embedded_bundle}:bundle must have #{Cog.embedded_bundle}:manage_commands"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:bundle must have #{Cog.Util.Misc.embedded_bundle}:manage_commands"
 
   def handle_message(req, state) do
     {subcommand, args} = Helpers.get_subcommand(req.args)
@@ -72,10 +72,10 @@ defmodule Cog.Commands.Bundle do
     do: "Bundle #{inspect name} cannot be found."
   defp error({:not_found, name, version}),
     do: "Bundle #{inspect name} with version #{inspect to_string(version)} cannot be found."
-  defp error({:protected_bundle, unquote(Cog.embedded_bundle)}),
-    do: "Bundle #{inspect Cog.embedded_bundle} is protected and cannot be disabled."
-  defp error({:protected_bundle, unquote(Cog.site_namespace)}),
-    do: "Bundle #{inspect Cog.site_namespace} is protected and cannot be enabled."
+  defp error({:protected_bundle, unquote(Cog.Util.Misc.embedded_bundle)}),
+    do: "Bundle #{inspect Cog.Util.Misc.embedded_bundle} is protected and cannot be disabled."
+  defp error({:protected_bundle, unquote(Cog.Util.Misc.site_namespace)}),
+    do: "Bundle #{inspect Cog.Util.Misc.site_namespace} is protected and cannot be enabled."
   defp error({:protected_bundle, bundle_name}),
     do: "Bundle #{inspect bundle_name} is protected and cannot be enabled or disabled."
   defp error({:invalid_version, version}),

--- a/lib/cog/commands/bundle/disable.ex
+++ b/lib/cog/commands/bundle/disable.ex
@@ -14,7 +14,7 @@ defmodule Cog.Commands.Bundle.Disable do
   A disabled bundle can be re-enabled using this the `enable`
   sub-command.
 
-  Cannot be used on the `#{Cog.embedded_bundle}` bundle.
+  Cannot be used on the `#{Cog.Util.Misc.embedded_bundle}` bundle.
 
   USAGE
     bundle disable [FLAGS] <name>

--- a/lib/cog/commands/bundle/enable.ex
+++ b/lib/cog/commands/bundle/enable.ex
@@ -11,7 +11,7 @@ defmodule Cog.Commands.Bundle.Enable do
   Enabling a bundle allows chat commands to be routed to it. Running
   this subcommand has no effect if a bundle is already enabled.
 
-  Cannot be used on the `#{Cog.embedded_bundle}` bundle.
+  Cannot be used on the `#{Cog.Util.Misc.embedded_bundle}` bundle.
 
   USAGE
     bundle enable [FLAGS] <name> [<version>]

--- a/lib/cog/commands/echo.ex
+++ b/lib/cog/commands/echo.ex
@@ -1,5 +1,5 @@
 defmodule Cog.Commands.Echo do
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle
+  use Cog.Command.GenCommand.Base, bundle: Cog.Util.Misc.embedded_bundle
 
   @description "Repeats whatever it is passed"
 
@@ -14,7 +14,7 @@ defmodule Cog.Commands.Echo do
     > this if nifty
   """
 
-  rule "when command is #{Cog.embedded_bundle}:echo allow"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:echo allow"
 
   def handle_message(req, state),
     do: {:reply, req.reply_to, Enum.join(req.args, " "), state}

--- a/lib/cog/commands/filter.ex
+++ b/lib/cog/commands/filter.ex
@@ -1,5 +1,5 @@
 defmodule Cog.Commands.Filter do
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle
+  use Cog.Command.GenCommand.Base, bundle: Cog.Util.Misc.embedded_bundle
 
   @description "Filter elements of a collection"
 
@@ -30,7 +30,7 @@ defmodule Cog.Commands.Filter do
     > { "foo": {"bar.qux": {"baz": "stuff"} } }
   """
 
-  rule "when command is #{Cog.embedded_bundle}:filter allow"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:filter allow"
 
   option "matches", short: "m", type: "string", required: false
   option "path", short: "p", type: "string", required: false

--- a/lib/cog/commands/group.ex
+++ b/lib/cog/commands/group.ex
@@ -1,5 +1,5 @@
 defmodule Cog.Commands.Group do
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle
+  use Cog.Command.GenCommand.Base, bundle: Cog.Util.Misc.embedded_bundle
   require Cog.Commands.Helpers, as: Helpers
   alias Cog.Commands.Group
 
@@ -27,8 +27,8 @@ defmodule Cog.Commands.Group do
   permission "manage_groups"
   permission "manage_users"
 
-  rule ~s(when command is #{Cog.embedded_bundle}:group must have #{Cog.embedded_bundle}:manage_groups)
-  rule ~s(when command is #{Cog.embedded_bundle}:group with arg[0] == 'member' must have #{Cog.embedded_bundle}:manage_users)
+  rule ~s(when command is #{Cog.Util.Misc.embedded_bundle}:group must have #{Cog.Util.Misc.embedded_bundle}:manage_groups)
+  rule ~s(when command is #{Cog.Util.Misc.embedded_bundle}:group with arg[0] == 'member' must have #{Cog.Util.Misc.embedded_bundle}:manage_users)
 
   # list options
   option "verbose", type: "bool", short: "v"

--- a/lib/cog/commands/help.ex
+++ b/lib/cog/commands/help.ex
@@ -1,6 +1,6 @@
 defmodule Cog.Commands.Help do
   use Cog.Command.GenCommand.Base,
-    bundle: Cog.embedded_bundle
+    bundle: Cog.Util.Misc.embedded_bundle
 
   use Cog.Models
   alias Cog.Repository.Commands
@@ -45,7 +45,7 @@ defmodule Cog.Commands.Help do
       operable:which
   """
 
-  rule "when command is #{Cog.embedded_bundle}:help allow"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:help allow"
 
   option "disabled", short: "d", type: "bool", required: false
 

--- a/lib/cog/commands/max.ex
+++ b/lib/cog/commands/max.ex
@@ -1,6 +1,6 @@
 defmodule Cog.Commands.Max do
   use Cog.Command.GenCommand.Base,
-    bundle: Cog.embedded_bundle
+    bundle: Cog.Util.Misc.embedded_bundle
 
   alias Cog.Command.Service.MemoryClient
   require Logger
@@ -27,7 +27,7 @@ defmodule Cog.Commands.Max do
     > {"a": {"b": 3}}
   """
 
-  rule "when command is #{Cog.embedded_bundle}:max allow"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:max allow"
 
   def handle_message(req, state) do
     root  = req.services_root

--- a/lib/cog/commands/min.ex
+++ b/lib/cog/commands/min.ex
@@ -1,6 +1,6 @@
 defmodule Cog.Commands.Min do
   use Cog.Command.GenCommand.Base,
-    bundle: Cog.embedded_bundle
+    bundle: Cog.Util.Misc.embedded_bundle
 
   alias Cog.Command.Service.MemoryClient
   require Logger
@@ -27,7 +27,7 @@ defmodule Cog.Commands.Min do
     > {"a": {"b": -1}}
   """
 
-  rule "when command is #{Cog.embedded_bundle}:min allow"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:min allow"
 
   def handle_message(req, state) do
     root  = req.services_root

--- a/lib/cog/commands/permission.ex
+++ b/lib/cog/commands/permission.ex
@@ -1,5 +1,5 @@
 defmodule Cog.Commands.Permission do
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle
+  use Cog.Command.GenCommand.Base, bundle: Cog.Util.Misc.embedded_bundle
   require Cog.Commands.Helpers, as: Helpers
 
   alias Cog.Commands.Permission.{Create, Delete, Grant, Info, List, Revoke}
@@ -29,14 +29,14 @@ defmodule Cog.Commands.Permission do
   permission "manage_roles"
 
   # first rule is for default list scenario
-  rule "when command is #{Cog.embedded_bundle}:permission must have #{Cog.embedded_bundle}:manage_permissions"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:permission must have #{Cog.Util.Misc.embedded_bundle}:manage_permissions"
 
-  rule "when command is #{Cog.embedded_bundle}:permission with arg[0] == create must have #{Cog.embedded_bundle}:manage_permissions"
-  rule "when command is #{Cog.embedded_bundle}:permission with arg[0] == delete must have #{Cog.embedded_bundle}:manage_permissions"
-  rule "when command is #{Cog.embedded_bundle}:permission with arg[0] == info must have #{Cog.embedded_bundle}:manage_permissions"
-  rule "when command is #{Cog.embedded_bundle}:permission with arg[0] == list must have #{Cog.embedded_bundle}:manage_permissions"
-  rule "when command is #{Cog.embedded_bundle}:permission with arg[0] == grant must have #{Cog.embedded_bundle}:manage_roles"
-  rule "when command is #{Cog.embedded_bundle}:permission with arg[0] == revoke must have #{Cog.embedded_bundle}:manage_roles"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:permission with arg[0] == create must have #{Cog.Util.Misc.embedded_bundle}:manage_permissions"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:permission with arg[0] == delete must have #{Cog.Util.Misc.embedded_bundle}:manage_permissions"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:permission with arg[0] == info must have #{Cog.Util.Misc.embedded_bundle}:manage_permissions"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:permission with arg[0] == list must have #{Cog.Util.Misc.embedded_bundle}:manage_permissions"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:permission with arg[0] == grant must have #{Cog.Util.Misc.embedded_bundle}:manage_roles"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:permission with arg[0] == revoke must have #{Cog.Util.Misc.embedded_bundle}:manage_roles"
 
   def handle_message(req, state) do
     {subcommand, args} = Helpers.get_subcommand(req.args)

--- a/lib/cog/commands/raw.ex
+++ b/lib/cog/commands/raw.ex
@@ -1,5 +1,5 @@
 defmodule Cog.Command.Raw do
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle
+  use Cog.Command.GenCommand.Base, bundle: Cog.Util.Misc.embedded_bundle
 
   alias Cog.Messages.Command
 
@@ -23,7 +23,7 @@ defmodule Cog.Command.Raw do
 
   """
 
-  rule "when command is #{Cog.embedded_bundle}:raw allow"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:raw allow"
 
   def handle_message(%Command{cog_env: nil}=req, state),
     do: {:reply, req.reply_to, "nil", state}

--- a/lib/cog/commands/relay.ex
+++ b/lib/cog/commands/relay.ex
@@ -1,5 +1,5 @@
 defmodule Cog.Commands.Relay do
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle
+  use Cog.Command.GenCommand.Base, bundle: Cog.Util.Misc.embedded_bundle
   alias Cog.Commands.Relay
 
   require Cog.Commands.Helpers, as: Helpers
@@ -23,7 +23,7 @@ defmodule Cog.Commands.Relay do
   """
   permission "manage_relays"
 
-  rule "when command is #{Cog.embedded_bundle}:relay must have #{Cog.embedded_bundle}:manage_relays"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:relay must have #{Cog.Util.Misc.embedded_bundle}:manage_relays"
 
   # list options
   option "group", type: "bool", short: "g"

--- a/lib/cog/commands/relay_group.ex
+++ b/lib/cog/commands/relay_group.ex
@@ -1,5 +1,5 @@
 defmodule Cog.Commands.RelayGroup do
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle, name: "relay-group"
+  use Cog.Command.GenCommand.Base, bundle: Cog.Util.Misc.embedded_bundle, name: "relay-group"
   alias Cog.Commands.RelayGroup
   alias Cog.Commands.Helpers
 
@@ -25,7 +25,7 @@ defmodule Cog.Commands.RelayGroup do
 
   permission "manage_relays"
 
-  rule "when command is #{Cog.embedded_bundle}:relay-group must have #{Cog.embedded_bundle}:manage_relays"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:relay-group must have #{Cog.Util.Misc.embedded_bundle}:manage_relays"
 
   # general options
   option "help", type: "bool", short: "h"

--- a/lib/cog/commands/role.ex
+++ b/lib/cog/commands/role.ex
@@ -1,5 +1,5 @@
 defmodule Cog.Commands.Role do
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle
+  use Cog.Command.GenCommand.Base, bundle: Cog.Util.Misc.embedded_bundle
   require Cog.Commands.Helpers, as: Helpers
 
   alias Cog.Commands.Role.{Create, Delete, Grant, Info, List, Rename, Revoke}
@@ -30,15 +30,15 @@ defmodule Cog.Commands.Role do
   permission "manage_groups"
 
   # This rule is for the default
-  rule "when command is #{Cog.embedded_bundle}:role must have #{Cog.embedded_bundle}:manage_roles"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:role must have #{Cog.Util.Misc.embedded_bundle}:manage_roles"
 
-  rule "when command is #{Cog.embedded_bundle}:role with arg[0] == create must have #{Cog.embedded_bundle}:manage_roles"
-  rule "when command is #{Cog.embedded_bundle}:role with arg[0] == delete must have #{Cog.embedded_bundle}:manage_roles"
-  rule "when command is #{Cog.embedded_bundle}:role with arg[0] == info must have #{Cog.embedded_bundle}:manage_roles"
-  rule "when command is #{Cog.embedded_bundle}:role with arg[0] == list must have #{Cog.embedded_bundle}:manage_roles"
-  rule "when command is #{Cog.embedded_bundle}:role with arg[0] == grant must have #{Cog.embedded_bundle}:manage_groups"
-  rule "when command is #{Cog.embedded_bundle}:role with arg[0] == rename must have #{Cog.embedded_bundle}:manage_roles"
-  rule "when command is #{Cog.embedded_bundle}:role with arg[0] == revoke must have #{Cog.embedded_bundle}:manage_groups"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:role with arg[0] == create must have #{Cog.Util.Misc.embedded_bundle}:manage_roles"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:role with arg[0] == delete must have #{Cog.Util.Misc.embedded_bundle}:manage_roles"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:role with arg[0] == info must have #{Cog.Util.Misc.embedded_bundle}:manage_roles"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:role with arg[0] == list must have #{Cog.Util.Misc.embedded_bundle}:manage_roles"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:role with arg[0] == grant must have #{Cog.Util.Misc.embedded_bundle}:manage_groups"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:role with arg[0] == rename must have #{Cog.Util.Misc.embedded_bundle}:manage_roles"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:role with arg[0] == revoke must have #{Cog.Util.Misc.embedded_bundle}:manage_groups"
 
   def handle_message(req, state) do
     {subcommand, args} = Helpers.get_subcommand(req.args)

--- a/lib/cog/commands/rule.ex
+++ b/lib/cog/commands/rule.ex
@@ -1,6 +1,6 @@
 defmodule Cog.Commands.Rule do
   use Cog.Command.GenCommand.Base,
-    bundle: Cog.embedded_bundle
+    bundle: Cog.Util.Misc.embedded_bundle
 
   alias Cog.Commands.Rule.{Info, List, Create, Delete}
   require Cog.Commands.Helpers, as: Helpers
@@ -28,7 +28,7 @@ defmodule Cog.Commands.Rule do
 
   permission "manage_commands"
 
-  rule "when command is #{Cog.embedded_bundle}:rule must have #{Cog.embedded_bundle}:manage_commands"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:rule must have #{Cog.Util.Misc.embedded_bundle}:manage_commands"
 
   def handle_message(req, state) do
     {subcommand, args} = Helpers.get_subcommand(req.args)

--- a/lib/cog/commands/seed.ex
+++ b/lib/cog/commands/seed.ex
@@ -1,5 +1,5 @@
 defmodule Cog.Command.Seed do
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle
+  use Cog.Command.GenCommand.Base, bundle: Cog.Util.Misc.embedded_bundle
 
   alias Cog.Messages.Command
   require Logger
@@ -30,7 +30,7 @@ defmodule Cog.Command.Seed do
 
   """
 
-  rule "when command is #{Cog.embedded_bundle}:seed allow"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:seed allow"
 
   def handle_message(%Command{args: [input]}=req, state) when not(is_binary(input)),
     do: {:error, req.reply_to, "Argument must be a string", state}

--- a/lib/cog/commands/sleep.ex
+++ b/lib/cog/commands/sleep.ex
@@ -1,6 +1,6 @@
 defmodule Cog.Commands.Sleep do
   use Cog.Command.GenCommand.Base,
-    bundle: Cog.embedded_bundle
+    bundle: Cog.Util.Misc.embedded_bundle
 
   alias Cog.Command.Service.MemoryClient
 
@@ -19,7 +19,7 @@ defmodule Cog.Commands.Sleep do
     > Lasagna is done cooking!
   """
 
-  rule "when command is #{Cog.embedded_bundle}:sleep allow"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:sleep allow"
 
   def handle_message(%{args: [seconds]} = req, state) when is_integer(seconds) do
     root  = req.services_root

--- a/lib/cog/commands/sort.ex
+++ b/lib/cog/commands/sort.ex
@@ -1,6 +1,6 @@
 defmodule Cog.Commands.Sort do
   use Cog.Command.GenCommand.Base,
-    bundle: Cog.embedded_bundle
+    bundle: Cog.Util.Misc.embedded_bundle
 
   alias Cog.Command.Service.MemoryClient
 
@@ -31,7 +31,7 @@ defmodule Cog.Commands.Sort do
     > [{"a": 1, "b": 4}, {"a: 3, "b": 4}, {"a": 2, "b": 6}]
   """
 
-  rule "when command is #{Cog.embedded_bundle}:sort allow"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:sort allow"
 
   option "desc", short: "d", type: "bool", required: false
   option "asc",  short: "a", type: "bool", required: false

--- a/lib/cog/commands/trigger.ex
+++ b/lib/cog/commands/trigger.ex
@@ -1,12 +1,12 @@
 defmodule Cog.Commands.Trigger do
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle
+  use Cog.Command.GenCommand.Base, bundle: Cog.Util.Misc.embedded_bundle
 
   alias Cog.Commands.Trigger.{Create, Delete, Disable, Enable, Info, List, Update}
   require Cog.Commands.Helpers, as: Helpers
 
   permission "manage_triggers"
 
-  rule "when command is #{Cog.embedded_bundle}:trigger must have #{Cog.embedded_bundle}:manage_triggers"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:trigger must have #{Cog.Util.Misc.embedded_bundle}:manage_triggers"
 
   @description "Manage triggered pipelines"
 

--- a/lib/cog/commands/unique.ex
+++ b/lib/cog/commands/unique.ex
@@ -1,6 +1,6 @@
 defmodule Cog.Commands.Unique do
   use Cog.Command.GenCommand.Base,
-    bundle: Cog.embedded_bundle
+    bundle: Cog.Util.Misc.embedded_bundle
 
   alias Cog.Command.Service.MemoryClient
 
@@ -17,7 +17,7 @@ defmodule Cog.Commands.Unique do
     > [{"a": 1}, {"a": 3}]
   """
 
-  rule "when command is #{Cog.embedded_bundle}:unique allow"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:unique allow"
 
   def handle_message(req, state) do
     root  = req.services_root

--- a/lib/cog/commands/user.ex
+++ b/lib/cog/commands/user.ex
@@ -1,6 +1,6 @@
 defmodule Cog.Commands.User do
   use Cog.Command.GenCommand.Base,
-    bundle: Cog.embedded_bundle
+    bundle: Cog.Util.Misc.embedded_bundle
 
   alias Cog.Commands.User.{AttachHandle, DetachHandle, Info, List, ListHandles}
 
@@ -32,7 +32,7 @@ defmodule Cog.Commands.User do
 
   permission "manage_users"
 
-  rule "when command is #{Cog.embedded_bundle}:user must have #{Cog.embedded_bundle}:manage_users"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:user must have #{Cog.Util.Misc.embedded_bundle}:manage_users"
 
   def handle_message(req, state) do
     {subcommand, args} = Helpers.get_subcommand(req.args)

--- a/lib/cog/commands/which.ex
+++ b/lib/cog/commands/which.ex
@@ -1,5 +1,5 @@
 defmodule Cog.Commands.Which do
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle
+  use Cog.Command.GenCommand.Base, bundle: Cog.Util.Misc.embedded_bundle
   alias Cog.Commands.Helpers
   alias Cog.Models.UserCommandAlias
   alias Cog.Models.SiteCommandAlias
@@ -34,7 +34,7 @@ defmodule Cog.Commands.Which do
     > No matching commands or aliases.
   """
 
-  rule "when command is #{Cog.embedded_bundle}:which allow"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:which allow"
 
   def handle_message(req, state) do
     results = with {:ok, [arg]} <- Helpers.get_args(req.args, count: 1),

--- a/lib/cog/models/bundle.ex
+++ b/lib/cog/models/bundle.ex
@@ -37,7 +37,7 @@ end
 defimpl Groupable, for: Cog.Models.Bundle do
 
   def add_to(bundle, relay_group) do
-    if bundle.name in [Cog.embedded_bundle, Cog.site_namespace] do
+    if bundle.name in [Cog.Util.Misc.embedded_bundle, Cog.Util.Misc.site_namespace] do
       raise Cog.ProtectedBundleError, bundle.name
     else
       Cog.Models.JoinTable.associate(bundle, relay_group)

--- a/lib/cog/models/group.ex
+++ b/lib/cog/models/group.ex
@@ -54,7 +54,7 @@ defmodule Cog.Models.Group do
   end
 
   defp protect_admin_group(%Changeset{data: data}=changeset) do
-    if data.name == Cog.admin_group do
+    if data.name == Cog.Util.Misc.admin_group do
       changeset
       |> add_error(:name, "admin group may not be modified")
     else
@@ -69,8 +69,8 @@ defimpl Permittable, for: Cog.Models.Group do
   def grant_to(group, permission_or_role),
     do: Cog.Models.JoinTable.associate(group, permission_or_role)
 
-  def revoke_from(%Cog.Models.Group{name: unquote(Cog.admin_group)=group_name},
-                  %Cog.Models.Role{name: unquote(Cog.admin_role)=role_name}),
+  def revoke_from(%Cog.Models.Group{name: unquote(Cog.Util.Misc.admin_group)=group_name},
+                  %Cog.Models.Role{name: unquote(Cog.Util.Misc.admin_role)=role_name}),
     do: {:error, {:permanent_role_grant, role_name, group_name}}
   def revoke_from(group, permission_or_role),
     do: Cog.Models.JoinTable.dissociate(group, permission_or_role)

--- a/lib/cog/models/role.ex
+++ b/lib/cog/models/role.ex
@@ -47,7 +47,7 @@ defmodule Cog.Models.Role do
   end
 
   defp protect_admin_role(%Changeset{data: data}=changeset) do
-    if data.name == Cog.admin_role do
+    if data.name == Cog.Util.Misc.admin_role do
       changeset
       |> add_error(:name, "admin role may not be modified")
     else
@@ -67,7 +67,7 @@ defimpl Permittable, for: Cog.Models.Role do
 
   def revoke_from(role, permission) do
     bundle = Repo.get(Bundle, permission.bundle_id)
-    if role.name == Cog.admin_role and bundle.name == Cog.embedded_bundle do
+    if role.name == Cog.Util.Misc.admin_role and bundle.name == Cog.Util.Misc.embedded_bundle do
       {:error, "cannot remove embedded permissions from admin role"}
     else
       JoinTable.dissociate(role, permission)

--- a/lib/cog/repository/bundles.ex
+++ b/lib/cog/repository/bundles.ex
@@ -26,8 +26,8 @@ defmodule Cog.Repository.Bundles do
   @bundle_dynamic_config_preloads [:bundle]
 
   @reserved_bundle_names [
-    Cog.embedded_bundle,
-    Cog.site_namespace,
+    Cog.Util.Misc.embedded_bundle,
+    Cog.Util.Misc.site_namespace,
     "user", # a bundle named "user" would break alias resolution
     "cog"   # we're going to squat on this for now to prevent potential confusion
   ]
@@ -75,7 +75,7 @@ defmodule Cog.Repository.Bundles do
     Logger.info("Dev mode detected. Resetting embedded bundle.")
     Repo.delete_all(from bv in BundleVersion,
                     join: b in assoc(bv, :bundle),
-                    where: b.name == ^Cog.embedded_bundle)
+                    where: b.name == ^Cog.Util.Misc.embedded_bundle)
   end
 
   @doc """
@@ -431,7 +431,7 @@ defmodule Cog.Repository.Bundles do
     # just select the highest-version of the bundle.
     #
     # Yay, abstraction!
-    embedded_name = Cog.embedded_bundle
+    embedded_name = Cog.Util.Misc.embedded_bundle
 
     Repo.one(from bv in BundleVersion,
              join: b in assoc(bv, :bundle),
@@ -450,7 +450,7 @@ defmodule Cog.Repository.Bundles do
     do: Repo.one!(site_bundle_version_query)
 
   def is_site_version?(version) do
-    (version.bundle.name == Cog.site_namespace) and
+    (version.bundle.name == Cog.Util.Misc.site_namespace) and
     (to_string(version.version) == @permanent_site_bundle_version)
   end
 
@@ -460,7 +460,7 @@ defmodule Cog.Repository.Bundles do
   def ensure_site_bundle do
     case Repo.one(site_bundle_version_query) do
       nil ->
-        {:ok, _} = __install(%{"name" => Cog.site_namespace,
+        {:ok, _} = __install(%{"name" => Cog.Util.Misc.site_namespace,
                                "version" => @permanent_site_bundle_version,
                                "config_file" => %{}})
         :ok
@@ -470,7 +470,7 @@ defmodule Cog.Repository.Bundles do
   end
 
   defp site_bundle_version_query do
-    site = Cog.site_namespace
+    site = Cog.Util.Misc.site_namespace
 
     from bv in BundleVersion,
     join: b in assoc(bv, :bundle),

--- a/lib/cog/repository/groups.ex
+++ b/lib/cog/repository/groups.ex
@@ -116,7 +116,7 @@ defmodule Cog.Repository.Groups do
   Updates a user group
   """
   @spec update(%Group{}, Map.t) :: {:ok, %Group{}} | {:error, Ecto.Changeset.t}
-  def update(%Group{name: unquote(Cog.admin_group)=name}, _),
+  def update(%Group{name: unquote(Cog.Util.Misc.admin_group)=name}, _),
     do: {:error, {:protected_group, name}}
   def update(%Group{}=group, attrs) do
     changeset = Group.changeset(group, attrs)

--- a/lib/cog/repository/roles.ex
+++ b/lib/cog/repository/roles.ex
@@ -15,7 +15,7 @@ defmodule Cog.Repository.Roles do
     end
   end
 
-  def delete(%Role{name: unquote(Cog.admin_role)=name}),
+  def delete(%Role{name: unquote(Cog.Util.Misc.admin_role)=name}),
     do: {:error, {:protected_role, name}}
   def delete(%Role{}=role),
     do: Repo.delete(role)
@@ -45,7 +45,7 @@ defmodule Cog.Repository.Roles do
   end
 
   # We don't (yet) have need of general update
-  def rename(%Role{name: unquote(Cog.admin_role)=name}, _),
+  def rename(%Role{name: unquote(Cog.Util.Misc.admin_role)=name}, _),
     do: {:error, {:protected_role, name}}
   def rename(%Role{}=role, new_name) do
     case role

--- a/lib/cog/util/misc.ex
+++ b/lib/cog/util/misc.ex
@@ -1,0 +1,34 @@
+defmodule Cog.Util.Misc do
+
+  @doc "The name of the embedded command bundle."
+  def embedded_bundle, do: "operable"
+
+  @doc "The name of the site namespace."
+  def site_namespace, do: "site"
+
+  @doc "The name of the admin role."
+  def admin_role, do: "cog-admin"
+
+  @doc "The name of the admin group."
+  def admin_group, do: "cog-admin"
+
+  ########################################################################
+  # Adapter Resolution Functions
+
+  @doc """
+  Returns the name of the currently configured chat provider module, if found
+  """
+  def chat_adapter_module do
+    # TODO: really "chat provider name"
+    config = Application.fetch_env!(:cog, Cog.Chat.Adapter)
+    case Keyword.fetch(config, :chat) do
+      {:ok, name} when is_atom(name) ->
+        {:ok, Atom.to_string(name)}
+      :error ->
+        {:error, :no_chat_provider_declared}
+    end
+  end
+
+  ########################################################################
+
+end

--- a/priv/repo/migrations/20160415152542_protect_internal_rows.exs
+++ b/priv/repo/migrations/20160415152542_protect_internal_rows.exs
@@ -8,7 +8,7 @@ RETURNS TRIGGER
 LANGUAGE plpgsql
 AS $$
 BEGIN
-  IF OLD.NAME = '#{Cog.admin_role}' THEN
+  IF OLD.NAME = '#{Cog.Util.Misc.admin_role}' THEN
     RAISE EXCEPTION 'cannot modify admin role';
   END IF;
   RETURN NULL;
@@ -29,7 +29,7 @@ RETURNS TRIGGER
 LANGUAGE plpgsql
 AS $$
 BEGIN
-  IF OLD.NAME = '#{Cog.admin_group}' THEN
+  IF OLD.NAME = '#{Cog.Util.Misc.admin_group}' THEN
     RAISE EXCEPTION 'cannot modify admin group';
   END IF;
   RETURN NULL;
@@ -50,7 +50,7 @@ RETURNS TRIGGER
 LANGUAGE plpgsql
 AS $$
 BEGIN
-  IF OLD.NAME = '#{Cog.embedded_bundle}' THEN
+  IF OLD.NAME = '#{Cog.Util.Misc.embedded_bundle}' THEN
     RAISE EXCEPTION 'cannot modify embedded bundle';
   END IF;
   RETURN NULL;

--- a/priv/repo/migrations/20160419154716_protect_admin_role_permissions.exs
+++ b/priv/repo/migrations/20160419154716_protect_admin_role_permissions.exs
@@ -19,7 +19,7 @@ BEGIN
    WHERE namespaces.id=permissions.namespace_id
      AND permissions.id=OLD.permission_id;
 
-  IF role = '#{Cog.admin_role}' AND namespace = '#{Cog.embedded_bundle}' THEN
+  IF role = '#{Cog.Util.Misc.admin_role}' AND namespace = '#{Cog.Util.Misc.embedded_bundle}' THEN
     RAISE EXCEPTION 'cannot remove embedded permissions from admin role';
   END IF;
   RETURN NULL;

--- a/priv/repo/migrations/20160505200538_bundle_version_schema.exs
+++ b/priv/repo/migrations/20160505200538_bundle_version_schema.exs
@@ -242,7 +242,7 @@ defmodule Cog.Repo.Migrations.BundleVersionSchema do
        WHERE bundles_v2.id=permissions_v2.bundle_id
          AND permissions_v2.id=OLD.permission_id;
 
-      IF role = '#{Cog.admin_role}' AND bundle = '#{Cog.embedded_bundle}' THEN
+      IF role = '#{Cog.Util.Misc.admin_role}' AND bundle = '#{Cog.Util.Misc.embedded_bundle}' THEN
         RAISE EXCEPTION 'cannot remove embedded permissions from admin role';
       END IF;
       RETURN NULL;

--- a/priv/repo/migrations/20160628204409_rename_v2_tables.exs
+++ b/priv/repo/migrations/20160628204409_rename_v2_tables.exs
@@ -59,7 +59,7 @@ defmodule Cog.Repo.Migrations.RenameV2Tables do
        WHERE bundles.id=permissions.bundle_id
          AND permissions.id=OLD.permission_id;
 
-      IF role = '#{Cog.admin_role}' AND bundle = '#{Cog.embedded_bundle}' THEN
+      IF role = '#{Cog.Util.Misc.admin_role}' AND bundle = '#{Cog.Util.Misc.embedded_bundle}' THEN
         RAISE EXCEPTION 'cannot remove embedded permissions from admin role';
       END IF;
       RETURN NULL;

--- a/test/cog/bootstrap_test.exs
+++ b/test/cog/bootstrap_test.exs
@@ -14,37 +14,37 @@ defmodule Cog.Bootstrap.Test do
       {:ok, bootstrapped: false}
     else
       {:ok, admin_user} = Cog.Bootstrap.bootstrap(@admin_user)
-      admin_role = Cog.Repo.get_by!(Role, name: Cog.admin_role)
-      admin_group = Cog.Repo.get_by!(Group, name: Cog.admin_group)
+      admin_role = Cog.Repo.get_by!(Role, name: Cog.Util.Misc.admin_role)
+      admin_group = Cog.Repo.get_by!(Group, name: Cog.Util.Misc.admin_group)
       {:ok, admin: admin_user, admin_role: admin_role, admin_group: admin_group, bootstrapped: true}
     end
   end
 
   test "creates the embedded bundle" do
-    assert Repo.get_by!(Bundle, name: Cog.embedded_bundle)
+    assert Repo.get_by!(Bundle, name: Cog.Util.Misc.embedded_bundle)
   end
 
   test "creates core permissions in the embedded bundle namespace" do
-    assert retrieve("#{Cog.embedded_bundle}:manage_users")
-    assert retrieve("#{Cog.embedded_bundle}:manage_roles")
-    assert retrieve("#{Cog.embedded_bundle}:manage_groups")
-    assert retrieve("#{Cog.embedded_bundle}:manage_permissions")
-    assert retrieve("#{Cog.embedded_bundle}:manage_commands")
+    assert retrieve("#{Cog.Util.Misc.embedded_bundle}:manage_users")
+    assert retrieve("#{Cog.Util.Misc.embedded_bundle}:manage_roles")
+    assert retrieve("#{Cog.Util.Misc.embedded_bundle}:manage_groups")
+    assert retrieve("#{Cog.Util.Misc.embedded_bundle}:manage_permissions")
+    assert retrieve("#{Cog.Util.Misc.embedded_bundle}:manage_commands")
   end
 
   test "creates the site bundle" do
-    assert Repo.get_by!(Bundle, name: Cog.site_namespace)
+    assert Repo.get_by!(Bundle, name: Cog.Util.Misc.site_namespace)
   end
 
   test "creates single site bundle version" do
-    bundle = Repo.get_by!(Bundle, name: Cog.site_namespace) |> Repo.preload(:versions)
+    bundle = Repo.get_by!(Bundle, name: Cog.Util.Misc.site_namespace) |> Repo.preload(:versions)
 
     {:ok, version} = Version.parse("0.0.0")
     assert [%BundleVersion{version: ^version}] = bundle.versions
   end
 
   test "the 'site' bundle contains no permissions" do
-    bundle = Repo.get_by!(Bundle, name: Cog.site_namespace) |> Repo.preload(:permissions)
+    bundle = Repo.get_by!(Bundle, name: Cog.Util.Misc.site_namespace) |> Repo.preload(:permissions)
     assert [] == bundle.permissions
   end
 
@@ -54,11 +54,11 @@ defmodule Cog.Bootstrap.Test do
   end
 
   test "admin role has all the embedded bundle permissions", %{admin_role: admin_role} do
-    assert_permission_is_granted(admin_role, retrieve("#{Cog.embedded_bundle}:manage_users"))
-    assert_permission_is_granted(admin_role, retrieve("#{Cog.embedded_bundle}:manage_roles"))
-    assert_permission_is_granted(admin_role, retrieve("#{Cog.embedded_bundle}:manage_groups"))
-    assert_permission_is_granted(admin_role, retrieve("#{Cog.embedded_bundle}:manage_permissions"))
-    assert_permission_is_granted(admin_role, retrieve("#{Cog.embedded_bundle}:manage_commands"))
+    assert_permission_is_granted(admin_role, retrieve("#{Cog.Util.Misc.embedded_bundle}:manage_users"))
+    assert_permission_is_granted(admin_role, retrieve("#{Cog.Util.Misc.embedded_bundle}:manage_roles"))
+    assert_permission_is_granted(admin_role, retrieve("#{Cog.Util.Misc.embedded_bundle}:manage_groups"))
+    assert_permission_is_granted(admin_role, retrieve("#{Cog.Util.Misc.embedded_bundle}:manage_permissions"))
+    assert_permission_is_granted(admin_role, retrieve("#{Cog.Util.Misc.embedded_bundle}:manage_commands"))
   end
 
   test "admin role is granted to admin group", %{admin_role: admin_role, admin_group: admin_group} do
@@ -74,7 +74,7 @@ defmodule Cog.Bootstrap.Test do
     refute Cog.Bootstrap.is_bootstrapped?
 
     Cog.Bootstrap.bootstrap(@admin_user)
-    assert Cog.Models.Group |> Cog.Repo.one! |> Map.get(:name) == Cog.admin_group
+    assert Cog.Models.Group |> Cog.Repo.one! |> Map.get(:name) == Cog.Util.Misc.admin_group
     assert Cog.Bootstrap.is_bootstrapped?
   end
 
@@ -106,7 +106,7 @@ defmodule Cog.Bootstrap.Test do
   end
 
   test "installs embedded bundle" do
-    assert Repo.get_by(Bundle, name: Cog.embedded_bundle)
+    assert Repo.get_by(Bundle, name: Cog.Util.Misc.embedded_bundle)
   end
 
   defp retrieve(permission_name) do

--- a/test/cog/models/group_test.exs
+++ b/test/cog/models/group_test.exs
@@ -16,8 +16,8 @@ defmodule Cog.Models.Group.Test do
 
   test "admin group cannot be renamed" do
     Cog.Bootstrap.bootstrap
-    group = Group |> Repo.get_by(name: Cog.admin_group)
-    assert group.name == Cog.admin_group
+    group = Group |> Repo.get_by(name: Cog.Util.Misc.admin_group)
+    assert group.name == Cog.Util.Misc.admin_group
     {:error, changeset} = Repo.update(Group.changeset(group, %{"name" => "not-cog-admin"}))
     assert {:name, {"admin group may not be modified", []}} in changeset.errors
   end

--- a/test/cog/models/role_test.exs
+++ b/test/cog/models/role_test.exs
@@ -9,10 +9,10 @@ defmodule Cog.Models.Role.Test do
     if _ = context[:bootstrap] do
       Cog.Bootstrap.bootstrap
 
-      admin_role = Role |> Repo.get_by(name: Cog.admin_role)
-      assert admin_role.name == Cog.admin_role
+      admin_role = Role |> Repo.get_by(name: Cog.Util.Misc.admin_role)
+      assert admin_role.name == Cog.Util.Misc.admin_role
 
-      admin_perms = Queries.Permission.from_bundle_name(Cog.embedded_bundle) |> Repo.all
+      admin_perms = Queries.Permission.from_bundle_name(Cog.Util.Misc.embedded_bundle) |> Repo.all
 
       {:ok, admin_role: admin_role, admin_perms: admin_perms, bootstrapped: true}
     else

--- a/test/controllers/v1/bundle_version_controller_test.exs
+++ b/test/controllers/v1/bundle_version_controller_test.exs
@@ -11,7 +11,7 @@ defmodule Cog.V1.BundleVersionControllerTest do
 
   setup do
     # Requests handled by the role controller require this permission
-    required_permission = permission("#{Cog.embedded_bundle}:manage_commands")
+    required_permission = permission("#{Cog.Util.Misc.embedded_bundle}:manage_commands")
 
     # This user will be used to test the normal operation of the controller
     authed_user = user("cog")

--- a/test/controllers/v1/bundle_version_status_controller_test.exs
+++ b/test/controllers/v1/bundle_version_status_controller_test.exs
@@ -11,7 +11,7 @@ defmodule Cog.V1.BundleVersionStatusControllerTest do
 
   setup do
     # Requests handled by the role controller require this permission
-    required_permission = permission("#{Cog.embedded_bundle}:manage_commands")
+    required_permission = permission("#{Cog.Util.Misc.embedded_bundle}:manage_commands")
 
     # This user will be used to test the normal operation of the controller
     authed_user = user("cog")

--- a/test/controllers/v1/bundles_controller_test.exs
+++ b/test/controllers/v1/bundles_controller_test.exs
@@ -11,7 +11,7 @@ defmodule Cog.V1.BundlesControllerTest do
 
   setup do
     # Requests handled by the role controller require this permission
-    required_permission = permission("#{Cog.embedded_bundle}:manage_commands")
+    required_permission = permission("#{Cog.Util.Misc.embedded_bundle}:manage_commands")
 
     # This user will be used to test the normal operation of the controller
     authed_user = user("cog")

--- a/test/controllers/v1/chat_handle_controller_test.exs
+++ b/test/controllers/v1/chat_handle_controller_test.exs
@@ -10,7 +10,7 @@ defmodule Cog.V1.ChatHandleControllerTest do
 
   setup context do
     # Requests handled by the role controller require this permission
-    required_permission = permission("#{Cog.embedded_bundle}:manage_users")
+    required_permission = permission("#{Cog.Util.Misc.embedded_bundle}:manage_users")
 
     # This user will be used to test the normal operation of the controller
     authed_user = user("cog")
@@ -63,7 +63,7 @@ defmodule Cog.V1.ChatHandleControllerTest do
 
   test "fails if chat adapter for provider is not running", params do
     chat_provider = "slack"
-    {:ok, chat} = Cog.chat_adapter_module
+    {:ok, chat} = Cog.Util.Misc.chat_adapter_module
     refute chat_provider == chat
 
     conn = api_request(params.authed,

--- a/test/controllers/v1/dynamic_config_controller_test.exs
+++ b/test/controllers/v1/dynamic_config_controller_test.exs
@@ -9,7 +9,7 @@ defmodule Cog.V1.DynamicConfigControllerTest do
 
   setup do
     # Requests handled by the dynamic config controller require this permission
-    required_permission = permission("#{Cog.embedded_bundle}:manage_commands")
+    required_permission = permission("#{Cog.Util.Misc.embedded_bundle}:manage_commands")
 
     # This user will be used to test the normal operation of the controller
     authed_user = user("cog")

--- a/test/controllers/v1/group_controller_test.exs
+++ b/test/controllers/v1/group_controller_test.exs
@@ -11,7 +11,7 @@ defmodule Cog.V1.GroupControllerTest do
 
   setup do
     # Requests handled by the role controller require this permission
-    required_permission = permission("#{Cog.embedded_bundle}:manage_groups")
+    required_permission = permission("#{Cog.Util.Misc.embedded_bundle}:manage_groups")
 
     # This user will be used to test the normal operation of the controller
     authed_user = user("cog")

--- a/test/controllers/v1/group_membership_controller_test.exs
+++ b/test/controllers/v1/group_membership_controller_test.exs
@@ -6,7 +6,7 @@ defmodule Cog.V1.GroupMembershipController.Test do
 
   setup do
     # Requests handled by the group membership controller require this permission
-    required_permission = permission("#{Cog.embedded_bundle}:manage_groups")
+    required_permission = permission("#{Cog.Util.Misc.embedded_bundle}:manage_groups")
 
     # This user will be used to test the normal operation of the controller
     authed_user = user("cog")

--- a/test/controllers/v1/permission_controller_test.exs
+++ b/test/controllers/v1/permission_controller_test.exs
@@ -7,7 +7,7 @@ defmodule Cog.V1.PermissionControllerTest do
   @bad_uuid "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 
   setup do
-    required_permission = permission("#{Cog.embedded_bundle}:manage_permissions")
+    required_permission = permission("#{Cog.Util.Misc.embedded_bundle}:manage_permissions")
 
     # This user will be used to test the normal operation of the controller
     authed_user = user("cog")
@@ -98,7 +98,7 @@ defmodule Cog.V1.PermissionControllerTest do
 
 
     # embedded bundle namespace
-    embedded_perm = permission("#{Cog.embedded_bundle}:test_perm") |> Repo.preload(:bundle)
+    embedded_perm = permission("#{Cog.Util.Misc.embedded_bundle}:test_perm") |> Repo.preload(:bundle)
     conn = api_request(user, :get, "/v1/permissions/#{embedded_perm.id}")
     assert json_response(conn, 200) == %{
       "permission" =>

--- a/test/controllers/v1/permission_grant_controller_test.exs
+++ b/test/controllers/v1/permission_grant_controller_test.exs
@@ -33,9 +33,9 @@ defmodule Cog.V1.PermissionGrantController.Test do
     # the permission that the user making the API requests needs to
     # have in order to be authorized to make the request.
     required_permission = case context[:base] do
-                            :user -> permission("#{Cog.embedded_bundle}:manage_users")
-                            :role -> permission("#{Cog.embedded_bundle}:manage_roles")
-                            :group -> permission("#{Cog.embedded_bundle}:manage_groups")
+                            :user -> permission("#{Cog.Util.Misc.embedded_bundle}:manage_users")
+                            :role -> permission("#{Cog.Util.Misc.embedded_bundle}:manage_roles")
+                            :group -> permission("#{Cog.Util.Misc.embedded_bundle}:manage_groups")
                           end
 
     # This user will be used to test the normal operation of the controller

--- a/test/controllers/v1/relay_controller_test.exs
+++ b/test/controllers/v1/relay_controller_test.exs
@@ -15,7 +15,7 @@ defmodule Cog.V1.RelayControllerTest do
 
   setup do
     # Requests handled by the role controller require this permission
-    required_permission = permission("#{Cog.embedded_bundle}:manage_relays")
+    required_permission = permission("#{Cog.Util.Misc.embedded_bundle}:manage_relays")
 
     # This user will be used to test the normal operation of the controller
     authed_user = user("cog")

--- a/test/controllers/v1/relay_group_controller_test.exs
+++ b/test/controllers/v1/relay_group_controller_test.exs
@@ -11,7 +11,7 @@ defmodule Cog.V1.RelayGroupControllerTest do
 
   setup do
     # Requests handled by the role controller require this permission
-    required_permission = permission("#{Cog.embedded_bundle}:manage_relays")
+    required_permission = permission("#{Cog.Util.Misc.embedded_bundle}:manage_relays")
 
     # This user will be used to test the normal operation of the controller
     authed_user = user("cog")

--- a/test/controllers/v1/relay_group_membership_controller_test.exs
+++ b/test/controllers/v1/relay_group_membership_controller_test.exs
@@ -12,8 +12,8 @@ defmodule Cog.V1.RelayGroupMembershipControllerTest do
     # This user will be used to test the normal operation of the controller
     authed_user = user("cog")
     |> with_token
-    |> with_permission("#{Cog.embedded_bundle}:manage_relays")
-    |> with_permission("#{Cog.embedded_bundle}:manage_commands")
+    |> with_permission("#{Cog.Util.Misc.embedded_bundle}:manage_relays")
+    |> with_permission("#{Cog.Util.Misc.embedded_bundle}:manage_commands")
 
     # This user will be used to verify that the above permission is
     # indeed required for requests
@@ -254,7 +254,7 @@ defmodule Cog.V1.RelayGroupMembershipControllerTest do
     assert bundle_ids == sorted_response
   end
 
-  Enum.each([Cog.embedded_bundle, Cog.site_namespace], fn(bundle_name)->
+  Enum.each([Cog.Util.Misc.embedded_bundle, Cog.Util.Misc.site_namespace], fn(bundle_name)->
     test "cannot assign protected bundle #{bundle_name} to a relay", %{authed: requestor} do
       relay_group = relay_group("test-group")
 

--- a/test/controllers/v1/role_controller_test.exs
+++ b/test/controllers/v1/role_controller_test.exs
@@ -8,7 +8,7 @@ defmodule Cog.V1.RoleController.Test do
 
   setup do
     # Requests handled by the role controller require this permission
-    required_permission = permission("#{Cog.embedded_bundle}:manage_roles")
+    required_permission = permission("#{Cog.Util.Misc.embedded_bundle}:manage_roles")
 
     # This user will be used to test the normal operation of the controller
     authed_user = user("cog")

--- a/test/controllers/v1/role_grant_controller_test.exs
+++ b/test/controllers/v1/role_grant_controller_test.exs
@@ -3,7 +3,7 @@ defmodule Cog.V1.RoleGrantController.Test do
   use Cog.ConnCase
 
   setup do
-    required_permission = permission("#{Cog.embedded_bundle}:manage_groups")
+    required_permission = permission("#{Cog.Util.Misc.embedded_bundle}:manage_groups")
 
     # This user will be used to test the normal operation of the controller
     authed_user = user("cog")
@@ -233,19 +233,19 @@ defmodule Cog.V1.RoleGrantController.Test do
     assert_role_is_granted(group, role)
   end
 
-  test "cannot revoke the #{Cog.admin_role} role from the #{Cog.admin_group} group", %{authed: requestor} do
+  test "cannot revoke the #{Cog.Util.Misc.admin_role} role from the #{Cog.Util.Misc.admin_group} group", %{authed: requestor} do
     # This is how the role and group get there in the first place
     Cog.Bootstrap.bootstrap
 
-    admin_role = %Cog.Models.Role{} = Cog.Repository.Roles.by_name(Cog.admin_role)
-    {:ok, admin_group}              = Cog.Repository.Groups.by_name(Cog.admin_group)
+    admin_role = %Cog.Models.Role{} = Cog.Repository.Roles.by_name(Cog.Util.Misc.admin_role)
+    {:ok, admin_group}              = Cog.Repository.Groups.by_name(Cog.Util.Misc.admin_group)
 
     conn = api_request(requestor, :post, "/v1/groups/#{admin_group.id}/roles",
                        body: %{"roles" => %{"revoke" => [admin_role.name]}})
 
     # TODO: Ideally, I'd like an error here instead... this'll change
     # when we get to https://github.com/operable/cog/issues/825
-    assert %{"roles" => [%{"name" => unquote(Cog.admin_role)}]} = json_response(conn, 200)
+    assert %{"roles" => [%{"name" => unquote(Cog.Util.Misc.admin_role)}]} = json_response(conn, 200)
 
     assert_role_is_granted(admin_group, admin_role)
   end

--- a/test/controllers/v1/rule_controller_test.exs
+++ b/test/controllers/v1/rule_controller_test.exs
@@ -5,7 +5,7 @@ defmodule Cog.V1.RuleController.Test do
   @bad_uuid "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 
   setup do
-    required_permission = permission("#{Cog.embedded_bundle}:manage_commands")
+    required_permission = permission("#{Cog.Util.Misc.embedded_bundle}:manage_commands")
 
     # This user will be used to test the normal operation of the controller
     authed_user = user("cog")

--- a/test/controllers/v1/trigger_controller_test.exs
+++ b/test/controllers/v1/trigger_controller_test.exs
@@ -8,7 +8,7 @@ defmodule Cog.V1.TriggerControllerTest do
 
   setup do
     # Requests handled by the role controller require this permission
-    required_permission = permission("#{Cog.embedded_bundle}:manage_triggers")
+    required_permission = permission("#{Cog.Util.Misc.embedded_bundle}:manage_triggers")
 
     # This user will be used to test the normal operation of the controller
     authed_user = user("cog")

--- a/test/controllers/v1/user_controller_test.exs
+++ b/test/controllers/v1/user_controller_test.exs
@@ -17,7 +17,7 @@ defmodule Cog.V1.UserControllerTest do
 
   setup do
     # Requests handled by the role controller require this permission
-    required_permission = permission("#{Cog.embedded_bundle}:manage_users")
+    required_permission = permission("#{Cog.Util.Misc.embedded_bundle}:manage_users")
 
     # This user will be used to test the normal operation of the controller
     authed_user = user("cog")

--- a/test/plugs/authorization_test.exs
+++ b/test/plugs/authorization_test.exs
@@ -6,15 +6,15 @@ defmodule Cog.Plug.Authorization.Test do
   setup do
     user = user("cog")
     no_perm_user = user("noperm")
-    granted = permission("#{Cog.embedded_bundle}:manage_users")
-    ungranted = permission("#{Cog.embedded_bundle}:manage_groups")
+    granted = permission("#{Cog.Util.Misc.embedded_bundle}:manage_users")
+    ungranted = permission("#{Cog.Util.Misc.embedded_bundle}:manage_groups")
     :ok = Permittable.grant_to(user, granted)
     {:ok, [user: user,
            no_perm_user: no_perm_user,
            granted: granted,
-           granted_name: "#{Cog.embedded_bundle}:manage_users",
+           granted_name: "#{Cog.Util.Misc.embedded_bundle}:manage_users",
            ungranted: ungranted,
-           ungranted_name: "#{Cog.embedded_bundle}:manage_groups"]}
+           ungranted_name: "#{Cog.Util.Misc.embedded_bundle}:manage_groups"]}
   end
 
   test "errors if :user assigns is missing", %{granted_name: permission} do
@@ -31,7 +31,7 @@ defmodule Cog.Plug.Authorization.Test do
 
   test "init fails when passing a list of permissions" do
     # permission lookup expects a single string
-    error = catch_error(Authorization.init(permission: ["#{Cog.embedded_bundle}:manage_users", "#{Cog.embedded_bundle}:manage_groups"]))
+    error = catch_error(Authorization.init(permission: ["#{Cog.Util.Misc.embedded_bundle}:manage_users", "#{Cog.Util.Misc.embedded_bundle}:manage_groups"]))
     assert %RuntimeError{} = error
   end
 
@@ -47,7 +47,7 @@ defmodule Cog.Plug.Authorization.Test do
   # TODO: we might want to rescue this error, log the problem, and
   # still return 403
   test "plug fails when passing an unrecognized permission" do
-    error = catch_error(conn(:get, "/") |> Authorization.call(Authorization.init(permission: "#{Cog.embedded_bundle}:do_stuff")))
+    error = catch_error(conn(:get, "/") |> Authorization.call(Authorization.init(permission: "#{Cog.Util.Misc.embedded_bundle}:do_stuff")))
     assert %Ecto.NoResultsError{} = error
   end
 

--- a/test/support/test_commands/bad_template.ex
+++ b/test/support/test_commands/bad_template.ex
@@ -1,9 +1,9 @@
 defmodule Cog.Support.TestCommands.BadTemplate do
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle, name: "bad-template"
+  use Cog.Command.GenCommand.Base, bundle: Cog.Util.Misc.embedded_bundle, name: "bad-template"
 
   @description "description"
 
-  rule "when command is #{Cog.embedded_bundle}:bad-template allow"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:bad-template allow"
 
   def handle_message(req, state) do
     {:reply, req.reply_to, "badtemplate", %{bad: %{foo: "bar"}}, state}

--- a/test/support/test_commands/required_opt_test_command.ex
+++ b/test/support/test_commands/required_opt_test_command.ex
@@ -1,9 +1,9 @@
 defmodule Cog.Support.TestCommands.RequiredOptTestCommand do
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle, name: "req-opt"
+  use Cog.Command.GenCommand.Base, bundle: Cog.Util.Misc.embedded_bundle, name: "req-opt"
 
   @description "description"
 
-  rule "when command is #{Cog.embedded_bundle}:req-opt allow"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:req-opt allow"
 
   option "req", type: "string", required: true
 

--- a/test/support/test_commands/secure-test-thorn.ex
+++ b/test/support/test_commands/secure-test-thorn.ex
@@ -1,5 +1,5 @@
 defmodule Cog.Commands.SecureTestThorn do
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle, name: "st-thorn"
+  use Cog.Command.GenCommand.Base, bundle: Cog.Util.Misc.embedded_bundle, name: "st-thorn"
 
   @upcase_thorn "Þ"
   @downcase_thorn "þ"
@@ -7,7 +7,7 @@ defmodule Cog.Commands.SecureTestThorn do
   @description "description"
 
   permission "st-thorn"
-  rule "when command is #{Cog.embedded_bundle}:st-thorn must have #{Cog.embedded_bundle}:st-thorn"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:st-thorn must have #{Cog.Util.Misc.embedded_bundle}:st-thorn"
 
   def handle_message(req, state) do
     text = Enum.join(req.args, " ")

--- a/test/support/test_commands/secure_test_echo.ex
+++ b/test/support/test_commands/secure_test_echo.ex
@@ -1,5 +1,5 @@
 defmodule Cog.Support.TestCommands.SecureTestEcho do
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle, name: "st-echo"
+  use Cog.Command.GenCommand.Base, bundle: Cog.Util.Misc.embedded_bundle, name: "st-echo"
 
   @description "description"
 
@@ -8,13 +8,13 @@ defmodule Cog.Support.TestCommands.SecureTestEcho do
 
   ## Example
 
-      @bot #{Cog.embedded_bundle}:secure-test-echo this is nifty
+      @bot #{Cog.Util.Misc.embedded_bundle}:secure-test-echo this is nifty
       > this if nifty
 
   """
 
   permission "st-echo"
-  rule "when command is #{Cog.embedded_bundle}:st-echo must have #{Cog.embedded_bundle}:st-echo"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:st-echo must have #{Cog.Util.Misc.embedded_bundle}:st-echo"
 
   def handle_message(req, state) do
     {:reply, req.reply_to, echo_string(req.args), state}

--- a/test/support/test_commands/test_echo.ex
+++ b/test/support/test_commands/test_echo.ex
@@ -1,5 +1,5 @@
 defmodule Cog.Support.TestCommands.TestEcho do
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle, name: "t-echo"
+  use Cog.Command.GenCommand.Base, bundle: Cog.Util.Misc.embedded_bundle, name: "t-echo"
 
   @description "description"
 
@@ -8,12 +8,12 @@ defmodule Cog.Support.TestCommands.TestEcho do
 
   ## Example
 
-      @bot #{Cog.embedded_bundle}:t-echo this is nifty
+      @bot #{Cog.Util.Misc.embedded_bundle}:t-echo this is nifty
       > this if nifty
 
   """
 
-  rule "when command is #{Cog.embedded_bundle}:t-echo allow"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:t-echo allow"
 
   def handle_message(req, state) do
     {:reply, req.reply_to, echo_string(req.args), state}

--- a/test/support/test_commands/types_test_command.ex
+++ b/test/support/test_commands/types_test_command.ex
@@ -1,5 +1,5 @@
 defmodule Cog.Support.TestCommands.TypesTestCommand do
-  use Cog.Command.GenCommand.Base, bundle: Cog.embedded_bundle, name: "type-test"
+  use Cog.Command.GenCommand.Base, bundle: Cog.Util.Misc.embedded_bundle, name: "type-test"
 
   @description "description"
 
@@ -9,7 +9,7 @@ defmodule Cog.Support.TestCommands.TypesTestCommand do
   option "float", type: "float", required: false
   option "incr", type: "incr", required: false
 
-  rule "when command is #{Cog.embedded_bundle}:type-test allow"
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:type-test allow"
 
   def handle_message(req, state) do
     {:reply, req.reply_to, "type-test response", state}

--- a/web/controllers/v1/bundle_dynamic_config_controller.ex
+++ b/web/controllers/v1/bundle_dynamic_config_controller.ex
@@ -7,7 +7,7 @@ defmodule Cog.V1.BundleDynamicConfigController do
   alias Cog.Repository.Bundles
 
   plug Cog.Plug.Authentication
-  plug Cog.Plug.Authorization, permission: "#{Cog.embedded_bundle}:manage_commands"
+  plug Cog.Plug.Authorization, permission: "#{Cog.Util.Misc.embedded_bundle}:manage_commands"
 
   def show_all(conn, %{"bundle_id" => id}),
     do: all_config(conn, id)

--- a/web/controllers/v1/bundle_status_controller.ex
+++ b/web/controllers/v1/bundle_status_controller.ex
@@ -7,7 +7,7 @@ defmodule Cog.V1.BundleStatusController do
   alias Cog.Repository
 
   plug Cog.Plug.Authentication
-  plug Cog.Plug.Authorization, permission: "#{Cog.embedded_bundle}:manage_commands"
+  plug Cog.Plug.Authorization, permission: "#{Cog.Util.Misc.embedded_bundle}:manage_commands"
 
   def show(conn, %{"id" => id}) do
     case Repository.Bundles.bundle(id) do

--- a/web/controllers/v1/bundle_version_controller.ex
+++ b/web/controllers/v1/bundle_version_controller.ex
@@ -5,7 +5,7 @@ defmodule Cog.V1.BundleVersionController do
   alias Cog.Repository
 
   plug Cog.Plug.Authentication
-  plug Cog.Plug.Authorization, permission: "#{Cog.embedded_bundle}:manage_commands"
+  plug Cog.Plug.Authorization, permission: "#{Cog.Util.Misc.embedded_bundle}:manage_commands"
 
   def index(conn, %{"bundle_id" => id}) do
     case Repository.Bundles.bundle(id) do

--- a/web/controllers/v1/bundles_controller.ex
+++ b/web/controllers/v1/bundles_controller.ex
@@ -5,7 +5,7 @@ defmodule Cog.V1.BundlesController do
   alias Cog.Models.Bundle
 
   plug Cog.Plug.Authentication
-  plug Cog.Plug.Authorization, permission: "#{Cog.embedded_bundle}:manage_commands"
+  plug Cog.Plug.Authorization, permission: "#{Cog.Util.Misc.embedded_bundle}:manage_commands"
 
   alias Cog.Repository
 

--- a/web/controllers/v1/chat_handle_controller.ex
+++ b/web/controllers/v1/chat_handle_controller.ex
@@ -6,7 +6,7 @@ defmodule Cog.V1.ChatHandleController do
   alias Cog.Models.User
 
   plug Cog.Plug.Authentication
-  plug Cog.Plug.Authorization, [permission: "#{Cog.embedded_bundle}:manage_users",
+  plug Cog.Plug.Authorization, [permission: "#{Cog.Util.Misc.embedded_bundle}:manage_users",
                                 self_updates_on: :upsert]
 
   plug :scrub_params, "chat_handle" when action in [:create, :update]
@@ -40,7 +40,7 @@ defmodule Cog.V1.ChatHandleController do
         |> put_status(:unprocessable_entity)
         |> render(Cog.ErrorView, "422.json", %{error: "User with handle '#{handle}' not found"})
       {:error, :adapter_not_running} ->
-        {:ok, adapter} = Cog.chat_adapter_module
+        {:ok, adapter} = Cog.Util.Misc.chat_adapter_module
         conn
         |> put_status(:unprocessable_entity)
         |> render(Cog.ErrorView, "422.json", %{error: "Currently, you can only set chat handles for the configured chat adapter, which handles '#{adapter.name}'. You requested a chat handle for '#{provider_name}'"})

--- a/web/controllers/v1/group_controller.ex
+++ b/web/controllers/v1/group_controller.ex
@@ -4,7 +4,7 @@ defmodule Cog.V1.GroupController do
   alias Cog.Repository.Groups
 
   plug Cog.Plug.Authentication
-  plug Cog.Plug.Authorization, permission: "#{Cog.embedded_bundle}:manage_groups"
+  plug Cog.Plug.Authorization, permission: "#{Cog.Util.Misc.embedded_bundle}:manage_groups"
 
   plug :scrub_params, "group" when action in [:create, :update]
 

--- a/web/controllers/v1/group_membership_controller.ex
+++ b/web/controllers/v1/group_membership_controller.ex
@@ -4,7 +4,7 @@ defmodule Cog.V1.GroupMembershipController do
   alias Cog.Repository.Groups
 
   plug Cog.Plug.Authentication
-  plug Cog.Plug.Authorization, permission: "#{Cog.embedded_bundle}:manage_groups"
+  plug Cog.Plug.Authorization, permission: "#{Cog.Util.Misc.embedded_bundle}:manage_groups"
 
   plug :put_view, Cog.V1.GroupView
 

--- a/web/controllers/v1/permission_controller.ex
+++ b/web/controllers/v1/permission_controller.ex
@@ -7,7 +7,7 @@ defmodule Cog.V1.PermissionController do
   plug :scrub_params, "permission" when action in [:create, :update]
 
   plug Cog.Plug.Authentication
-  plug Cog.Plug.Authorization, permission: "#{Cog.embedded_bundle}:manage_permissions"
+  plug Cog.Plug.Authorization, permission: "#{Cog.Util.Misc.embedded_bundle}:manage_permissions"
 
   @site "site"
 

--- a/web/controllers/v1/permission_grant_controller.ex
+++ b/web/controllers/v1/permission_grant_controller.ex
@@ -6,7 +6,7 @@ defmodule Cog.V1.PermissionGrantController do
 
   plug Cog.Plug.Authentication
 
-  plug Cog.Plug.Authorization, [permission: "#{Cog.embedded_bundle}:manage_roles"] when action == :manage_role_permissions
+  plug Cog.Plug.Authorization, [permission: "#{Cog.Util.Misc.embedded_bundle}:manage_roles"] when action == :manage_role_permissions
 
   plug :put_view, Cog.V1.PermissionView
 

--- a/web/controllers/v1/relay_controller.ex
+++ b/web/controllers/v1/relay_controller.ex
@@ -4,7 +4,7 @@ defmodule Cog.V1.RelayController do
   alias Cog.Repository.Relays, as: RelaysRepo
 
   plug Cog.Plug.Authentication
-  plug Cog.Plug.Authorization, permission: "#{Cog.embedded_bundle}:manage_relays"
+  plug Cog.Plug.Authorization, permission: "#{Cog.Util.Misc.embedded_bundle}:manage_relays"
 
   plug :scrub_params, "relay" when action in [:create, :update]
 

--- a/web/controllers/v1/relay_group_controller.ex
+++ b/web/controllers/v1/relay_group_controller.ex
@@ -7,7 +7,7 @@ defmodule Cog.V1.RelayGroupController do
   alias Cog.Repo
 
   plug Cog.Plug.Authentication
-  plug Cog.Plug.Authorization, permission: "#{Cog.embedded_bundle}:manage_relays"
+  plug Cog.Plug.Authorization, permission: "#{Cog.Util.Misc.embedded_bundle}:manage_relays"
 
   plug :scrub_params, "relay_group" when action in [:create, :update]
 

--- a/web/controllers/v1/relay_group_membership_controller.ex
+++ b/web/controllers/v1/relay_group_membership_controller.ex
@@ -5,7 +5,7 @@ defmodule Cog.V1.RelayGroupMembershipController do
   alias Cog.Repository.RelayGroups
 
   plug Cog.Plug.Authentication
-  plug Cog.Plug.Authorization, permission: "#{Cog.embedded_bundle}:manage_relays"
+  plug Cog.Plug.Authorization, permission: "#{Cog.Util.Misc.embedded_bundle}:manage_relays"
 
   plug :put_view, Cog.V1.RelayGroupView
 

--- a/web/controllers/v1/role_controller.ex
+++ b/web/controllers/v1/role_controller.ex
@@ -4,7 +4,7 @@ defmodule Cog.V1.RoleController do
   alias Cog.Models.Role
 
   plug Cog.Plug.Authentication
-  plug Cog.Plug.Authorization, permission: "#{Cog.embedded_bundle}:manage_roles"
+  plug Cog.Plug.Authorization, permission: "#{Cog.Util.Misc.embedded_bundle}:manage_roles"
 
   # Search by name only for now
   def index(conn, %{"name" => name}) do

--- a/web/controllers/v1/role_grant_controller.ex
+++ b/web/controllers/v1/role_grant_controller.ex
@@ -6,7 +6,7 @@ defmodule Cog.V1.RoleGrantController do
 
   plug Cog.Plug.Authentication
 
-  plug Cog.Plug.Authorization, [permission: "#{Cog.embedded_bundle}:manage_groups"]
+  plug Cog.Plug.Authorization, [permission: "#{Cog.Util.Misc.embedded_bundle}:manage_groups"]
 
   plug :put_view, Cog.V1.RoleView
 

--- a/web/controllers/v1/rule_controller.ex
+++ b/web/controllers/v1/rule_controller.ex
@@ -5,7 +5,7 @@ defmodule Cog.V1.RuleController do
   require Logger
 
   plug Cog.Plug.Authentication
-  plug Cog.Plug.Authorization, permission: "#{Cog.embedded_bundle}:manage_commands"
+  plug Cog.Plug.Authorization, permission: "#{Cog.Util.Misc.embedded_bundle}:manage_commands"
 
   def index(conn, %{"for-command" => command}) do
     case Rules.rules_for_command(command) do

--- a/web/controllers/v1/trigger_controller.ex
+++ b/web/controllers/v1/trigger_controller.ex
@@ -3,7 +3,7 @@ defmodule Cog.V1.TriggerController do
   require Logger
 
   plug Cog.Plug.Authentication
-  plug Cog.Plug.Authorization, permission: "#{Cog.embedded_bundle}:manage_triggers"
+  plug Cog.Plug.Authorization, permission: "#{Cog.Util.Misc.embedded_bundle}:manage_triggers"
 
   alias Cog.Repository.Triggers
 

--- a/web/controllers/v1/user_controller.ex
+++ b/web/controllers/v1/user_controller.ex
@@ -4,7 +4,7 @@ defmodule Cog.V1.UserController do
   alias Cog.Repository.Users
 
   plug Cog.Plug.Authentication
-  plug Cog.Plug.Authorization, [permission: "#{Cog.embedded_bundle}:manage_users",
+  plug Cog.Plug.Authorization, [permission: "#{Cog.Util.Misc.embedded_bundle}:manage_users",
                                 self_updates_on: [:update, :show]]
 
   plug :scrub_params, "user" when action in [:create, :update]


### PR DESCRIPTION
This PR addresses the following compile time issues:

- Over-use of `lib/cog.ex` by other modules due to the presence of utility functions. These functions have been moved to `lib/cog/util/misc.ex` to break the dependency. This set of deps was especially onerous as `lib/cog.ex` also defines the top level supervisor and refers to its immediate children. Between the supervisors and the file being referenced all over the code base it pretty much guaranteed a full recompile most of the time.
- Cyclic deps incorporating `lib/cog.ex`

Fixes #927 