### PR TITLE
Organize provider code by implementation

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -12,13 +12,13 @@ config :cog, :embedded_bundle_version, "0.12.0"
 # ========================================================================
 
 config :cog, Cog.Chat.Adapter,
-  providers: [http: Cog.Chat.HttpProvider],
+  providers: [http: Cog.Chat.Http.Provider],
   cache_ttl: {60, :sec}
 
-config :cog, Cog.Chat.SlackProvider,
+config :cog, Cog.Chat.Slack.Provider,
   api_token: System.get_env("SLACK_API_TOKEN")
 
-config :cog, Cog.Chat.HttpProvider,
+config :cog, Cog.Chat.Http.Provider,
   foo: "blah"
 
 config :cog, :enable_spoken_commands, ensure_boolean(System.get_env("ENABLE_SPOKEN_COMMANDS")) || true

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -13,7 +13,7 @@ config :cog,
   :template_cache_ttl, {1, :sec}
 
 config :cog, Cog.Chat.Adapter,
-  providers: [slack: Cog.Chat.SlackProvider],
+  providers: [slack: Cog.Chat.Slack.Provider],
   chat: :slack
 
 config :cog, Cog.Endpoint,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -10,5 +10,5 @@ config :comeonin,
   bcrypt_log_rounds: 14
 
 config :cog, Cog.Chat.Adapter,
-  providers: [slack: Cog.Chat.SlackProvider],
+  providers: [slack: Cog.Chat.Slack.Provider],
   chat: :slack

--- a/config/test.exs
+++ b/config/test.exs
@@ -7,10 +7,10 @@ config :lager, :handlers,
   [{LagerLogger, [level: :error]}]
 
 config :cog, Cog.Chat.Adapter,
-  providers: [test: Cog.Chat.TestProvider],
+  providers: [test: Cog.Chat.Test.Provider],
   chat: :test
 
-config :cog, Cog.Chat.TestProvider,
+config :cog, Cog.Chat.Test.Provider,
   verbose: true
 
 config :cog, Cog.Repo,

--- a/lib/cog/chat/adapter.ex
+++ b/lib/cog/chat/adapter.ex
@@ -283,7 +283,7 @@ defmodule Cog.Chat.Adapter do
     # The notion of "bot name" only really makes sense in the context
     # of chat providers, where we can use that to determine whether or
     # not a message is being addressed to the bot. For other providers
-    # (lookin' at you, HttpProvider), this makes no sense, because all
+    # (lookin' at you, Http.Provider), this makes no sense, because all
     # messages are directed to the bot, by definition.
     if message.room.is_dm == true do
       {true, message.text}

--- a/lib/cog/chat/http/connector.ex
+++ b/lib/cog/chat/http/connector.ex
@@ -1,7 +1,8 @@
-defmodule Cog.Chat.HttpConnector do
+defmodule Cog.Chat.Http.Connector do
   @moduledoc """
   Mediates interactions between HTTP requests and pipeline executions
   """
+  alias Cog.Chat.Http.Provider
 
   use GenServer
   use Adz
@@ -30,7 +31,7 @@ defmodule Cog.Chat.HttpConnector do
 
   # TODO: pass timeout in order to queue up clearing the data from the map?
   def handle_call({:submit_request, requestor, id, initial_context, pipeline}, from, state) do
-    GenServer.cast(Cog.Chat.HttpProvider, {:pipeline, requestor, id, initial_context, pipeline})
+    GenServer.cast(Provider, {:pipeline, requestor, id, initial_context, pipeline})
     {:noreply, Map.put(state, id, from)}
   end
   def handle_call({:finish_request, room_id, response}, _from, state) do

--- a/lib/cog/chat/http/provider.ex
+++ b/lib/cog/chat/http/provider.ex
@@ -1,11 +1,13 @@
-defmodule Cog.Chat.HttpProvider do
+defmodule Cog.Chat.Http.Provider do
   use GenServer
   use Cog.Chat.Provider
-  alias Cog.Chat.HttpConnector
-  alias Cog.Chat.Room
-  alias Cog.Chat.Message
+
   alias Carrier.Messaging.Connection
   alias Carrier.Messaging.GenMqtt
+  alias Cog.Chat.Http.Connector
+  alias Cog.Chat.Message
+  alias Cog.Chat.Room
+
   require Logger
 
   @provider_name "http"
@@ -19,7 +21,7 @@ defmodule Cog.Chat.HttpProvider do
   # Provider Implementation
 
   def send_message(room, response),
-    do: HttpConnector.finish_request(room, response)
+    do: Connector.finish_request(room, response)
 
   def lookup_room(_room),
     do: {:error, :not_found}

--- a/lib/cog/chat/http/supervisor.ex
+++ b/lib/cog/chat/http/supervisor.ex
@@ -1,11 +1,11 @@
-defmodule Cog.Chat.HttpSupervisor do
+defmodule Cog.Chat.Http.Supervisor do
   use Supervisor
 
   def start_link,
     do: Supervisor.start_link(__MODULE__, [], name: __MODULE__)
 
   def init(_) do
-    children = [worker(Cog.Chat.HttpConnector, [])]
+    children = [worker(Cog.Chat.Http.Connector, [])]
     supervise(children, strategy: :one_for_all)
   end
 end

--- a/lib/cog/chat/slack/connector.ex
+++ b/lib/cog/chat/slack/connector.ex
@@ -1,12 +1,12 @@
-defmodule Cog.Chat.SlackConnector do
+defmodule Cog.Chat.Slack.Connector do
   require Logger
   use Slack
 
-  alias Cog.Chat.SlackProvider
-  alias Cog.Chat.SlackFormatter
-  alias Cog.Chat.User
-  alias Cog.Chat.Room
   alias Cog.Chat.Message
+  alias Cog.Chat.Room
+  alias Cog.Chat.Slack.Formatter
+  alias Cog.Chat.Slack.Provider
+  alias Cog.Chat.User
 
   @provider_name "slack"
 
@@ -31,7 +31,7 @@ defmodule Cog.Chat.SlackConnector do
       :ignore ->
         :ok
       msg ->
-        GenServer.cast(SlackProvider, msg)
+        GenServer.cast(Provider, msg)
         :ok
     end
   end
@@ -240,7 +240,7 @@ defmodule Cog.Chat.SlackConnector do
  defp annotate(_, _), do: :ignore
 
  defp annotate_message(%{channel: << <<"C">>, _::binary >>=channel, user: userid, text: text}, state) do
-   text = SlackFormatter.unescape(text, state)
+   text = Formatter.unescape(text, state)
    user = lookup_user(userid, state.users, by: :id)
    if user == nil do
      Logger.info("Failed looking up user '#{userid}'.")
@@ -258,7 +258,7 @@ defmodule Cog.Chat.SlackConnector do
    end
  end
  defp annotate_message(%{channel: << <<"D">>, _::binary >>=channel, user: userid, text: text}, state) do
-   text = SlackFormatter.unescape(text, state)
+   text = Formatter.unescape(text, state)
    user = lookup_user(userid, state.users, by: :id)
    if user == nil do
      Logger.info("Failed looking up user '#{userid}'.")

--- a/lib/cog/chat/slack/formatter.ex
+++ b/lib/cog/chat/slack/formatter.ex
@@ -1,4 +1,4 @@
-defmodule Cog.Chat.SlackFormatter do
+defmodule Cog.Chat.Slack.Formatter do
 
   @channel ~r/<\#(C.*)(\|(.*))?>/U
   @user    ~r/<\@(U.*)(\|(.*))?>/U

--- a/lib/cog/core_sup.ex
+++ b/lib/cog/core_sup.ex
@@ -14,7 +14,7 @@ defmodule Cog.CoreSup do
                 supervisor(Cog.Endpoint, []),
                 supervisor(Cog.TriggerEndpoint, []),
                 supervisor(Cog.ServiceEndpoint, []),
-                supervisor(Cog.Chat.HttpSupervisor,[]),
+                supervisor(Cog.Chat.Http.Supervisor,[]),
                 worker(Cog.Chat.Adapter, [])]
     {:ok, {%{strategy: :one_for_one, intensity: 10, period: 60}, children}}
   end

--- a/test/support/adapter_case.ex
+++ b/test/support/adapter_case.ex
@@ -92,8 +92,8 @@ defmodule Cog.AdapterCase do
     end
   end
 
-  defp provider_for(:test),  do: Cog.Chat.TestProvider
-  defp provider_for(:slack), do: Cog.Chat.SlackProvider
+  defp provider_for(:test),  do: Cog.Chat.Test.Provider
+  defp provider_for(:slack), do: Cog.Chat.Slack.Provider
   defp provider_for(other),
     do: raise "I don't know what implements the #{other} provider yet!"
 

--- a/test/support/adapters/test/helpers.ex
+++ b/test/support/adapters/test/helpers.ex
@@ -51,6 +51,6 @@ defmodule Cog.Adapters.Test.Helpers do
   end
 
   def send_message(%Cog.Models.User{}=user, here_id, "@bot: " <> message) do
-    Cog.Chat.TestProvider.chat_message(user, here_id, "@bot: " <> message)
+    Cog.Chat.Test.Provider.chat_message(user, here_id, "@bot: " <> message)
   end
 end

--- a/test/support/test_provider.ex
+++ b/test/support/test_provider.ex
@@ -1,4 +1,4 @@
-defmodule Cog.Chat.TestProvider do
+defmodule Cog.Chat.Test.Provider do
   require Logger
 
   use GenServer

--- a/web/controllers/v1/trigger_execution_controller.ex
+++ b/web/controllers/v1/trigger_execution_controller.ex
@@ -12,7 +12,7 @@ defmodule Cog.V1.TriggerExecutionController do
   alias Cog.Models.User
   alias Cog.Models.Trigger
   alias Cog.Repository.Triggers
-  alias Cog.Chat.HttpConnector
+  alias Cog.Chat.Http.Connector
 
   plug :parse
 
@@ -35,7 +35,7 @@ defmodule Cog.V1.TriggerExecutionController do
 
             requestor = to_chat_user(user)
 
-            case HttpConnector.submit_request(requestor, request_id, context, trigger.pipeline, timeout) do
+            case Connector.submit_request(requestor, request_id, context, trigger.pipeline, timeout) do
               "ok" ->
                 conn |> send_resp(:no_content, "")
               {:error, :timeout} ->


### PR DESCRIPTION
Instead of tossing all the provider implementation code in a single
directory, consolidate by implementation; all Slack-related code goes in
`lib/cog/chat/slack`, HTTP-related code goes in `lib/cog/chat/http`,
etc.

This will make it easier to manage as we add more implementations, and
more features per implementation.