### PR TITLE
Allow Postgres SSL connections

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -96,7 +96,8 @@ config :cog, Cog.Repo,
   pool_timeout: ensure_integer(System.get_env("COG_DB_POOL_TIMEOUT")) || 15000,
   timeout: ensure_integer(System.get_env("COG_DB_TIMEOUT")) || 15000,
   parameters: [timezone: 'UTC'],
-  loggers: [{Cog.LogHelper, :log, []}]
+  loggers: [{Cog.LogHelper, :log, []}],
+  ssl: ensure_boolean(System.get_env("COG_DB_SSL")) || false
 
 # ========================================================================
 


### PR DESCRIPTION
Adds a `COG_DB_SSL` environment variable that allows SSL support for Postgres to be enabled.