### PR TITLE
Help docs improvements

### DIFF
--- a/lib/cog/commands/help/command_formatter.ex
+++ b/lib/cog/commands/help/command_formatter.ex
@@ -101,7 +101,7 @@ defmodule Cog.Commands.Help.CommandFormatter do
       required_options ->
         required_options = required_options
         |> Enum.map(&render_option/1)
-        |> Enum.join("\n")
+        |> Enum.join("\n\n")
 
         """
         REQUIRED OPTIONS
@@ -119,7 +119,7 @@ defmodule Cog.Commands.Help.CommandFormatter do
       optional_options ->
         optional_options = optional_options
         |> Enum.map(&render_option/1)
-        |> Enum.join("\n")
+        |> Enum.join("\n\n")
 
         """
         OPTIONS
@@ -128,15 +128,15 @@ defmodule Cog.Commands.Help.CommandFormatter do
     end
   end
 
-  defp render_option(%CommandOption{name: name, long_flag: long_flag, desc: desc, option_type: %CommandOptionType{name: type}}) do
-    desc = case desc do
+  defp render_option(%CommandOption{name: name, long_flag: long_flag, description: description, option_type: %CommandOptionType{name: type}}) do
+    description = case description do
       nil ->
         nil
-      desc ->
-        indent(desc)
+      description ->
+        indent(description)
     end
 
-    [render_flag(long_flag, name, type), desc]
+    [render_flag(long_flag, name, type), description]
     |> Enum.reject(&is_nil/1)
     |> Enum.join("\n")
   end

--- a/lib/cog/commands/help/command_formatter.ex
+++ b/lib/cog/commands/help/command_formatter.ex
@@ -74,10 +74,20 @@ defmodule Cog.Commands.Help.CommandFormatter do
   defp render_synopsis_options([]),
     do: nil
   defp render_synopsis_options(options) do
-    options
-    |> Enum.sort_by(&(&1.required))
-    |> Enum.reverse
-    |> Enum.map(&render_synopsis_option/1)
+    required_options = Enum.filter(options, &(&1.required))
+    optional_options = Enum.reject(options, &(&1.required))
+
+    required_options = Enum.map(required_options, &render_synopsis_option/1)
+
+    optional_options = case optional_options do
+      optional_options when length(optional_options) > 5 ->
+        "[options]"
+      optional_options ->
+        Enum.map(optional_options, &render_synopsis_option/1)
+    end
+
+    [required_options, optional_options]
+    |> List.flatten
     |> Enum.join(" ")
   end
 

--- a/lib/cog/models/command_opt.ex
+++ b/lib/cog/models/command_opt.ex
@@ -38,14 +38,14 @@ defmodule Cog.Models.CommandOption do
     field :type, :string, virtual: true
     field :short_flag, :string
     field :long_flag, :string
-    field :desc, :string
+    field :description, :string
 
     belongs_to :command_version, Cog.Models.CommandVersion
     belongs_to :option_type, Cog.Models.CommandOptionType
   end
 
   @required_fields ~w(name required)
-  @optional_fields ~w(desc type option_type_id short_flag long_flag)
+  @optional_fields ~w(description type option_type_id short_flag long_flag)
 
   summary_fields [:id, :name, :required]
   detail_fields [:id, :name, :required, :short_flag, :long_flag,

--- a/priv/repo/migrations/20160909200244_rename_command_option_desc_to_description.exs
+++ b/priv/repo/migrations/20160909200244_rename_command_option_desc_to_description.exs
@@ -1,0 +1,7 @@
+defmodule Cog.Repo.Migrations.RenameCommandOptionDescToDescription do
+  use Ecto.Migration
+
+  def change do
+    rename table(:command_options), :desc, to: :description
+  end
+end


### PR DESCRIPTION
* Fixes missing command option description
* Condenses options to a single segment of the synopsis once there are more than 5