### PR TITLE
Only return disabled bundles from disabled bundle query

### DIFF
--- a/lib/cog/repository/bundles.ex
+++ b/lib/cog/repository/bundles.ex
@@ -303,7 +303,7 @@ defmodule Cog.Repository.Bundles do
   def highest_disabled_versions do
     query = from bv in BundleVersion,
             left_join: e in "enabled_bundle_versions",
-              on: bv.bundle_id == e.bundle_id and bv.version == e.version,
+              on: bv.bundle_id == e.bundle_id,
             join: b in assoc(bv, :bundle),
             where: is_nil(e.bundle_id) and b.name != "site",
             distinct: bv.bundle_id,


### PR DESCRIPTION
Fixes @imbriaco's issue:

```
imbriaco [10:53 AM]  
@ash help

ashBOT [10:53 AM]  
ENABLED BUNDLES
  * cfn - AWS CloudFormation
  * operable - Core chat commands for Cog

DISABLED BUNDLES
  * cfn - AWS CloudFormation

To learn more about a specific bundle and the commands available within it,
you can use `operable:help <bundle>`.


imbriaco [10:54 AM]  
@vanstee ^^^ note the `cfn` bundle duplicated.

[10:54]  
Guessing that's because of multiple versions.
```