### PR TITLE
Actually print all lines of text output

### DIFF
--- a/priv/templates/common/text.greenbar
+++ b/priv/templates/common/text.greenbar
@@ -1,4 +1,5 @@
 ~each var=$results~
-# # TODO: Need to have a join tag for this; body is a list
-~$item.body[0]~
+~each var=$item.body as=line~
+~$line~
+~end~
 ~end~


### PR DESCRIPTION
Discovered this while writing a command that wrapped an existing,
non-Cog aware executable. The output was just what the wrapped program
returned on standard output. Without this fix, only the first line of
that output showed up in chat. Now, everything comes through.