### PR TITLE
Send relay, relay-group usage messages to template

### DIFF
--- a/lib/cog/commands/relay/list.ex
+++ b/lib/cog/commands/relay/list.ex
@@ -1,10 +1,10 @@
 defmodule Cog.Commands.Relay.List do
-  alias Cog.Commands.Helpers
+  require Cog.Commands.Helpers, as: Helpers
   alias Cog.Repository.Relays
 
   alias Cog.Commands.Relay.ViewHelpers
 
-  @moduledoc """
+  Helpers.usage """
   Lists relays.
 
   USAGE
@@ -36,7 +36,4 @@ defmodule Cog.Commands.Relay.List do
     end
   end
 
-  defp show_usage do
-    {:ok, "usage", %{usage: @moduledoc}}
-  end
 end

--- a/lib/cog/commands/relay/update.ex
+++ b/lib/cog/commands/relay/update.ex
@@ -1,10 +1,10 @@
 defmodule Cog.Commands.Relay.Update do
   alias Cog.Repository.Relays
-  alias Cog.Commands.Helpers
+  require Cog.Commands.Helpers, as: Helpers
 
   alias Cog.Commands.Relay.ViewHelpers
 
-  @moduledoc """
+  Helpers.usage """
   Updates relay name and/or description.
 
   USAGE
@@ -53,7 +53,4 @@ defmodule Cog.Commands.Relay.Update do
     end
   end
 
-  def show_usage(error \\ nil) do
-    {:ok, "usage", %{usage: @moduledoc, error: error}}
-  end
 end

--- a/lib/cog/commands/relay_group.ex
+++ b/lib/cog/commands/relay_group.ex
@@ -1,7 +1,7 @@
 defmodule Cog.Commands.RelayGroup do
   use Cog.Command.GenCommand.Base, bundle: Cog.Util.Misc.embedded_bundle, name: "relay-group"
   alias Cog.Commands.RelayGroup
-  alias Cog.Commands.Helpers
+  require Cog.Commands.Helpers, as: Helpers
 
   @description "Manage relay groups"
 
@@ -18,8 +18,7 @@ defmodule Cog.Commands.RelayGroup do
 
   rule "when command is #{Cog.Util.Misc.embedded_bundle}:relay-group must have #{Cog.Util.Misc.embedded_bundle}:manage_relays"
 
-  # general options
-  option "help", type: "bool", short: "h"
+  Helpers.usage(:root)
 
   # list options
   option "verbose", type: "bool", short: "v"
@@ -73,17 +72,7 @@ defmodule Cog.Commands.RelayGroup do
   end
 
   defp bundle_json(bundle) do
-    %{"name" => bundle.name}#,
-#      "version" => bundle.version,
-   #   "status" => bundle_status(bundle)}
+    %{"name" => bundle.name}
   end
 
-  # defp bundle_status(%{enabled: true}),
-  #   do: :enabled
-  # defp bundle_status(%{enabled: false}),
-  #   do: :disabled
-
-  defp show_usage(error \\ nil) do
-    {:ok, "usage", %{usage: @moduledoc, error: error}}
-  end
 end

--- a/lib/cog/commands/relay_group/create.ex
+++ b/lib/cog/commands/relay_group/create.ex
@@ -1,9 +1,9 @@
 defmodule Cog.Commands.RelayGroup.Create do
-  alias Cog.Commands.Helpers
+  require Cog.Commands.Helpers, as: Helpers
   alias Cog.Repository.RelayGroups
   alias Cog.Commands.RelayGroup
 
-  @moduledoc """
+  Helpers.usage """
   Creates relay groups
 
   USAGE
@@ -39,7 +39,4 @@ defmodule Cog.Commands.RelayGroup.Create do
     end
   end
 
-  defp show_usage(error \\ nil) do
-    {:ok, "usage", %{usage: @moduledoc, error: error}}
-  end
 end

--- a/lib/cog/commands/relay_group/delete.ex
+++ b/lib/cog/commands/relay_group/delete.ex
@@ -1,9 +1,9 @@
 defmodule Cog.Commands.RelayGroup.Delete do
-  alias Cog.Commands.Helpers
+  require Cog.Commands.Helpers, as: Helpers
   alias Cog.Repository.RelayGroups
   alias Cog.Commands.RelayGroup
 
-  @moduledoc """
+  Helpers.usage """
   Deletes relay groups
 
   USAGE
@@ -48,7 +48,4 @@ defmodule Cog.Commands.RelayGroup.Delete do
     end
   end
 
-  def show_usage(error \\ nil) do
-    {:ok, "usage", %{usage: @moduledoc, error: error}}
-  end
 end

--- a/lib/cog/commands/relay_group/info.ex
+++ b/lib/cog/commands/relay_group/info.ex
@@ -1,9 +1,9 @@
 defmodule Cog.Commands.RelayGroup.Info do
-  alias Cog.Commands.Helpers
+  require Cog.Commands.Helpers, as: Helpers
   alias Cog.Repository.RelayGroups
   alias Cog.Commands.RelayGroup
 
-  @moduledoc """
+  Helpers.usage """
   Get info on one or more relay groups.
 
   USAGE
@@ -42,7 +42,4 @@ defmodule Cog.Commands.RelayGroup.Info do
     end
   end
 
-  defp show_usage do
-    {:ok, "usage", %{usage: @moduledoc}}
-  end
 end

--- a/lib/cog/commands/relay_group/list.ex
+++ b/lib/cog/commands/relay_group/list.ex
@@ -1,9 +1,9 @@
 defmodule Cog.Commands.RelayGroup.List do
-  alias Cog.Commands.Helpers
+  require Cog.Commands.Helpers, as: Helpers
   alias Cog.Repository.RelayGroups
   alias Cog.Commands.RelayGroup
 
-  @moduledoc """
+  Helpers.usage """
   List all relay groups
 
   USAGE
@@ -24,7 +24,4 @@ defmodule Cog.Commands.RelayGroup.List do
   defp generate_response(relay_groups),
     do: Enum.map(relay_groups, &RelayGroup.json/1)
 
-  defp show_usage do
-    {:ok, "usage", %{usage: @moduledoc}}
-  end
 end

--- a/lib/cog/commands/relay_group/member.ex
+++ b/lib/cog/commands/relay_group/member.ex
@@ -1,8 +1,8 @@
 defmodule Cog.Commands.RelayGroup.Member do
-  alias Cog.Commands.Helpers
+  require Cog.Commands.Helpers, as: Helpers
   alias Cog.Commands.RelayGroup.Member
 
-  @moduldoc """
+  Helpers.usage """
   Manages relay and bundle assignments to relay groups.
 
   USAGE
@@ -49,7 +49,4 @@ defmodule Cog.Commands.RelayGroup.Member do
     "Invalid subcommand '#{invalid}' for 'member'. Please specify 'add', 'remove', 'assign' or 'unassign'."
   end
 
-  defp show_usage(error \\ nil) do
-    {:ok, "usage", %{usage: @moduldoc, error: error}}
-  end
 end

--- a/lib/cog/commands/relay_group/member/add.ex
+++ b/lib/cog/commands/relay_group/member/add.ex
@@ -1,9 +1,9 @@
 defmodule Cog.Commands.RelayGroup.Member.Add do
-  alias Cog.Commands.Helpers
+  require Cog.Commands.Helpers, as: Helpers
   alias Cog.Repository.RelayGroups
   alias Cog.Commands.RelayGroup
 
-  @moduledoc """
+  Helpers.usage """
   Adds relays to relay groups
 
   USAGE
@@ -57,7 +57,4 @@ defmodule Cog.Commands.RelayGroup.Member.Add do
     "Missing required args. At a minimum you must include the relay group name and at least one relay name"
   end
 
-  defp show_usage(error \\ nil) do
-    {:ok, "usage", %{usage: @moduledoc, error: error}}
-  end
 end

--- a/lib/cog/commands/relay_group/member/assign.ex
+++ b/lib/cog/commands/relay_group/member/assign.ex
@@ -1,9 +1,9 @@
 defmodule Cog.Commands.RelayGroup.Member.Assign do
-  alias Cog.Commands.Helpers
+  require Cog.Commands.Helpers, as: Helpers
   alias Cog.Repository.RelayGroups
   alias Cog.Commands.RelayGroup
 
-  @moduledoc """
+  Helpers.usage """
   Assigns bundles to relay groups.
 
   USAGE
@@ -57,7 +57,4 @@ defmodule Cog.Commands.RelayGroup.Member.Assign do
     "Missing required args. At a minimum you must include the relay group name and at least one bundle name"
   end
 
-  defp show_usage(error \\ nil) do
-    {:ok, "usage", %{usage: @moduledoc, error: error}}
-  end
 end

--- a/lib/cog/commands/relay_group/member/remove.ex
+++ b/lib/cog/commands/relay_group/member/remove.ex
@@ -1,9 +1,9 @@
 defmodule Cog.Commands.RelayGroup.Member.Remove do
-  alias Cog.Commands.Helpers
+  require Cog.Commands.Helpers, as: Helpers
   alias Cog.Repository.RelayGroups
   alias Cog.Commands.RelayGroup
 
-  @moduledoc """
+  Helpers.usage """
   Removes relays from relay groups
 
   USAGE
@@ -48,7 +48,4 @@ defmodule Cog.Commands.RelayGroup.Member.Remove do
     "Missing required args. At a minimum you must include the relay group name and at least one relay name"
   end
 
-  defp show_usage(error \\ nil) do
-    {:ok, "usage", %{usage: @moduledoc, error: error}}
-  end
 end

--- a/lib/cog/commands/relay_group/member/unassign.ex
+++ b/lib/cog/commands/relay_group/member/unassign.ex
@@ -1,9 +1,9 @@
 defmodule Cog.Commands.RelayGroup.Member.Unassign do
-  alias Cog.Commands.Helpers
+  require Cog.Commands.Helpers, as: Helpers
   alias Cog.Repository.RelayGroups
   alias Cog.Commands.RelayGroup
 
-  @moduledoc """
+  Helpers.usage """
   Unassigns bundles from relay groups
 
   USAGE
@@ -48,7 +48,4 @@ defmodule Cog.Commands.RelayGroup.Member.Unassign do
     "Missing required args. At a minimum you must include the relay group name and at least one bundle name"
   end
 
-  defp show_usage(error \\ nil) do
-    {:ok, "usage", %{usage: @moduledoc, error: error}}
-  end
 end

--- a/lib/cog/commands/relay_group/rename.ex
+++ b/lib/cog/commands/relay_group/rename.ex
@@ -1,9 +1,9 @@
 defmodule Cog.Commands.RelayGroup.Rename do
-  alias Cog.Commands.Helpers
+  require Cog.Commands.Helpers, as: Helpers
   alias Cog.Repository.RelayGroups
   alias Cog.Commands.RelayGroup
 
-  @moduledoc """
+  Helpers.usage """
   Renames relay groups
 
   USAGE
@@ -51,7 +51,4 @@ defmodule Cog.Commands.RelayGroup.Rename do
     end
   end
 
-  def show_usage(error \\ nil) do
-    {:ok, "usage", %{usage: @moduledoc, error: error}}
-  end
 end


### PR DESCRIPTION
A few commands weren't using the `Helpers.usage` macro that everything
else was using.