### PR TITLE
Add global switch to toggle access rule enforcment

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,6 +2,12 @@ use Mix.Config
 import Cog.Config.Helpers
 
 # ========================================================================
+# Set this to :unenforcing to globally disable all access rules.
+# NOTE: This is a global setting.
+# ========================================================================
+config :cog, :access_rules, :unenforcing
+
+# ========================================================================
 # Embedded Command Bundle Version (for built-in commands)
 # NOTE: Do not change this value unless you know what you're doing.
 # ========================================================================

--- a/config/config.exs
+++ b/config/config.exs
@@ -5,7 +5,12 @@ import Cog.Config.Helpers
 # Set this to :unenforcing to globally disable all access rules.
 # NOTE: This is a global setting.
 # ========================================================================
-config :cog, :access_rules, :enforcing
+
+if System.get_env("DISABLE_RULE_ENFORCEMENT") do
+  config :cog, :access_rules, :unenforcing
+else
+  config :cog, :access_rules, :enforcing
+end
 
 # ========================================================================
 # Embedded Command Bundle Version (for built-in commands)

--- a/config/config.exs
+++ b/config/config.exs
@@ -5,7 +5,7 @@ import Cog.Config.Helpers
 # Set this to :unenforcing to globally disable all access rules.
 # NOTE: This is a global setting.
 # ========================================================================
-config :cog, :access_rules, :unenforcing
+config :cog, :access_rules, :enforcing
 
 # ========================================================================
 # Embedded Command Bundle Version (for built-in commands)

--- a/lib/cog.ex
+++ b/lib/cog.ex
@@ -5,6 +5,7 @@ defmodule Cog do
   import Supervisor.Spec, warn: false
 
   def start(_type, _args) do
+    maybe_display_unenforcing_warning()
     children = [worker(Cog.BusDriver, [], shutdown: 1000),
                 worker(Cog.Repo, []),
                 supervisor(Cog.CoreSup, [])]
@@ -81,6 +82,15 @@ defmodule Cog do
       :ok
     else
       {:error, latest_applied_migration, latest_migration}
+    end
+  end
+
+  defp maybe_display_unenforcing_warning() do
+    case Application.get_env(:cog, :access_rules) do
+      :unenforcing ->
+        Logger.warn("Access rule enforcement has been GLOBALLY disabled. ALL command invocations will be permitted.")
+      _ ->
+        :ok
     end
   end
 


### PR DESCRIPTION
_Caveat: I'm conflicted on whether or not this is a good idea. Feedback encouraged!_

This PR introduces a new config entry, `:access_rules` which controls whether or not Cog enforces access rules associated with command invocations. Setting this entry to `:enforcing` causes Cog to enforce access rules just as it currently does. `:enforcing` is also the default.

Setting the entry to `:unenforcing` disables access rule enforcement **globally** for the entire Cog installation. This is intended to simplify Cog adoption for teams which have previous experience with simpler bots such as Hubot and Lita. Later, they can set `:access_rules` to `:enforcing` and take advantage of Cog's access controls.

Disabling access rule enforcement causes Cog to log an explicit warning at startup. Values other than `:enforcing` and `:unenforcing` are ignored by Cog and logged to the console w/a warning message. Cog defaults to `:enforcing` when unknown config values are encountered.

Fixes #977 