### PR TITLE
Support slack private channels (groups)

### DIFF
--- a/lib/cog/chat/slack/connector.ex
+++ b/lib/cog/chat/slack/connector.ex
@@ -251,34 +251,25 @@ defmodule Cog.Chat.Slack.Connector do
   end
  defp annotate(_, _), do: :ignore
 
- defp annotate_message(%{channel: << <<"C">>, _::binary >>=channel, user: userid, text: text}, state) do
+ defp annotate_message(%{channel: channel, user: userid, text: text}, state) do
    text = Formatter.unescape(text, state)
    user = lookup_user(userid, state.users, by: :id)
+
    if user == nil do
      Logger.info("Failed looking up user '#{userid}'.")
      :ignore
    else
-     room = lookup_room(channel, state.channels, by: :id)
-     if room == nil do
-       Logger.info("Failed looking up room '#{channel}'.")
-       :ignore
-     else
-       {:chat_message, %Message{id: Cog.Events.Util.unique_id,
-                                room: room, user: user, text: text, provider: @provider_name,
-                                bot_name: "@#{state.me.name}", edited: false}}
+     room = case channel_type(channel) do
+       :room ->
+         lookup_room(channel, state.channels, by: :id)
+       :group ->
+         lookup_room(channel, state.groups, by: :id)
+       :dm ->
+         lookup_dm(userid, state.users)
      end
-   end
- end
- defp annotate_message(%{channel: << <<"D">>, _::binary >>=channel, user: userid, text: text}, state) do
-   text = Formatter.unescape(text, state)
-   user = lookup_user(userid, state.users, by: :id)
-   if user == nil do
-     Logger.info("Failed looking up user '#{userid}'.")
-     :ignore
-   else
-     room = lookup_dm(channel, state.ims)
+
      if room == nil do
-       Logger.info("Failed looking up direct message session '#{channel}'.")
+       Logger.info("Failed looking up channel '#{channel}'.")
        :ignore
      else
          {:chat_message, %Message{id: Cog.Events.Util.unique_id,
@@ -287,6 +278,13 @@ defmodule Cog.Chat.Slack.Connector do
      end
    end
  end
+
+ defp channel_type(<<"C", _ :: binary>>),
+   do: :room
+ defp channel_type(<<"G", _ :: binary>>),
+   do: :group
+ defp channel_type(<<"D", _ :: binary>>),
+   do: :dm
 
  # Strip off any enclosing angle brackets (Slack processes strings
  # like "#channel_name" and "@user_name" to their internal identifiers

--- a/test/integration/slack_test.exs
+++ b/test/integration/slack_test.exs
@@ -54,4 +54,11 @@ defmodule Integration.SlackTest do
     assert_response_contains "Sorry, you aren't allowed to execute 'operable:st-thorn $body' :(\n You will need at least one of the following permissions to run this command: 'operable:st-thorn'", after: message
   end
 
+  test "sending a message to a group", %{user: user} do
+    user |> with_permission("operable:echo")
+    private_channel = "group_ci_bot_testing"
+
+    message = send_message("@#{@bot}: operable:echo blah", private_channel)
+    assert_response "blah", [after: message], private_channel
+  end
 end


### PR DESCRIPTION
This allows the bot to both communicate and redirect messages to private channels (also known as groups in the API). Redirection also has some bugs, so I held off from writing a test for that until we rework that.

Fixes https://github.com/operable/cog/issues/973