### PR TITLE
get proper slack ids when redirecting

### DIFF
--- a/test/integration/slack_test.exs
+++ b/test/integration/slack_test.exs
@@ -61,4 +61,26 @@ defmodule Integration.SlackTest do
     message = send_message("@#{@bot}: operable:echo blah", private_channel)
     assert_response "blah", [after: message], private_channel
   end
+
+  test "redirecting from a private channel", %{user: user} do
+    user |> with_permission("operable:echo")
+    private_channel = "group_ci_bot_testing"
+
+    message = send_message("@#{@bot}: operable:echo blah > #ci_bot_testing", private_channel)
+    assert_response "blah", [after: message]
+  end
+
+  test "redirecting to 'here'", %{user: user} do
+    user |> with_permission("operable:echo")
+
+    message = send_message("@#{@bot}: operable:echo blah > here")
+    assert_response "blah", [after: message]
+  end
+
+  test "redirecting to a user", %{user: user} do
+    user |> with_permission("operable:echo")
+
+    message = send_message("@#{@bot}: operable:echo blah > @peck")
+    assert_response "blah", [after: message]
+  end
 end

--- a/test/support/adapters/slack/helpers.ex
+++ b/test/support/adapters/slack/helpers.ex
@@ -59,6 +59,8 @@ defmodule Cog.Adapters.Slack.Helpers do
         "https://slack.com/api/channels.history"
       "G" <> _ ->
         "https://slack.com/api/groups.history"
+      "D" <> _ ->
+        "https://slack.com/api/im.history"
     end
 
     params = %{channel: channel, oldest: oldest, count: count, token: token}


### PR DESCRIPTION
We weren't always getting the proper slack id when doing redirects. I think either the slack api or the lib that we are using changed. With this change we do a lookup when classifying ids in the connector, making sure to grab the correct identifier.

resolves #976 