### PR TITLE
Don't crash on slackbot messages

### DIFF
--- a/lib/cog/chat/slack/connector.ex
+++ b/lib/cog/chat/slack/connector.ex
@@ -201,26 +201,20 @@ defmodule Cog.Chat.Slack.Connector do
   end
 
   defp make_user(user) do
-    if user.is_bot do
+    # Slack doesn't set is_bot on slackbot messages :(
+    if user.is_bot or user.name == "slackbot" do
       %User{id: user.id,
-            first_name: user.name, #user.profile.first_name,
-            last_name: user.name, #user.profile.last_name,
+            first_name: user.name,
+            last_name: user.name,
             handle: user.name,
             provider: "slack"}
     else
-
-      # ACTUALLY IS BOT?!?!
-      #
-      # Is botci a bot or a user? If a user, do we just not have a
-      #name set?
-      #
-      # Does profile even have first_name / last_name, or just
-      #real_name, and real_name_normalized?
+      profile = user.profile
       %User{id: user.id,
-            first_name: user.name, #user.profile.first_name,
-            last_name: user.name, #user.profile.last_name,
+            first_name: Map.get(profile, :first_name, user.name),
+            last_name: Map.get(profile, :last_name, user.name),
             handle: user.name,
-            email: user.profile.email,
+            email: profile.email,
             provider: "slack"}
     end
   end


### PR DESCRIPTION
This commit changes the Slack provider to treat messages with either the `is_bot` flag set OR user.name == `slackbot` as coming from a bot user. This is an important distinction to make as these classes of messages have different fields. Using the wrong one can result in a process crash when a non-existent field is referenced.

The fix is based on inspection of strack traces from Cog instances encountering this problem on Slack. I haven't been able to figure out how to get Slack to generate these slackbot messages myself hence no additional tests.

This commit also fixes some wonky first_name, last_name handling behavior introduced in an earlier commit.

Fixes #982