### PR TITLE
Don't replace ids with names in redirects

### DIFF
--- a/test/integration/slack_test.exs
+++ b/test/integration/slack_test.exs
@@ -61,4 +61,26 @@ defmodule Integration.SlackTest do
     message = send_message("@#{@bot}: operable:echo blah", private_channel)
     assert_response "blah", [after: message], private_channel
   end
+
+  test "redirecting from a private channel", %{user: user} do
+    user |> with_permission("operable:echo")
+    private_channel = "group_ci_bot_testing"
+
+    message = send_message("@#{@bot}: operable:echo blah > #ci_bot_testing", private_channel)
+    assert_response "blah", [after: message]
+  end
+
+  test "redirecting to 'here'", %{user: user} do
+    user |> with_permission("operable:echo")
+
+    message = send_message("@#{@bot}: operable:echo blah > here")
+    assert_response "blah", [after: message]
+  end
+
+  test "redirecting to a user", %{user: user} do
+    user |> with_permission("operable:echo")
+
+    message = send_message("@#{@bot}: operable:echo blah > @peck")
+    assert_response "blah", [after: message]
+  end
 end


### PR DESCRIPTION
When a valid room name or user name is sent in a message slack replaces it with the channel or user id respectively. We take those ids, do a lookup, and then replacing the ids with the original room or user name at the very beginning of execution.

In general that's probably a good idea. I would think that command authors would expect to receive the name of the room or user in a command's text instead of an id. But in the case of redirects, it was causing some unforeseen side effects. When verifying destinations we never know if we will receive an id or a name. This is mostly due to the special keywords 'me' and 'here' which get replaced with their proper ids earlier during destination validation.

This PR skips lookups for redirects at the start of execution. Which should ensure that the pipeline destination module gets ids and can deal with lookup during redirect validation.

Note: There are a couple issues that still need to be dealt with regarding redirect validation. Namely passing a string like `@USER` will cause Cog to crash and passing a tring like `<@KJHKJ>` will cause Cog to return `...`. But I think those are issues that deserve a follow up PR.

resolves #976 