### PR TITLE
Bundle install via registry

### DIFF
--- a/lib/cog/bundle_registry.ex
+++ b/lib/cog/bundle_registry.ex
@@ -9,7 +9,14 @@ defmodule Cog.BundleRegistry do
       %HTTPotion.Response{status_code: 200, body: body} ->
         {:ok, Poison.decode!(body)}
       %HTTPotion.Response{status_code: 404} ->
-        {:error, "Bundle not found"}
+        case version do
+          "latest" ->
+            {:error, {:not_found, bundle}}
+          version ->
+            {:error, {:not_found, bundle, version}}
+        end
+      _ ->
+        {:error, :registry_error}
     end
   end
 end

--- a/lib/cog/bundle_registry.ex
+++ b/lib/cog/bundle_registry.ex
@@ -1,0 +1,15 @@
+defmodule Cog.BundleRegistry do
+  @registry_url "https://bundles.operable.io"
+
+  def get_config(bundle, version) do
+    headers = ["Accepts": "application/json"]
+    response = HTTPotion.get(@registry_url <> "/api/bundles/#{bundle}/#{version}", headers: headers)
+
+    case response do
+      %HTTPotion.Response{status_code: 200, body: body} ->
+        {:ok, Poison.decode!(body)}
+      %HTTPotion.Response{status_code: 404} ->
+        {:error, "Bundle not found"}
+    end
+  end
+end

--- a/lib/cog/commands/bundle.ex
+++ b/lib/cog/commands/bundle.ex
@@ -20,7 +20,7 @@ defmodule Cog.Commands.Bundle do
     "enable <bundle> [<version>]" => "Enable a specific version of an installed bundle",
     "disable <bundle>" => "Disable an installed bundle",
     "versions <bundle>" => "List all installed versions for a given bundle",
-    "install <bundle>[:<version>]" => "Install latest or specified version of bundle from registry"
+    "install <bundle> [<version>]" => "Install latest or specified version of bundle from registry"
   }
 
   permission "manage_commands"

--- a/lib/cog/commands/bundle.ex
+++ b/lib/cog/commands/bundle.ex
@@ -3,7 +3,7 @@ defmodule Cog.Commands.Bundle do
     bundle: Cog.Util.Misc.embedded_bundle
 
   alias Cog.Models.{Bundle, BundleVersion}
-  alias Cog.Commands.Bundle.{List, Versions, Info, Enable, Disable}
+  alias Cog.Commands.Bundle.{List, Versions, Info, Enable, Disable, Install}
 
   require Cog.Commands.Helpers, as: Helpers
   require Logger
@@ -19,13 +19,9 @@ defmodule Cog.Commands.Bundle do
     "info <bundle>" => "Detailed information on an installed bundle",
     "enable <bundle> [<version>]" => "Enable a specific version of an installed bundle",
     "disable <bundle>" => "Disable an installed bundle",
-    "versions <bundle>" => "List all installed versions for a given bundle"
+    "versions <bundle>" => "List all installed versions for a given bundle",
+    "install <bundle>[:<version>]" => "Install latest or specified version of bundle from registry"
   }
-
-  @notes """
-  Installation and uninstallation of bundles cannot currently be done via
-  chat; please use `cogctl` for this functionality.
-  """
 
   permission "manage_commands"
 
@@ -40,6 +36,7 @@ defmodule Cog.Commands.Bundle do
                "info"     -> Info.info(req, args)
                "disable"  -> Disable.disable(req, args)
                "enable"   -> Enable.enable(req, args)
+               "install"  -> Install.install(req, args)
                nil ->
                  if Helpers.flag?(req.options, "help") do
                    show_usage
@@ -78,6 +75,8 @@ defmodule Cog.Commands.Bundle do
     do: "Bundle #{inspect bundle_name} is already disabled."
   defp error(:invalid_invocation),
     do: "That is not a valid invocation of the bundle command"
+  defp error({:already_installed, bundle, version}),
+    do: "Bundle #{inspect bundle} with version #{inspect version} already installed."
   defp error(error),
     do: Helpers.error(error)
 

--- a/lib/cog/commands/bundle.ex
+++ b/lib/cog/commands/bundle.ex
@@ -74,9 +74,11 @@ defmodule Cog.Commands.Bundle do
   defp error({:already_disabled, %BundleVersion{bundle: %Bundle{name: bundle_name}}}),
     do: "Bundle #{inspect bundle_name} is already disabled."
   defp error(:invalid_invocation),
-    do: "That is not a valid invocation of the bundle command"
+    do: "That is not a valid invocation of the bundle command."
   defp error({:already_installed, bundle, version}),
     do: "Bundle #{inspect bundle} with version #{inspect version} already installed."
+  defp error(:registry_error),
+    do: "Bundle registry responded with an error."
   defp error(error),
     do: Helpers.error(error)
 

--- a/lib/cog/commands/bundle/install.ex
+++ b/lib/cog/commands/bundle/install.ex
@@ -1,6 +1,7 @@
 defmodule Cog.Commands.Bundle.Install do
   alias Cog.Repository.Bundles
   alias Cog.BundleRegistry
+  alias Cog.Models.BundleVersion
   require Cog.Commands.Helpers, as: Helpers
 
   Helpers.usage """
@@ -31,8 +32,10 @@ defmodule Cog.Commands.Bundle.Install do
                            "config_file" => config}
 
         case Bundles.install(revised_config) do
-          {:ok, bundle} ->
-            {:ok, "bundle-install", bundle}
+          {:ok, %BundleVersion{bundle: bundle} = bundle_version} ->
+            bundle = %{bundle | versions: [bundle_version]}
+            rendered = Cog.V1.BundlesView.render("show.json", %{bundle: bundle})
+            {:ok, "bundle-install", rendered[:bundle]}
           {:error, {:db_errors, [version: {"has already been taken", []}]}} ->
             {:error, {:already_installed, bundle, version}}
           {:error, error} ->

--- a/lib/cog/commands/bundle/install.ex
+++ b/lib/cog/commands/bundle/install.ex
@@ -38,13 +38,8 @@ defmodule Cog.Commands.Bundle.Install do
           {:error, error} ->
             {:error, error}
         end
-      {:error, _} ->
-        case version do
-          "latest" ->
-            {:error, {:not_found, bundle}}
-          version ->
-            {:error, {:not_found, bundle, version}}
-        end
+      {:error, error} ->
+        {:error, error}
     end
   end
 end

--- a/lib/cog/commands/bundle/install.ex
+++ b/lib/cog/commands/bundle/install.ex
@@ -1,0 +1,50 @@
+defmodule Cog.Commands.Bundle.Install do
+  alias Cog.Repository.Bundles
+  alias Cog.BundleRegistry
+  require Cog.Commands.Helpers, as: Helpers
+
+  Helpers.usage """
+  Install latest or specified version of bundle from registry.
+
+  USAGE
+    bundle install <bundle> [<version>]
+
+  ARGS
+    bundle   The name of a bundle
+    version  The version of a bundle
+
+  FLAGS
+    -h, --help  Display this usage info
+  """
+
+  def install(%{options: %{"help" => true}}, _args),
+    do: show_usage
+  def install(_req, []),
+    do: {:error, {:not_enough_args, 1}}
+  def install(req, [bundle]),
+    do: install(req, [bundle, "latest"])
+  def install(_req, [bundle, version]) do
+    case BundleRegistry.get_config(bundle, version) do
+      {:ok, %{"name" => name, "version" => version} = config} ->
+        revised_config = %{"name" => name,
+                           "version" => version,
+                           "config_file" => config}
+
+        case Bundles.install(revised_config) do
+          {:ok, bundle} ->
+            {:ok, "bundle-install", bundle}
+          {:error, {:db_errors, [version: {"has already been taken", []}]}} ->
+            {:error, {:already_installed, bundle, version}}
+          {:error, error} ->
+            {:error, error}
+        end
+      {:error, _} ->
+        case version do
+          "latest" ->
+            {:error, {:not_found, bundle}}
+          version ->
+            {:error, {:not_found, bundle, version}}
+        end
+    end
+  end
+end

--- a/priv/templates/embedded/bundle-install.greenbar
+++ b/priv/templates/embedded/bundle-install.greenbar
@@ -1,1 +1,3 @@
-Bundle "~$results[0].name~" version "~$results[0].version~" installed.
+~each var=$results~
+Bundle "~$item.name~" version "~$item.versions[0].version~" installed.
+~end~

--- a/priv/templates/embedded/bundle-install.greenbar
+++ b/priv/templates/embedded/bundle-install.greenbar
@@ -1,0 +1,1 @@
+Bundle "~$results[0].name~" version "~$results[0].version~" installed.

--- a/test/cog/chat/slack/templates/embedded/bundle_install_test.exs
+++ b/test/cog/chat/slack/templates/embedded/bundle_install_test.exs
@@ -3,7 +3,7 @@ defmodule Cog.Chat.Slack.Templates.Embedded.BundleInstallTest do
 
   test "bundle-info template" do
     data = %{"results" => [%{"name" => "heroku",
-                             "version" => "0.0.4"}]}
+                             "versions" => [%{"version" => "0.0.4"}]}]}
 
     expected = "Bundle \"heroku\" version \"0.0.4\" installed."
 

--- a/test/cog/chat/slack/templates/embedded/bundle_install_test.exs
+++ b/test/cog/chat/slack/templates/embedded/bundle_install_test.exs
@@ -1,0 +1,15 @@
+defmodule Cog.Chat.Slack.Templates.Embedded.BundleInstallTest do
+  use Cog.TemplateCase
+
+  test "bundle-info template" do
+    data = %{"results" => [%{"name" => "heroku",
+                             "version" => "0.0.4"}]}
+
+    expected = """
+    Bundle "heroku" version "0.0.4" installed.
+    """ |> String.strip
+
+    assert_rendered_template(:slack, :embedded, "bundle-install", data, expected)
+  end
+
+end

--- a/test/cog/chat/slack/templates/embedded/bundle_install_test.exs
+++ b/test/cog/chat/slack/templates/embedded/bundle_install_test.exs
@@ -5,9 +5,7 @@ defmodule Cog.Chat.Slack.Templates.Embedded.BundleInstallTest do
     data = %{"results" => [%{"name" => "heroku",
                              "version" => "0.0.4"}]}
 
-    expected = """
-    Bundle "heroku" version "0.0.4" installed.
-    """ |> String.strip
+    expected = "Bundle \"heroku\" version \"0.0.4\" installed."
 
     assert_rendered_template(:slack, :embedded, "bundle-install", data, expected)
   end

--- a/test/integration/commands/bundle_test.exs
+++ b/test/integration/commands/bundle_test.exs
@@ -61,4 +61,8 @@ defmodule Integration.Commands.BundleTest do
     assert_error_message_contains(response, "Unknown subcommand 'not-a-subcommand'")
   end
 
+  test "installing a bundle", %{user: user} do
+    [payload] = send_message(user, "@bot: operable:bundle install heroku 0.0.4")
+    assert %{name: "heroku", version: "0.0.4"} = payload
+  end
 end

--- a/test/integration/commands/bundle_test.exs
+++ b/test/integration/commands/bundle_test.exs
@@ -63,6 +63,6 @@ defmodule Integration.Commands.BundleTest do
 
   test "installing a bundle", %{user: user} do
     [payload] = send_message(user, "@bot: operable:bundle install heroku 0.0.4")
-    assert %{name: "heroku", version: "0.0.4"} = payload
+    assert %{name: "heroku", versions: [%{version: "0.0.4"}]} = payload
   end
 end


### PR DESCRIPTION
This adds support for installing a bundle via the registry.

Example:

```
@vanstee: !bundle install heroku
@cog: Bundle "heroku" version "0.0.4" installed.

@vanstee: !bundle install pagerduty 0.0.1
@cog: Bundle "pagerduty" version "0.0.1" installed.
```

I'll follow this up with a `bundle uninstall` subcommand as well.