### PR TITLE
Lookup room refactor

### DIFF
--- a/lib/cog/chat/provider.ex
+++ b/lib/cog/chat/provider.ex
@@ -12,7 +12,8 @@ defmodule Cog.Chat.Provider do
 
   @callback lookup_user(name :: String.t) :: {:ok, %User{}} | {:error, term}
 
-  @callback lookup_room(name :: String.t) :: {:ok, %Room{}} | {:error, term}
+  @callback lookup_room([name: String.t]) :: {:ok, %Room{}} | {:error, term}
+  @callback lookup_room([id: String.t]) :: {:ok, %Room{}} | {:error, term}
 
   @callback list_joined_rooms :: {:ok, [%Room{}] | []} | {:error, term}
 

--- a/lib/cog/chat/slack/provider.ex
+++ b/lib/cog/chat/slack/provider.ex
@@ -17,8 +17,10 @@ defmodule Cog.Chat.Slack.Provider do
     GenServer.start_link(__MODULE__, [config], name: __MODULE__)
   end
 
-  def lookup_room(id),
-    do: GenServer.call(__MODULE__, {:lookup_room, id}, :infinity)
+  def lookup_room({:id, id}),
+    do: GenServer.call(__MODULE__, {:lookup_room, {:id, id}}, :infinity)
+  def lookup_room({:name, name}),
+    do: GenServer.call(__MODULE__, {:lookup_room, {:name, name}}, :infinity)
 
   def lookup_user(handle) do
     GenServer.call(__MODULE__, {:lookup_user, handle}, :infinity)
@@ -49,8 +51,11 @@ defmodule Cog.Chat.Slack.Provider do
     {:ok, %__MODULE__{token: token, incoming: incoming, connector: pid, mbus: mbus}}
   end
 
-  def handle_call({:lookup_room, id}, _from, %__MODULE__{connector: connector, token: token}=state) do
+  def handle_call({:lookup_room, {:id, id}}, _from, %__MODULE__{connector: connector, token: token}=state) do
     {:reply, Connector.call(connector, token, :lookup_room, %{id: id}), state}
+  end
+  def handle_call({:lookup_room, {:name, name}}, _from, %__MODULE__{connector: connector, token: token}=state) do
+    {:reply, Connector.call(connector, token, :lookup_room, %{name: name}), state}
   end
 
   def handle_call({:lookup_user, handle}, _from, %__MODULE__{connector: connector, token: token}=state) do

--- a/lib/cog/command/pipeline/destination.ex
+++ b/lib/cog/command/pipeline/destination.ex
@@ -86,14 +86,14 @@ defmodule Cog.Command.Pipeline.Destination do
     # TODO: handle the pathological case of the sender ID not actually
     # resolving to a destination... also need to handle the case where
     # "me" isn't a recognized destination (e.g., for HTTP adapter)
-    {:ok, room} = Cog.Chat.Adapter.lookup_room(adapter, sender.id)
+    {:ok, room} = Cog.Chat.Adapter.lookup_room(adapter, id: sender.id)
     {:ok, %{dest | adapter: adapter, room: room}}
   end
   defp resolve_destination(%__MODULE__{raw: redir}=dest, _sender, _origin_room, origin_adapter) do
 
     {adapter, destination} = adapter_destination(redir, origin_adapter)
 
-    case Cog.Chat.Adapter.lookup_room(adapter, destination) do
+    case Cog.Chat.Adapter.lookup_room(adapter, name: destination) do
       {:error, reason} ->
         {:error, {reason, redir}}
       {:ok, room} ->

--- a/test/integration/slack_test.exs
+++ b/test/integration/slack_test.exs
@@ -56,7 +56,7 @@ defmodule Integration.SlackTest do
 
   test "sending a message to a group", %{user: user} do
     user |> with_permission("operable:echo")
-    private_channel = "group_ci_bot_testing"
+    private_channel = "#group_ci_bot_testing"
 
     message = send_message("@#{@bot}: operable:echo blah", private_channel)
     assert_response "blah", [after: message], private_channel

--- a/test/integration/slack_test.exs
+++ b/test/integration/slack_test.exs
@@ -61,4 +61,58 @@ defmodule Integration.SlackTest do
     message = send_message("@#{@bot}: operable:echo blah", private_channel)
     assert_response "blah", [after: message], private_channel
   end
+
+  test "redirecting from a private channel", %{user: user} do
+    user |> with_permission("operable:echo")
+    private_channel = "#group_ci_bot_testing"
+    marker = send_message("Redirect test starts here")
+
+    send_message("@#{@bot}: operable:echo blah > #ci_bot_testing", private_channel)
+    assert_response "blah", [after: marker]
+  end
+
+  test "redirecting to a private channel", %{user: user} do
+    user |> with_permission("operable:echo")
+    private_channel = "#group_ci_bot_testing"
+    marker = send_message("Redirect test starts here", private_channel)
+
+    send_message("@#{@bot}: operable:echo blah > #{private_channel}")
+    assert_response "blah", [after: marker], private_channel
+  end
+
+  test "redirecting to 'here'", %{user: user} do
+    user |> with_permission("operable:echo")
+
+    message = send_message("@#{@bot}: operable:echo blah > here")
+    assert_response "blah", [after: message]
+  end
+
+  test "redirecting to 'me'", %{user: user} do
+    user |> with_permission("operable:echo")
+    marker = send_message("echo here", "@#{@user}")
+
+    send_message("@#{@bot}: operable:echo blah > me")
+    # Since Cog responds when direct messaging it we have to assert
+    # that both our marker text and message test exist.
+    assert_response "here\nblah", [after: marker, count: 2], "@#{@user}"
+  end
+
+  test "redirecting to a specific user", %{user: user} do
+    user |> with_permission("operable:echo")
+    marker = send_message("echo here", "@#{@user}")
+
+    send_message("@#{@bot}: operable:echo blah > @#{@user}")
+    # Since Cog responds when direct messaging it we have to assert
+    # that both our marker text and message test exist.
+    assert_response "here\nblah", [after: marker, count: 2], "@#{@user}"
+  end
+
+  test "redirecting to another channel", %{user: user} do
+    user |> with_permission("operable:echo")
+    redirect_channel = "#ci_bot_redirect_tests"
+    marker = send_message("echo here", redirect_channel)
+
+    send_message("@#{@bot}: operable:echo blah > #{redirect_channel}")
+    assert_response "blah", [after: marker], redirect_channel
+  end
 end

--- a/test/support/adapters/slack/helpers.ex
+++ b/test/support/adapters/slack/helpers.ex
@@ -3,7 +3,7 @@ defmodule Cog.Adapters.Slack.Helpers do
 
   require Logger
   @bot_handle "deckard"
-  @room "ci_bot_testing"
+  @room "#ci_bot_testing"
   @interval 1000 # 1 second
   @timeout 120000 # 2 minutes
 
@@ -52,7 +52,7 @@ defmodule Cog.Adapters.Slack.Helpers do
   def retrieve_last_message(room: room, oldest: oldest),
     do: retrieve_last_message(room: room, oldest: oldest, count: 1)
   def retrieve_last_message(room: room, oldest: oldest, count: count) do
-    {:ok, %{id: channel}} = Cog.Chat.Adapter.lookup_room("slack", room)
+    {:ok, %{id: channel}} = Cog.Chat.Adapter.lookup_room("slack", name: room)
 
     url = case channel do
       "C" <> _ ->
@@ -69,7 +69,7 @@ defmodule Cog.Adapters.Slack.Helpers do
   end
 
   def send_message(message, room \\ @room) do
-    {:ok, %{id: channel}} = Cog.Chat.Adapter.lookup_room("slack", room)
+    {:ok, %{id: channel}} = Cog.Chat.Adapter.lookup_room("slack", name: room)
 
     url = "https://slack.com/api/chat.postMessage"
     params = %{channel: channel, text: message, as_user: true,
@@ -82,7 +82,7 @@ defmodule Cog.Adapters.Slack.Helpers do
   end
 
   def send_edited_message(message, initial_message \\ "FOO3rjha92") do
-    {:ok, %{id: channel}} = Cog.Chat.Adapter.lookup_room("slack", @room)
+    {:ok, %{id: channel}} = Cog.Chat.Adapter.lookup_room("slack", name: @room)
     initial_response = send_message(initial_message)
     url = "https://slack.com/api/chat.update"
     params = %{channel: channel, ts: initial_response["ts"], text: message, parse: "full", as_user: true, token: token}

--- a/test/support/adapters/slack/helpers.ex
+++ b/test/support/adapters/slack/helpers.ex
@@ -59,6 +59,8 @@ defmodule Cog.Adapters.Slack.Helpers do
         "https://slack.com/api/channels.history"
       "G" <> _ ->
         "https://slack.com/api/groups.history"
+      "D" <> _ ->
+        "https://slack.com/api/im.history"
     end
 
     params = %{channel: channel, oldest: oldest, count: count, token: token}

--- a/test/support/test_provider.ex
+++ b/test/support/test_provider.ex
@@ -37,15 +37,21 @@ defmodule Cog.Chat.Test.Provider do
                    email: handle}
   end
 
-  def lookup_room("user1") do
+  def lookup_room({:id, "user1"}) do
     %Cog.Chat.Room{id: "user1_dm",
                    name: "user1",
                    provider: @provider_name,
                    is_dm: true}
   end
-  def lookup_room(identifier) do
-    %Cog.Chat.Room{id: identifier,
-                   name: identifier,
+  def lookup_room({:id, id}) do
+    %Cog.Chat.Room{id: id,
+                   name: id,
+                   provider: @provider_name,
+                   is_dm: false}
+  end
+  def lookup_room({:name, name}) do
+    %Cog.Chat.Room{id: name,
+                   name: name,
                    provider: @provider_name,
                    is_dm: false}
   end


### PR DESCRIPTION
This changes the `Cog.Chat.Adapter.lookup_room` function to take a keyword list as it's second argument containing either `[id: id]` or `[name: name]`. Making the call more explicit should help simplify the lookup room logic in the adapter.

resolves #976 

TODO:
 - [x] update tests
 - [x] add some tests for redirection