### PR TITLE
serialize maps and lists when passed to echo

### DIFF
--- a/lib/cog/commands/echo.ex
+++ b/lib/cog/commands/echo.ex
@@ -8,5 +8,13 @@ defmodule Cog.Commands.Echo do
   rule "when command is #{Cog.Util.Misc.embedded_bundle}:echo allow"
 
   def handle_message(req, state),
-    do: {:reply, req.reply_to, Enum.join(req.args, " "), state}
+    do: {:reply, req.reply_to, Enum.map_join(req.args, " ", &serialize/1), state}
+
+  # We should only have to worry about maps and lists here. Anything else
+  # we might get should implement 'to_string'.
+  defp serialize(val) when is_map(val) or is_list(val),
+    do: Poison.encode!(val)
+  defp serialize(val),
+    do: to_string(val)
+
 end

--- a/test/integration/commands/echo_test.exs
+++ b/test/integration/commands/echo_test.exs
@@ -12,4 +12,9 @@ defmodule Integration.Commands.EchoTest do
     response = send_message(user, "@bot: operable:echo this is nifty")
     assert response == "this is nifty"
   end
+
+  test "serializes json when it's passed", %{user: user} do
+    response = send_message(user, ~s(@bot: seed '{"foo": {"bar": "baz"}}' | echo $foo))
+    assert response == %{bar: "baz"}
+  end
 end


### PR DESCRIPTION
echo was causing Cog to crash whenever it received a value that didn't implement `to_string`, ie maps and lists. This change serializes those types with `Poison.encode!`.

resolves #981 