### PR TITLE
Make sure we pull in the description and long_description

### DIFF
--- a/lib/cog/repository/bundles.ex
+++ b/lib/cog/repository/bundles.ex
@@ -622,7 +622,7 @@ defmodule Cog.Repository.Bundles do
   end
 
   defp new_version!(bundle, params) do
-    params = Map.merge(params, Map.take(params["config_file"], ["author", "homepage"]))
+    params = Map.merge(params, Map.take(params["config_file"], ["description", "long_description", "author", "homepage"]))
 
     bundle
     |> Ecto.build_assoc(:versions)


### PR DESCRIPTION
Not really sure how this ever worked, but I noticed that bundle description and long_description attributes weren't being pulled in during install.