### PR TITLE
use the slack id for the mention name instead of the user handle

### DIFF
--- a/lib/cog/chat/slack/provider.ex
+++ b/lib/cog/chat/slack/provider.ex
@@ -17,6 +17,17 @@ defmodule Cog.Chat.Slack.Provider do
     GenServer.start_link(__MODULE__, [config], name: __MODULE__)
   end
 
+  def mention_name(handle) do
+    # Lookup the user and return the id properly formatted instead of just the
+    # handle. If we just return the handle slack doesn't always recognize the
+    # handle and alert the user. For example, when you return the mention name
+    # followed by a colon.
+    case lookup_user(handle) do
+      %Cog.Chat.User{id: id} -> "<@#{id}>"
+      _ -> super(handle)
+    end
+  end
+
   def lookup_room({:id, id}),
     do: GenServer.call(__MODULE__, {:lookup_room, {:id, id}}, :infinity)
   def lookup_room({:name, name}),

--- a/test/integration/slack_registration_test.exs
+++ b/test/integration/slack_registration_test.exs
@@ -14,7 +14,7 @@ defmodule Integration.SlackRegistrationTest do
 
   test "executing a command without a registered handle" do
     message = send_message("@#{@bot}: operable:echo If only Cog could automatically register me!")
-    assert_response("@#{@user}: I'm terribly sorry, but either I don't have a Cog account for you, or your Slack chat handle has not been registered. Currently, only registered users can interact with me.\n\nYou'll need to ask a Cog administrator to fix this situation and to register your Slack handle.",
+    assert_response("#{mention_name(@user)}: I'm terribly sorry, but either I don't have a Cog account for you, or your Slack chat handle has not been registered. Currently, only registered users can interact with me.\n\nYou'll need to ask a Cog administrator to fix this situation and to register your Slack handle.",
                     after: message)
   end
 
@@ -24,7 +24,7 @@ defmodule Integration.SlackRegistrationTest do
 
     # We should get a confirmation message, as well as the actual
     # output of the command
-    assert_response("@#{@user}: Hello #{@user}! It's great to meet you! You're the proud owner of a shiny new Cog account named '#{@user}'.\nYay, I autoregistered!",
+    assert_response("#{mention_name(@user)}: Hello #{@user}! It's great to meet you! You're the proud owner of a shiny new Cog account named '#{@user}'.\nYay, I autoregistered!",
                     after: message,
                     count: 2)
   end
@@ -49,7 +49,7 @@ defmodule Integration.SlackRegistrationTest do
 
     # We should get a confirmation message, as well as the actual
     # output of the command
-    assert_response("@#{@user}: Hello #{@user}! It's great to meet you! You're the proud owner of a shiny new Cog account named '#{expected_username}'.\nI am slow but I get there eventually",
+    assert_response("#{mention_name(@user)}: Hello #{@user}! It's great to meet you! You're the proud owner of a shiny new Cog account named '#{expected_username}'.\nI am slow but I get there eventually",
                      after: message,
                      count: 2)
 
@@ -71,7 +71,7 @@ defmodule Integration.SlackRegistrationTest do
     Enum.each(1..max, &user("#{@user}_#{&1}"))
 
     message = send_message("@#{@bot}: operable:echo alas it was not meant to be")
-    assert_response("@#{@user}: Unfortunately I was unable to automatically create a Cog account for your Slack chat handle. Only users with Cog accounts can interact with me.\n\nYou'll need to ask a Cog administrator to investigate the situation and set up your account.",
+    assert_response("#{mention_name(@user)}: Unfortunately I was unable to automatically create a Cog account for your Slack chat handle. Only users with Cog accounts can interact with me.\n\nYou'll need to ask a Cog administrator to investigate the situation and set up your account.",
                     after: message)
   end
 

--- a/test/integration/slack_test.exs
+++ b/test/integration/slack_test.exs
@@ -23,7 +23,7 @@ defmodule Integration.SlackTest do
     user |> with_permission("operable:st-echo")
 
     message = send_edited_message("@#{@bot}: operable:st-echo test")
-    assert_edited_response "@#{@user} Executing edited command 'operable:st-echo test'\ntest", after: message
+    assert_edited_response "#{mention_name(@user)} Executing edited command 'operable:st-echo test'\ntest", after: message
   end
 
   test "running the st-echo command", %{user: user} do

--- a/test/support/adapters/slack/helpers.ex
+++ b/test/support/adapters/slack/helpers.ex
@@ -7,6 +7,11 @@ defmodule Cog.Adapters.Slack.Helpers do
   @interval 1000 # 1 second
   @timeout 120000 # 2 minutes
 
+  def mention_name(handle) do
+    {:ok, mention_name} = Cog.Chat.Adapter.mention_name("slack", handle)
+    mention_name
+  end
+
   # keyword args:
   #   after: the last Slack message sent; you only want to look at
   #          responses that came in after this one. Required argument.


### PR DESCRIPTION
Returning the slack id of the user instead of the handle causes Slack to treat the output more predictably. Characters around the mention name don't cause Slack to not recognize the user's handle.

resolves #944 

TODO:
 - [x] Fix tests