### PR TITLE
Adds an optional config section to the help ouput for bundles

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -61,7 +61,7 @@
   "probe": {:git, "https://github.com/operable/probe.git", "f2197509f01922a28219ab47af4e5c6324f47ac6", []},
   "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []},
   "slack": {:git, "https://github.com/operable/Elixir-Slack.git", "a0dae7d46a10f9d7e7924a1c8fe5cef17b7cfb82", [branch: "allow-attachments"]},
-  "spanner": {:git, "https://github.com/operable/spanner.git", "d336e5b63afe8ca4e66d9cc8c476413d5edcf53a", []},
+  "spanner": {:git, "https://github.com/operable/spanner.git", "8fc1847ab4e5c3120a7e654081ea0071a92d5d96", []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
   "table_rex": {:hex, :table_rex, "0.8.3", "1c68dfc6886d6f118f5047b0449d6402ae0ac5709064789e578c2f4659f4064b", [:mix], []},
   "uuid": {:hex, :uuid, "1.1.3", "06ca38801a1a95b751701ca40716bb97ddf76dfe7e26da0eec7dba636740d57a", [:mix], []},

--- a/priv/templates/embedded/help-bundle.greenbar
+++ b/priv/templates/embedded/help-bundle.greenbar
@@ -12,6 +12,22 @@ __Description__
 ~br~
 ~end~
 
+~if cond=$bundle.config_file.config~
+__Configuration__
+~br~
+
+~if cond=$bundle.config_file.config.notes~
+~$bundle.config_file.config.notes~
+~br~
+~end~
+
+~each var=$bundle.config_file.config.env as=env_var~
+* ~$env_var.var~~if cond=$env_var.description~ - ~$env_var.description~~end~
+
+~end~
+~br~
+~end~
+
 ~if cond=$bundle.commands not_empty?~
 __Commands__
 ~br~

--- a/test/cog/chat/slack/templates/embedded/help_bundle_test.exs
+++ b/test/cog/chat/slack/templates/embedded/help_bundle_test.exs
@@ -8,6 +8,13 @@ defmodule Cog.Chat.Slack.Templates.Embedded.HelpBundleTest do
                              "commands" => [%{"name" => "test-command",
                                               "description" => "does just one thing"}],
                              "author" => "vanstee",
+                             "config_file" => %{
+                               "config" => %{
+                                 "notes" => "Some notes about config",
+                                 "env" => [%{"var" => "VAR1", "description" => "description1"},
+                                           %{"var" => "VAR2"}]
+                               }
+                             },
                              "homepage" => "test-bundle.com"}]}
 
 
@@ -19,6 +26,13 @@ defmodule Cog.Chat.Slack.Templates.Embedded.HelpBundleTest do
     *Description*
 
     No really, it does a thing
+
+    *Configuration*
+
+    Some notes about config
+
+    • VAR1 - description1
+    • VAR2
 
     *Commands*
 


### PR DESCRIPTION
This adds an optional config section to the help output for bundles. The section contains notes and a list of env vars. Both notes and env vars are optional.

Note that I didn't add the config section info to the bundle version model. I'm just pulling straight from the config file in the template. Since the data was already available in the config file and it's not used anywhere else right now, I figured that was the easiest solution.

Example config.yaml excert:
```
...
config:
  notes:
    The cfn bundle makes use of CloudFormation stack templates and stack policies that are
    defined in JSON documents and stored in pre-defined S3 locations. These locations are
    defined with the 'CFN_TEMPLATE_URL' and 'CFN_POLICY_URL' configuration variables.
  env:
    - var: AWS_REGION
    - var: AWS_ACCESS_KEY_ID
    - var: AWS_SECRET_ACCESS_KEY
    - var: AWS_STS_ROLE_ARN
      description: STS role ARN that should be assumed. Defined as 'arn:aws:iam::<account_number>:role/<role_name>'.
    - var: CFN_TEMPLATE_URL
      description: S3 Location of your stack templates. Defined as 's3://<bucket>/<path>'.
    - var: CFN_POLICY_URL
      description: S3 Location of your stack policies. Defined as 's3://<bucket>/<path>'.
...
```

Help output:
<img width="1108" alt="screen shot 2016-10-05 at 12 46 15 pm" src="https://cloud.githubusercontent.com/assets/47858/19122717/babc6610-8af9-11e6-852a-652d6d84e8df.png">

resolves #948 
depends on https://github.com/operable/spanner/pull/77