### PR TITLE
add env var for enabling a chat provider - WIP

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -25,6 +25,10 @@ config :cog, :embedded_bundle_version, "0.13.0"
 config :cog, Cog.Chat.Http.Provider,
   foo: "blah"
 
+config :cog, Cog.Chat.Adapter,
+  providers: provider_list(),
+  chat: enabled_chat_provider()
+
 config :cog, :enable_spoken_commands, ensure_boolean(System.get_env("ENABLE_SPOKEN_COMMANDS")) || true
 
 config :cog, :message_bus,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -10,10 +10,7 @@ config :lager, :handlers,
 config :cog, :enable_spoken_commands, ensure_boolean(System.get_env("ENABLE_SPOKEN_COMMANDS")) || false
 
 config :cog, Cog.Chat.Adapter,
-  providers: [slack: Cog.Chat.Slack.Provider,
-              http: Cog.Chat.Http.Provider],
-  cache_ttl: {1, :sec},
-  chat: :slack
+  cache_ttl: {1, :sec}
 
 config :cog, Cog.Endpoint,
   debug_errors: true,

--- a/config/helpers.exs
+++ b/config/helpers.exs
@@ -28,7 +28,7 @@ defmodule Cog.Config.Helpers do
 
   # Returns a list containing the enabled chat provider and all other providers.
   def provider_list,
-    do: [Enum.find(@chat_providers, hd(@chat_providers), &enabled_provider?/1)] ++ @other_providers
+    do: [Enum.find(@chat_providers, &enabled_provider?/1)] ++ @other_providers
 
   def enabled_chat_provider do
     # I'm using filter here so we can give some feedback to the user if they don't
@@ -36,7 +36,7 @@ defmodule Cog.Config.Helpers do
     case Enum.filter(@chat_providers, &enabled_provider?/1) do
       [] ->
         # No provider specified.
-        raise("No chat provider specified.")
+        if Mix.env == :test, do: :test, else: raise("No chat provider specified.")
       [{provider, _module}] ->
         provider
       _ ->

--- a/config/helpers.exs
+++ b/config/helpers.exs
@@ -1,4 +1,11 @@
 defmodule Cog.Config.Helpers do
+
+  # List of available chat providers. Only one can be enabled at a time.
+  @chat_providers [slack: Cog.Chat.Slack.Provider,
+                   hipchat: Cog.Chat.HipChat.Provider]
+  # Other providers. These are all enabled.
+  @other_providers [http: Cog.Chat.Http.Provider]
+
   def data_dir do
     System.get_env("COG_DATA_DIR") || Path.expand(Path.join([Path.dirname(__ENV__.file), "..", "data"]))
   end
@@ -12,13 +19,42 @@ defmodule Cog.Config.Helpers do
   def ensure_integer(ttl) when is_integer(ttl), do: ttl
 
   def ensure_boolean(nil), do: nil
+  def ensure_boolean(value) when is_boolean(value), do: value
   def ensure_boolean(value) when is_binary(value) do
     value
     |> String.downcase
     |> string_to_boolean
   end
 
+  # Returns a list containing the enabled chat provider and all other providers.
+  def provider_list,
+    do: [Enum.find(@chat_providers, hd(@chat_providers), &enabled_provider?/1)] ++ @other_providers
+
+  def enabled_chat_provider do
+    # I'm using filter here so we can give some feedback to the user if they don't
+    # specify a provider or they specify multiple providers.
+    case Enum.filter(@chat_providers, &enabled_provider?/1) do
+      [] ->
+        # No provider specified.
+        raise("No chat provider specified.")
+      [{provider, _module}] ->
+        provider
+      _ ->
+        # Multiple providers were specified.
+        raise("Multiple chat providers were specified. You can only enable one provider at a time.")
+    end
+  end
+
   defp string_to_boolean("true"), do: true
   defp string_to_boolean(_), do: false
+
+  defp provider_var(provider) when is_atom(provider),
+    do: "COG_" <> (Atom.to_string(provider) |> String.upcase) <> "_ENABLED"
+
+  defp enabled_provider?({provider, _module}) do
+    provider_var(provider)
+    |> System.get_env
+    |> ensure_boolean
+  end
 
 end

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -10,6 +10,4 @@ config :comeonin,
   bcrypt_log_rounds: 14
 
 config :cog, Cog.Chat.Adapter,
-  providers: [slack: Cog.Chat.Slack.Provider],
-  chat: :slack,
   cache_ttl: {60, :sec}


### PR DESCRIPTION
@kevsmith I may be oversimplifying but could we do something like this make it easier to enable providers?

Adds an env var `COG_CHAT_PROVIDER` that can be set to "slack" or "hipchat" to enable either provider. Defaults to "slack".