### PR TITLE
Allow the bot to respond in HipChat DMs

### DIFF
--- a/lib/cog/chat/hipchat/util.ex
+++ b/lib/cog/chat/hipchat/util.ex
@@ -24,7 +24,12 @@ defmodule Cog.Chat.HipChat.Util do
             if message.body == nil or message.body == "" do
               :ignore
             else
-              {:dm, message.from.full, message.body}
+              case parse_jid(message.from.full) do
+                nil ->
+                  :ignore
+                {jid, _resource} ->
+                  {:dm, jid, message.body}
+              end
             end
           true ->
             :ignore

--- a/lib/cog/chat/hipchat/util.ex
+++ b/lib/cog/chat/hipchat/util.ex
@@ -24,12 +24,8 @@ defmodule Cog.Chat.HipChat.Util do
             if message.body == nil or message.body == "" do
               :ignore
             else
-              case parse_jid(message.from.full) do
-                nil ->
-                  :ignore
-                {jid, _resource} ->
-                  {:dm, jid, message.body}
-              end
+              jid = parse_dm_jid(message.from.full)
+              {:dm, jid, message.body}
             end
           true ->
             :ignore
@@ -85,4 +81,9 @@ defmodule Cog.Chat.HipChat.Util do
     end
   end
 
+  defp parse_dm_jid(jid) do
+    jid
+    |> String.split("/", parts: 2)
+    |> List.first
+  end
 end

--- a/test/support/hipchat_client.ex
+++ b/test/support/hipchat_client.ex
@@ -73,7 +73,7 @@ defmodule Cog.Test.Support.HipChatClient do
                 {user, users} = Users.lookup(state.users, state.conn, jid: sender_jid)
                 state = %{state | users: users}
                 handle_dm(user.mention_name, body, state)
-               :ignore ->
+              :ignore ->
                 state
             end
     {:noreply, state}


### PR DESCRIPTION
We weren't parsing out the jid from the stanza from attribute (ex: `479543_3152608@chat.hipchat.com/web||proxy|proxy-c410.hipchat.com|5252`) which resulted in us not being able to find the user in our local user cache so we ignored the message. Was a simple fix to parse out the jid.

Fixes #1053