### PR TITLE
All MQTT connections have usernames and passwords

### DIFF
--- a/lib/cog.ex
+++ b/lib/cog.ex
@@ -13,6 +13,8 @@ defmodule Cog do
   end
 
   def start(_type, _args) do
+    Application.put_env(:cog, :message_queue_password, gen_password(64))
+
     maybe_display_unenforcing_warning()
     children = [worker(Cog.BusDriver, [], shutdown: 1000),
                 worker(Cog.Repo, []),
@@ -100,6 +102,13 @@ defmodule Cog do
       _ ->
         :ok
     end
+  end
+
+  # Generate a random string `length` characters long
+  defp gen_password(length) do
+    :crypto.strong_rand_bytes(length)
+    |> Base.encode64
+    |> binary_part(0, length)
   end
 
 end

--- a/lib/cog/util/misc.ex
+++ b/lib/cog/util/misc.ex
@@ -12,6 +12,10 @@ defmodule Cog.Util.Misc do
   @doc "The name of the admin group."
   def admin_group, do: "cog-admin"
 
+  @doc "Username that all Cog-initiated message queue connections use"
+  def internal_mq_username,
+    do: "COG_INTERNAL"
+
   ########################################################################
   # Adapter Resolution Functions
 

--- a/priv/config/ssl_mqtt.exs
+++ b/priv/config/ssl_mqtt.exs
@@ -1,7 +1,5 @@
 use Mix.Config
 
-use Mix.Config
-
 config :emqttd, :listeners,
   [{mqtt_type, mqtt_port,
     [acceptors: 8,


### PR DESCRIPTION
Previously, only connections coming from Relays had usernames and
passwords associated with them; any connection from Cog itself had
neither. We would distinguish between them by examining which host the
connection was coming from; if it was 127.0.0.1, we treated it like it
was a Cog connection, and like a Relay connection (which needed to be
authenticated) otherwise.

This would cause Cog to crash if a Relay process was running on the same
host as Cog, and if it tried to connect prior to being registered with
Cog.

Now, _all_ connections have a username and password associated with
them. All Cog-initiated connections have a username of `COG_INTERNAL`,
and use a randomly-generated password that is generated at Cog startup,
allowing us to properly distinguish between Cog connections and Relay
connections.

Fixes #1034