### PR TITLE
build image with erlang 19.1 and elixir 1.3.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,20 @@ ENV MIX_ENV ${MIX_ENV:-dev}
 RUN apk update -U && apk add bash ca-certificates curl git openssl postgresql-client
 
 # Install Erlang
-RUN apk update -U && \
-    apk add `apk search erlang | grep -E "cos|eldap|gs|mibs|snmp|common-test|jinterface|megaco|diameter|odbc|observer|orber|test-server" -v | sed "s/-18.3.2-r0//g"`
+#RUN apk update -U && \
+    #apk add `apk search erlang | grep -E "cos|eldap|gs|mibs|snmp|common-test|jinterface|megaco|diameter|odbc|observer|orber|test-server" -v | sed "s/-18.3.2-r0//g"`
 
-# Install Elixir 1.3.1
-RUN wget https://github.com/elixir-lang/elixir/releases/download/v1.3.1/Precompiled.zip && \
+# install Erlang 19.1
+COPY ./scripts/install_erlang .
+RUN apk update -U && \
+    apk add gcc g++ make perl-dev zlib-dev ncurses-dev openssl-dev openjdk7 unixodbc-dev && \
+    ./install_erlang && \
+    apk del gcc g++ perl-dev zlib-dev ncurses-dev openssl-dev openjdk7 unixodbc-dev && \
+    rm install_erlang && \
+    rm -f /var/cache/apk/*
+
+# Install Elixir 1.3.4
+RUN wget https://github.com/elixir-lang/elixir/releases/download/v1.3.4/Precompiled.zip && \
     unzip -d /usr/local Precompiled.zip && rm -f /usr/local/bin/*.bat && rm -f Precompiled.zip
 
 # Setup Operable user. UID/GID default to 60000 but can be overriden.

--- a/scripts/install_erlang
+++ b/scripts/install_erlang
@@ -1,0 +1,18 @@
+#!/bin/sh -x
+
+set -e
+
+ERLANG_SOURCE="otp_src_19.1"
+
+wget "http://erlang.org/download/$ERLANG_SOURCE.tar.gz"
+tar -xzf $ERLANG_SOURCE.tar.gz
+
+cd $ERLANG_SOURCE
+
+./otp_build remove_prebuilt_files
+./configure && make && make install
+
+cd ..
+
+rm -rf $ERLANG_SOURCE
+rm $ERLANG_SOURCE.tar.gz


### PR DESCRIPTION
Probably want to hold off on this until we get the build stuff worked out. But this updates elixir and erlang in the docker image. Unfortunately there isn't a package for erlang 19.1 on alpine:3.4, which is what the image is based on, so we're building erlang from scratch. This also has the side effect of increasing the image size by about 100MB.