### PR TITLE
return an error tuple instead of nil when a slack user isn't found

### DIFF
--- a/lib/cog/chat/slack/connector.ex
+++ b/lib/cog/chat/slack/connector.ex
@@ -275,37 +275,41 @@ defmodule Cog.Chat.Slack.Connector do
     if user == state.me.id do
       :ignore
     else
-      user = lookup_user(user, state.users, by: :id)
-      {:chat_event, %{type: "presence_change", user: user, presence: presence, provider: "slack"}}
+      case lookup_user(user, state.users, by: :id) do
+        {:ok, user} ->
+          {:chat_event, %{type: "presence_change", user: user, presence: presence, provider: "slack"}}
+        {:error, :not_found} ->
+          :ignore
+      end
     end
   end
   defp annotate(_, _), do: :ignore
 
   defp annotate_message(%{channel: channel, user: userid, text: text}, state) do
     text = Formatter.unescape(text, state)
-    user = lookup_user(userid, state.users, by: :id)
 
-    if user == nil do
-      Logger.info("Failed looking up user '#{userid}'.")
-      :ignore
-    else
-      room = case channel_type(channel) do
-        :room ->
-          lookup_room(channel, state.channels, by: :id)
-        :group ->
-          lookup_room(channel, state.groups, by: :id)
-        :dm ->
-          lookup_dm(userid, state.users)
-      end
-
-      if room == nil do
-        Logger.info("Failed looking up channel '#{channel}'.")
+    case lookup_user(userid, state.users, by: :id) do
+      {:error, :not_found} ->
+        Logger.info("Failed looking up user '#{userid}'.")
         :ignore
-      else
-        {:chat_message, %Message{id: Cog.Events.Util.unique_id,
-            room: room, user: user, text: text, provider: @provider_name,
-            bot_name: "@#{state.me.name}", edited: false}}
-      end
+      {:ok, user} ->
+        room = case channel_type(channel) do
+          :room ->
+            lookup_room(channel, state.channels, by: :id)
+          :group ->
+            lookup_room(channel, state.groups, by: :id)
+          :dm ->
+            lookup_dm(userid, state.users)
+        end
+
+        if room == nil do
+          Logger.info("Failed looking up channel '#{channel}'.")
+          :ignore
+        else
+          {:chat_message, %Message{id: Cog.Events.Util.unique_id,
+              room: room, user: user, text: text, provider: @provider_name,
+              bot_name: "@#{state.me.name}", edited: false}}
+        end
     end
   end
 

--- a/lib/cog/chat/slack/connector.ex
+++ b/lib/cog/chat/slack/connector.ex
@@ -169,10 +169,16 @@ defmodule Cog.Chat.Slack.Connector do
   end
 
   defp lookup_user(value, users, [by: :id]) do
-    Enum.reduce_while(users, nil, &(user_by_id(value, &1, &2)))
+    case Enum.reduce_while(users, nil, &(user_by_id(value, &1, &2))) do
+      nil -> {:error, :not_found}
+      user -> {:ok, user}
+    end
   end
   defp lookup_user(value, users, [by: :handle]) do
-    Enum.reduce_while(users, nil, &(user_by_name(value, &1, &2)))
+    case Enum.reduce_while(users, nil, &(user_by_name(value, &1, &2))) do
+      nil -> {:error, :not_found}
+      user -> {:ok, user}
+    end
   end
 
   defp lookup_dm(value, dms) do

--- a/lib/cog/chat/slack/provider.ex
+++ b/lib/cog/chat/slack/provider.ex
@@ -28,7 +28,7 @@ defmodule Cog.Chat.Slack.Provider do
     # handle and alert the user. For example, when you return the mention name
     # followed by a colon.
     case lookup_user(handle) do
-      %Cog.Chat.User{id: id} -> "<@#{id}>"
+      {:ok, %Cog.Chat.User{id: id}} -> "<@#{id}>"
       _ -> super(handle)
     end
   end


### PR DESCRIPTION
If a slack user wasn't found we returned `nil` instead of an `{:error, :not_found}` tuple. This caused Cog to crash when calling `User.from_map/1` in `Cog.Chat.Adapter`. HipChat already returns a tuple so everything is groovy there.

resolves #1049 