### PR TITLE
explicitly pass the 'raw' template for the 'raw' command

### DIFF
--- a/lib/cog/commands/raw.ex
+++ b/lib/cog/commands/raw.ex
@@ -22,7 +22,11 @@ defmodule Cog.Command.Raw do
 
   def handle_message(%Command{cog_env: nil}=req, state),
     do: {:reply, req.reply_to, "nil", state}
+  # Note we specify the "raw" template here. This is the template located at
+  # priv/templates/embedded/raw. We do this so commands that return an object
+  # like {"body": ["list", "of", "strings"]} won't get caught by the fallback
+  # logic and rendered as text.
   def handle_message(req, state),
-    do: {:reply, req.reply_to, req.cog_env, state}
+    do: {:reply, req.reply_to, "raw", req.cog_env, state}
 
 end

--- a/priv/templates/embedded/raw.greenbar
+++ b/priv/templates/embedded/raw.greenbar
@@ -1,0 +1,6 @@
+# This template is used explicitly when the 'raw' command is called. This allows
+# us to render the entire json object, {"body": ["text"]}, for commands piped in
+# that normally just render text.
+# This is necessary for commands that return an object like {"body": ["list", "of", "strings"]}
+# to prevent the fallback logic from rendering it with the text template.
+~json var=$results~

--- a/test/cog/chat/hipchat/templates/embedded/raw_test.exs
+++ b/test/cog/chat/hipchat/templates/embedded/raw_test.exs
@@ -1,0 +1,16 @@
+defmodule Cog.Chat.HipChat.Templates.Embedded.RawTest do
+  use Cog.TemplateCase
+
+  test "raw renders properly even when the return contains a body tag" do
+    data = %{"results" => [%{"body" => ["bar"]}]}
+    expected = "<pre>[\n  {\n    \"body\": [\n      \"bar\"\n    ]\n  }\n]</pre>"
+    assert_rendered_template(:hipchat, :embedded, "raw", data, expected)
+  end
+
+  test "raw renders properly" do
+    data = %{"results" => [%{"foo" => "bar"}]}
+    expected = "<pre>[\n  {\n    \"foo\": \"bar\"\n  }\n]</pre>"
+    assert_rendered_template(:hipchat, :embedded, "raw", data, expected)
+  end
+
+end

--- a/test/cog/chat/slack/templates/embedded/raw_test.exs
+++ b/test/cog/chat/slack/templates/embedded/raw_test.exs
@@ -1,0 +1,30 @@
+defmodule Cog.Chat.Slack.Templates.Embedded.RawTest do
+  use Cog.TemplateCase
+
+  test "raw renders properly even when the return contains a body tag" do
+    data = %{"results" => [%{"body" => ["bar"]}]}
+    expected = """
+    ```[
+      {
+        "body": [
+          "bar"
+        ]
+      }
+    ]```
+    """ |> String.strip
+    assert_rendered_template(:slack, :embedded, "raw", data, expected)
+  end
+
+  test "raw renders properly" do
+    data = %{"results" => [%{"foo" => "bar"}]}
+    expected = """
+    ```[
+      {
+        "foo": "bar"
+      }
+    ]```
+    """ |> String.strip
+    assert_rendered_template(:slack, :common, "raw", data, expected)
+  end
+
+end


### PR DESCRIPTION
The `raw` command simply takes whatever it gets on std and passes it along, basically stripping the template from the command output. We then take advantage of Cog's default behavior when there is no specified template, and just render the raw json. However, some commands just render text. We determine whether to render json or plain text based on the presence of a "body" key in the response. If a user pipes output from a command that returns text to raw, the object goes through unchanged and the output is rendered as text instead of as the raw json as expected.

To alleviate that we just copy the raw template to embedded and explicitly pass it in the return from the raw command.

resolves #1023 