### PR TITLE
Make first reaping in the token reaper configurable

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -16,7 +16,8 @@ config :cog, Cog.Chat.Test.Provider,
   verbose: true
 
 config :cog, Cog.Repo,
-  pool: Ecto.Adapters.SQL.Sandbox
+  pool: Ecto.Adapters.SQL.Sandbox,
+  ownership_timeout: 60000
 
 config :cog,
   :template_cache_ttl, {1, :sec}

--- a/lib/cog/token_reaper.ex
+++ b/lib/cog/token_reaper.ex
@@ -54,7 +54,8 @@ defmodule Cog.TokenReaper do
   - ttl: the age at which a token is considered expired, in seconds
   """
   def init([period, ttl]) do
-    schedule_next_reaping(5000)
+    delete_expired_tokens(ttl)
+    schedule_next_reaping(period)
     {:ok, %__MODULE__{period: period,
                       ttl: ttl}}
   end


### PR DESCRIPTION
This makes the reaping of the token reaper configurable. Previously it was hard coded to 5000 milliseconds. The hard coded value caused a race condition during testing. Connections to the DB must be checked out or allowed before they can be used. Since reaping happens independently it would sometimes attempt to reap before the connection had been checked out. This caused the token reaper to crash randomly.

Tests are running more reliably in CI. There is a bit of "noise" in the integration tests. We get some red whenever the `Cog.Chat.Adapter` process is killed, but the tests still pass. Probably worth another pass to see if there is a better way to load the proper chat adapter, but I think this PR is good for now.

resolves #1061 