### PR TITLE
Dockerized CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,11 @@
+
+steps:
+  - command: "make unit-tests integration-tests"
+    label: ":cogops: Cog Tests"
+    env:
+      BUILDKITE_DOCKER_COMPOSE_CONTAINER: cog
+      BUILDKITE_DOCKER_COMPOSE_FILE: docker-compose.ci.yml
+      MIX_ENV: test
+    agents:
+      - docker=1.12.1
+

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,7 @@
+FROM operable/elixir:1.3.1-r3
+
+COPY . /code
+WORKDIR /code
+RUN mix deps.get
+RUN MIX_ENV=test mix deps.compile
+RUN MIX_ENV=test mix compile

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,10 @@ endif
 
 DOCKER_IMAGE      ?= operable/cog:0.5-dev
 
+deps:
+	mix deps.get
+
 ifeq ($(wildcard NO_CI),)
-ci: export DATABASE_URL = $(TEST_DATABASE_URL)
 ci: export MIX_ENV = test
 ci: ci-setup test-all ci-cleanup
 
@@ -21,10 +23,9 @@ ci-reset:
 	@echo "Resetting build environment"
 #	@rm -rf _build
 
-ci-setup: ci-reset
+ci-setup: deps ci-reset
 # Nuke mnesia dirs so we don't get borked on emqttd upgrades
 	rm -rf Mnesia.* $(GENERATED_FILES) deps
-	mix deps.get
 
 ci-cleanup:
 	mix ecto.drop
@@ -45,7 +46,7 @@ setup:
 run:
 	iex -S mix phoenix.server
 
-reset-db:
+reset-db: deps
 	mix ecto.reset --no-start
 
 test-rollbacks: export MIX_ENV = test
@@ -53,16 +54,18 @@ test-rollbacks: reset-db
 	mix do ecto.rollback --all, ecto.drop
 
 test: export MIX_ENV = test
-test: reset-db
+test: deps reset-db
 	mix test $(TEST)
 
 test-all: export MIX_ENV = test
 test-all: unit-tests integration-tests
 
-unit-tests: reset-db
+unit-tests: export MIX_ENV = test
+unit-tests: deps reset-db
 	mix test --exclude=integration
 
-integration-tests: reset-db
+integration-tests: export MIX_ENV = test
+integration-tests: deps reset-db
 	mix test --only=integration
 
 test-watch: export MIX_ENV = test
@@ -77,4 +80,4 @@ coverage:
 docker:
 	docker build --build-arg MIX_ENV=prod -t $(DOCKER_IMAGE) .
 
-.PHONY: ci ci-setup ci-cleanup test docker unit-tests integration-tests
+.PHONY: ci ci-setup ci-cleanup test docker unit-tests integration-tests deps

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,30 @@
+version: '2'
+services:
+  postgres:
+    image: postgres:9.5
+    cpu_shares: 512
+    environment:
+      - POSTGRES_USER=cog
+      - POSTGRES_PASSWORD=cog
+  cog:
+    build:
+      context: .
+      dockerfile: Dockerfile.ci
+    depends_on:
+      - postgres
+    environment:
+      - COG_MQTT_HOST=0.0.0.0
+      - DATABASE_URL=ecto://cog:cog@postgres:5432/cog
+      - SLACK_API_TOKEN=${SLACK_API_TOKEN}
+      - SLACK_USER_API_TOKEN=${SLACK_USER_API_TOKEN}
+      - HIPCHAT_USER_API_TOKEN=${HIPCHAT_USER_API_TOKEN}
+      - HIPCHAT_USER_JID=${HIPCHAT_USER_JID}
+      - HIPCHAT_USER_PASSWORD=${HIPCHAT_USER_PASSWORD}
+      - HIPCHAT_USER_NICKNAME=${HIPCHAT_USER_NICKNAME}
+      - HIPCHAT_ROOMS=${HIPCHAT_ROOMS}
+      - HIPCHAT_API_TOKEN=${HIPCHAT_API_TOKEN}
+      - HIPCHAT_JABBER_ID=${HIPCHAT_JABBER_ID}
+      - HIPCHAT_JABBER_PASSWORD=${HIPCHAT_JABBER_PASSWORD}
+      - HIPCHAT_NICKNAME=${HIPCHAT_NICKNAME}
+      - TEST_SLACK=${TEST_SLACK}
+      - TEST_HIPCHAT=${TEST_HIPCHAT}

--- a/test/support/snoop.ex
+++ b/test/support/snoop.ex
@@ -28,7 +28,7 @@ defmodule Cog.Snoop do
 
   # Wait a total of @tries x @wait ms to receive a single response
   # from the test adapter
-  @tries 100
+  @tries 200
   @wait 50 # ms
 
   @doc """


### PR DESCRIPTION
This updates Cog tests to run in a docker container in CI. Ideally I think we would want to run integration tests in a separate step from unit tests, then we could parallelize unit tests across builds, but right now that requires us to build Cog twice and it takes forever. Probably a good use case for leveraging artifacts, but I didn't want to complicate this for now.

resolves #1072 