### PR TITLE
Fix rule evaluation for list options

### DIFF
--- a/lib/cog/permissions/eval/contain_expr.ex
+++ b/lib/cog/permissions/eval/contain_expr.ex
@@ -91,6 +91,9 @@ defimpl Cog.Eval, for: Piper.Permissions.Ast.ContainExpr do
     end
   end
 
+  defp expr_match?(lhsv, rhsv) when is_list(lhsv) do
+    Enum.any?(lhsv, fn(item) -> expr_match?(item, rhsv) end)
+  end
   defp expr_match?(lhsv, %Regex{}=rhsv) do
     Regex.match?(rhsv, "#{lhsv}")
   end

--- a/test/cog/permissions/eval_test.exs
+++ b/test/cog/permissions/eval_test.exs
@@ -183,13 +183,27 @@ must have foo:write
     assert Eval.value_of(ast, context) == {true, 2}
   end
 
-  test "in expr referencing an option" do
+  test "in expr referencing an option (==)" do
     {:ok, ast} = :piper_rule_parser.parse_rule("""
 when command is debug:opts with option[list] in ["foo", "bar"] allow
     """)
-    context = make_context("debug:opts", [], %{"list" => "foo"})
+    context = make_context("debug:opts", [], %{"list" => ["foo"]})
     assert Eval.value_of(ast, context) == {true, 1}
-    context = make_context("debug:opts", [], %{"list" => "baz"})
+    context = make_context("debug:opts", [], %{"list" => ["baz"]})
+    assert Eval.value_of(ast, context) == :nomatch
+    context = make_context("debug:opts", [], %{"list" => ["f","oo"]})
+    assert Eval.value_of(ast, context) == :nomatch
+  end
+
+  test "in expr referencing an option (regex)" do
+    {:ok, ast} = :piper_rule_parser.parse_rule("""
+when command is debug:opts with option[list] in [/foo/] allow
+    """)
+    context = make_context("debug:opts", [], %{"list" => ["foo"]})
+    assert Eval.value_of(ast, context) == {true, 1}
+    context = make_context("debug:opts", [], %{"list" => ["baz"]})
+    assert Eval.value_of(ast, context) == :nomatch
+    context = make_context("debug:opts", [], %{"list" => ["f","oo"]})
     assert Eval.value_of(ast, context) == :nomatch
   end
 

--- a/test/cog/permissions/eval_test.exs
+++ b/test/cog/permissions/eval_test.exs
@@ -185,6 +185,26 @@ must have foo:write
 
   test "in expr referencing an option (==)" do
     {:ok, ast} = :piper_rule_parser.parse_rule("""
+when command is debug:opts with option[foo] in ["foo", "bar"] allow
+    """)
+    context = make_context("debug:opts", [], %{"foo" => ["foo"]})
+    assert Eval.value_of(ast, context) == {true, 1}
+    context = make_context("debug:opts", [], %{"foo" => ["baz"]})
+    assert Eval.value_of(ast, context) == :nomatch
+  end
+
+  test "in expr referencing an option (regex)" do
+    {:ok, ast} = :piper_rule_parser.parse_rule("""
+when command is debug:opts with option[foo] in [/foo/, /bar/] allow
+    """)
+    context = make_context("debug:opts", [], %{"foo" => ["foo"]})
+    assert Eval.value_of(ast, context) == {true, 1}
+    context = make_context("debug:opts", [], %{"foo" => ["baz"]})
+    assert Eval.value_of(ast, context) == :nomatch
+  end
+
+  test "in expr referencing a list option (==)" do
+    {:ok, ast} = :piper_rule_parser.parse_rule("""
 when command is debug:opts with option[list] in ["foo", "bar"] allow
     """)
     context = make_context("debug:opts", [], %{"list" => ["foo"]})
@@ -195,7 +215,7 @@ when command is debug:opts with option[list] in ["foo", "bar"] allow
     assert Eval.value_of(ast, context) == :nomatch
   end
 
-  test "in expr referencing an option (regex)" do
+  test "in expr referencing a list option (regex)" do
     {:ok, ast} = :piper_rule_parser.parse_rule("""
 when command is debug:opts with option[list] in [/foo/] allow
     """)


### PR DESCRIPTION
Previously, the rule evaluator would coerce list type options into a string before evaluating the comparisons contained within the right-hand-side of an `in` operation. For example:

**String Comparison:**

Example Command:  `my-command --list foo --list bar --list baz`
Rule: `when command is my-command with option[list] in [ foo ] allow`
Evaluates: `"foobarbaz" == "foo"`

This would only return the expected result if the list option only had a single value.

**Regex Match:**

Example Command:  `my-command --list foo --list bar --list baz`
Rule: `when command is my-command with option[list] in [ /foo/ ] allow`
Evaluates: `Regex.match?(~r/foo/, "foobarbaz")`

The Regex version of this would usually return the expected results, though there could be unexpected behavior which would also affect the string comparison version. 

**Edge Cases, Oh My:**

For instance, the following command and rule would evaluate to true which is unlikely to be the expected behavior.

Example Command:  `my-command --list f --list oo`
Rule: `when command is my-command with option[list] in [ foo ] allow`
Evaluates: `"foo" == "foo"`

This PR cases the `in` expression to be evaluated against each item in the option rather than on a stringified version of the option.




