### PR TITLE
Remove token reaper startup delay and increase ownership timeout

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -16,7 +16,8 @@ config :cog, Cog.Chat.Test.Provider,
   verbose: true
 
 config :cog, Cog.Repo,
-  pool: Ecto.Adapters.SQL.Sandbox
+  pool: Ecto.Adapters.SQL.Sandbox,
+  ownership_timeout: 60000
 
 config :cog,
   :template_cache_ttl, {1, :sec}

--- a/lib/cog/token_reaper.ex
+++ b/lib/cog/token_reaper.ex
@@ -54,7 +54,8 @@ defmodule Cog.TokenReaper do
   - ttl: the age at which a token is considered expired, in seconds
   """
   def init([period, ttl]) do
-    schedule_next_reaping(5000)
+    delete_expired_tokens(ttl)
+    schedule_next_reaping(period)
     {:ok, %__MODULE__{period: period,
                       ttl: ttl}}
   end


### PR DESCRIPTION
The startup delay on the token reaper was causing the occasional db ownership error because it would try to query the db after we set `Ecto.Adapter.Sandbox.mode` to manual but before we update it to shared before tests. The db ownership error caused the token reaper to crash and then restart only to crash again. This created some pretty unstable and unpredictable test results.

By reaping tokens during init we hit the db before setting the sandbox mode to manual so the reaper doesn't start flopping. We do occasionally get db connection timeouts because the token reaper process hangs on to the connection for too long, but this doesn't cause the same instability that crashing the process does. I increased the ownership timeout to alleviate that a bit.

This isn't a 100% fix, but it does ease some of the unpredictability with tests in CI.