### PR TITLE
Trigger cogctl pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,3 @@
-
 steps:
   - command: "make unit-tests integration-tests"
     label: ":cogops: Cog Tests"
@@ -9,3 +8,7 @@ steps:
     agents:
       - docker=1.12.1
 
+  - wait
+
+  - command: ".buildkite/scripts/trigger_dependent_build.sh cogctl"
+    label: ":cogops: cogctl build"

--- a/.buildkite/scripts/trigger_dependent_build.sh
+++ b/.buildkite/scripts/trigger_dependent_build.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DEPENDENT_PROJECT=${1}
+TRIGGER_PIPELINE_SLUG=${DEPENDENT_PROJECT}
+
+if git ls-remote --exit-code --heads https://github.com/operable/$DEPENDENT_PROJECT refs/heads/${BUILDKITE_BRANCH} > /dev/null 2>&1
+then
+    TRIGGER_BRANCH=${BUILDKITE_BRANCH}
+else
+    TRIGGER_BRANCH='master'
+fi
+
+TRIGGER_MESSAGE=":cogops: Dependent Build Triggered from ${BUILDKITE_BUILD_URL} :cogops:"
+
+curl \
+  "https://api.buildkite.com/v2/organizations/${BUILDKITE_ORGANIZATION_SLUG}/pipelines/${TRIGGER_PIPELINE_SLUG}/builds" \
+  --request POST \
+  --fail \
+  --header "Authorization: Bearer ${BUILDKITE_API_ACCESS_TOKEN}" \
+  --header "Content-Type: application/json" \
+  --data "{
+    \"commit\": \"HEAD\",
+    \"branch\": \"${TRIGGER_BRANCH}\",
+    \"message\": \"${TRIGGER_MESSAGE}\",
+    \"env\": {
+      \"COG_BRANCH\": \"${BUILDKITE_BRANCH}\"
+    }
+  }"


### PR DESCRIPTION
This is now a pipeline step, rathe than a post-command callback, in
order to ensure that it fires only after all preceeding steps pass.

For now, we're not requiring the cogctl pipeline to pass in order for
this cog pipeline to pass, but that can easily be added with a
subsequent API polling step in the future.