### PR TITLE
error messages

### DIFF
--- a/lib/cog/audit_message.ex
+++ b/lib/cog/audit_message.ex
@@ -19,6 +19,10 @@ defmodule Cog.AuditMessage do
     do: "User #{request.sender.handle} denied access to '#{current_invocation}'"
   def render({:no_relays, bundle_name}, _request),
     do: ErrorResponse.render({:no_relays, bundle_name}) # Uses same user message for now
+  def render({:no_relay_group, bundle_name}, _request),
+    do: ErrorResponse.render({:no_relay_group, bundle_name})
+  def render({:no_enabled_relays, bundle_name}, _request),
+    do: ErrorResponse.render({:no_relay_group, bundle_name})
   def render({:disabled_bundle, %Bundle{name: name}}, _request),
     do: "The #{name} bundle is currently disabled"
   def render({:command_error, response}, _request),

--- a/lib/cog/error_response.ex
+++ b/lib/cog/error_response.ex
@@ -16,8 +16,16 @@ defmodule Cog.ErrorResponse do
     perms = Enum.map(Ast.Rule.permissions_used(rule), &("'#{&1}'")) |> Enum.join(", ")
     "Sorry, you aren't allowed to execute '#{current_invocation}' :(\n You will need at least one of the following permissions to run this command: #{perms}."
   end
-  def render({:no_relays, bundle_name}), # TODO: Add version, too?
-    do: "No Cog Relays supporting the `#{bundle_name}` bundle are currently online"
+  def render({:no_relays, bundle_name}) do # TODO: Add version, too?
+    "No Cog Relays supporting the `#{bundle_name}` bundle are currently online. " <>
+    "If you just assigned the bundle to a relay group you will need to wait for the relay refresh interval to pick up the new bundle."
+  end
+  def render({:no_relay_group, bundle_name}),
+    do: "Bundle '#{bundle_name}' is not assigned to a relay group. Assign the bundle to a relay group and try again."
+  def render({:no_enabled_relays, bundle_name}) do # TODO: Should we print the list of disabled relays?
+    "No Cog Relays supporting the `#{bundle_name}` bundle are currently available. " <>
+    "There are one or more relays serving the bundle, but they are disabled. Enable an appropriate relay and try again."
+  end
   def render({:disabled_bundle, %Bundle{name: name}}),
     do: "The #{name} bundle is currently disabled"
   def render({:timeout, full_command_name}),

--- a/lib/cog/relay/relays.ex
+++ b/lib/cog/relay/relays.ex
@@ -108,8 +108,12 @@ defmodule Cog.Relay.Relays do
     tracker = remove_relay(state.tracker, relay.id)
     {:reply, :ok, %{state | tracker: tracker}}
   end
-  def handle_call({:relays_running, bundle_name, version} , _from, state),
-    do: {:reply, Tracker.relays(state.tracker, bundle_name, version), state}
+  def handle_call({:relays_running, bundle_name, version} , _from, state) do
+    case Tracker.relays(state.tracker, bundle_name, version) do
+      {:ok, relays} -> {:reply, relays, state}
+      {:error, _} -> {:reply, [], state}
+    end
+  end
 
   def handle_info({:publish, @relays_discovery_topic, message}, state) do
     try do
@@ -202,8 +206,8 @@ defmodule Cog.Relay.Relays do
 
   defp random_relay(tracker, bundle, version) do
     case Tracker.relays(tracker, bundle, version) do
-      [] -> nil
-      relays -> Enum.random(relays)
+      {:ok, relays} -> {:ok, Enum.random(relays)}
+      error -> error
     end
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -54,7 +54,7 @@
   "phoenix_html": {:hex, :phoenix_html, "2.7.0", "19e12e2044340c2e43df206a06d059677c59ea1868bd1c35165438d592cd420b", [:mix], [{:plug, "~> 1.0", [hex: :plug, optional: false]}]},
   "phoenix_live_reload": {:hex, :phoenix_live_reload, "1.0.5", "829218c4152ba1e9848e2bf8e161fcde6b4ec679a516259442561d21fde68d0b", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}, {:phoenix, "~> 1.0 or ~> 1.2-rc", [hex: :phoenix, optional: false]}]},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.1", "c10ddf6237007c804bf2b8f3c4d5b99009b42eca3a0dfac04ea2d8001186056a", [:mix], []},
-  "piper": {:git, "https://github.com/operable/piper.git", "93a0034334b237cafd96cebb51257a7c3f4c14b1", []},
+  "piper": {:git, "https://github.com/operable/piper.git", "22ce7b6eecfdb51c7453b31a3c0f54d3484552c4", []},
   "plug": {:hex, :plug, "1.2.2", "cfbda521b54c92ab8ddffb173fbaabed8d8fc94bec07cd9bb58a84c1c501b0bd", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},

--- a/test/cog/relay/tracker_test.exs
+++ b/test/cog/relay/tracker_test.exs
@@ -90,12 +90,17 @@ defmodule Cog.Relay.Tracker.Test do
   defp bundle_spec(name, version),
     do: {name, version}
 
-  defp assert_missing({name, version}, tracker),
-    do: assert [] = Tracker.relays(tracker, name, version)
+  defp assert_missing(bundle_spec, tracker),
+    do: assert [] = actual_relays(tracker, bundle_spec)
 
-  defp assert_relays(tracker, {name, version}, expected_relays) do
-    actual_relays = Tracker.relays(tracker, name, version)
-    assert Enum.sort(expected_relays) == Enum.sort(actual_relays)
+  defp assert_relays(tracker, bundle_spec, expected_relays),
+    do: assert Enum.sort(expected_relays) == Enum.sort(actual_relays(tracker, bundle_spec))
+
+  defp actual_relays(tracker, {name, version}) do
+    case Tracker.relays(tracker, name, version) do
+      {:ok, relays} -> relays
+      {:error, _} -> []
+    end
   end
 
 end


### PR DESCRIPTION
This adds/updates a number of error messages to make it easier for users to troubleshoot issues.

resolves #1092 
- Executing a command in a bundle not assigned to a relay group
  - `Bundle 'test' is not assigned to a relay group. Assign the bundle to a relay group and try again.`
- Executing a command that only exists on a disabled relay
  - `No Cog Relays supporting the`test`bundle are currently available. There are one or more relays serving the bundle, but they are disabled. Enable an appropriate relay and try again.`
- Updates to the standard "No Cog Relays supporting..." error
  - `No Cog Relays supporting the`test`bundle are currently online. If you just assigned the bundle to a relay group you will need to wait for the relay refresh interval to pick up the new bundle.`

Provided by piper:
- Executing a command in a disabled bundle
  - `Bundle 'mybundle' is disabled. Please enable it and try running the command again.`
- Executing a command that does not exist in a bundle
  - `Bundle '#{bundle}' doesn't contain a command named '#{text}'.`
