### PR TITLE
add the env to the telemetry data

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -4,8 +4,9 @@ import Cog.Config.Helpers
 # ========================================================================
 # Cog Telemetry - By default, Cog is configured to send an event to the
 # Operable telemetry service every time it starts. This event contains a
-# unique ID (based on the SHA256 of the UUID for your operable bundle)
-# and the Cog version number.
+# unique ID (based on the SHA256 of the UUID for your operable bundle),
+# the Cog version number, and the Elixir mix environment (:prod, :dev, etc)
+# that Cog is running under.
 #
 # If you would like to opt-out of sending this data, you can set the
 # COG_TELEMETRY environment variable to "false".

--- a/lib/cog/telemetry.ex
+++ b/lib/cog/telemetry.ex
@@ -26,11 +26,15 @@ defmodule Cog.Telemetry do
       bundle_id ->
         telemetry_id = Base.encode16(:crypto.hash(:sha256, bundle_id))
         {:ok, version} = :application.get_key(:cog, :vsn)
-        {:ok, %{ cog: %{ id: telemetry_id, version: to_string(version) }}}
+        {:ok,
+          %{ cog:
+            %{ id: telemetry_id,
+               version: to_string(version),
+               env: Atom.to_string(Mix.env) }}
     end
   end
 
-  defp telemetry_enabled do
+  def telemetry_enabled do
     Application.fetch_env!(:cog, :telemetry)
   end
 


### PR DESCRIPTION
This adds an `env` key to the Cog start telemetry event with the value of `Atom.to_string(Mix.env)` so we can differentiate between `dev` instances, `test` instances, and `prod` instances. 