### PR TITLE
Fix password reset email

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -201,7 +201,7 @@ config :cog, :trigger_timeout_buffer, (System.get_env("COG_TRIGGER_TIMEOUT_BUFFE
 config :cog, Cog.Mailer,
   adapter: Bamboo.SMTPAdapter,
   server: System.get_env("COG_SMTP_SERVER"),
-  port: System.get_env("COG_SMTP_PORT"),
+  port: ensure_integer(System.get_env("COG_SMTP_PORT")),
   username: System.get_env("COG_SMTP_USERNAME"),
   password: System.get_env("COG_SMTP_PASSWORD"),
   tls: :if_available, # can be `:always` or `:never`

--- a/config/helpers.exs
+++ b/config/helpers.exs
@@ -14,9 +14,9 @@ defmodule Cog.Config.Helpers do
     Path.join([data_dir, subdir])
   end
 
-  def ensure_integer(ttl) when is_nil(ttl), do: false
-  def ensure_integer(ttl) when is_binary(ttl), do: String.to_integer(ttl)
-  def ensure_integer(ttl) when is_integer(ttl), do: ttl
+  def ensure_integer(number) when is_nil(number), do: false
+  def ensure_integer(number) when is_binary(number), do: String.to_integer(number)
+  def ensure_integer(number) when is_integer(number), do: number
 
   def ensure_boolean(nil), do: nil
   def ensure_boolean(value) when is_boolean(value), do: value


### PR DESCRIPTION
The SMTP port was not being cast from the string we get from the environment to an integer.