### PR TITLE
help no longer requires the fully qualified command name

### DIFF
--- a/lib/cog/commands/help.ex
+++ b/lib/cog/commands/help.ex
@@ -27,42 +27,28 @@ defmodule Cog.Commands.Help do
 
   rule "when command is #{Cog.Util.Misc.embedded_bundle}:help allow"
 
+  # When help is called with no arguments we return the list of installed bundles
   def handle_message(%{args: []} = req, state) do
     bundles = %{enabled: Repo.preload(Bundles.enabled, :bundle),
                 disabled: Repo.preload(Bundles.highest_disabled_versions, :bundle)}
     {:reply, req.reply_to, "help-bundles", bundles, state}
   end
-
-  def handle_message(%{args: [bundle_or_command]} = req, state) do
-    response = case String.split(bundle_or_command, ":") do
-      [bundle_name] ->
-        bundle_version = bundle_name
-        |> Bundles.with_status_by_name
-
-        case bundle_version do
-          nil ->
-            {:error, "Bundle #{inspect(bundle_name)} not found"}
-          %BundleVersion{config_file: config_file} ->
-            commands =
-              Enum.map(config_file["commands"], fn({name, map}) -> Map.put(map, "name", name) end)
-            {:ok, {:bundle, %{config_file | "commands" => commands}}}
-        end
-      [bundle_name, command_name] ->
-        full_command_name = bundle_name <> ":" <> command_name
-
-        command_version = full_command_name
-        |> Commands.with_status_by_any_name
-        |> Commands.preloads_for_help
-
-        case command_version do
-          [] ->
-            {:error, "Command #{inspect(full_command_name)} not found"}
-          [%CommandVersion{bundle_version: %BundleVersion{config_file: %{"cog_bundle_version" => version}}} = command] when version < 4 ->
-            {:ok, {:documentation, command.documentation}}
-          [%CommandVersion{} = command_version] ->
-            rendered = Cog.CommandVersionHelpView.render("command_version.json", %{command_version: command_version})
-            {:ok, {:command, rendered}}
-        end
+  # When called with arguments the user could be requesting help for either a bundle or
+  # a command. We first do a lookup and then return the appropriate help.
+  def handle_message(%{args: args} = req, state) do
+    response = case lookup(args) do
+      {:ok, %CommandVersion{bundle_version: %BundleVersion{config_file: %{"cog_bundle_version" => version}}} = command} when version < 4 ->
+        command = Commands.preloads_for_help(command)
+        {:ok, {:documentation, command.documentation}}
+      {:ok, %CommandVersion{} = command} ->
+        command = Commands.preloads_for_help(command)
+        rendered = Cog.CommandVersionHelpView.render("command_version.json", %{command_version: command})
+        {:ok, {:command, rendered}}
+      {:ok, %BundleVersion{config_file: config_file}} ->
+        commands = Enum.map(config_file["commands"], fn({name, map}) -> Map.put(map, "name", name) end)
+        {:ok, {:bundle, %{config_file | "commands" => commands}}}
+      error ->
+        error
     end
 
     case response do
@@ -75,11 +61,103 @@ defmodule Cog.Commands.Help do
       {:ok, body} ->
         {:reply, req.reply_to, body, state}
       {:error, error} ->
-        {:error, req.reply_to, error, state}
+        {:error, req.reply_to, error_msg(error), state}
     end
   end
 
-  def handle_message(req, state) do
-    {:reply, req.reply_to, "usage", %{usage: @moduledoc}, state}
+  # Note: We could do the command lookup first regardless of the presence of ':'
+  # This would eliminate the second case statement but would also mean that commands
+  # with the same name as bundles would take precedence.
+  defp lookup(args) do
+    cond do
+      # If the first item in the arg list contains a ':' then we know the user is
+      # requesting help for a command.
+      String.contains?(hd(args), ":") ->
+        lookup_command(args)
+      # If any other item in the arg list has a ':' then the user left a space in
+      # the bundle name which is invalid.
+      Enum.any?(tl(args), &String.contains?(&1, ":")) ->
+        bundle_name = Enum.join(args, " ")
+                      |> String.split(":")
+                      |> List.first()
+
+        {:error, {:invalid_bundle, bundle_name}}
+      # If there is no ':' then the user could be requesting help for a bundle or a command.
+      # Bundles should take precedence over commands so we first see if a bundle exists.
+      true ->
+        case lookup_bundle(args) do
+          {:ok, bundle} ->
+            {:ok, bundle}
+          {:error, bundle_error} ->
+            # If there is no bundle then we do a command lookup
+            case lookup_command(args) do
+              {:ok, command} ->
+                {:ok, command}
+              # If the command isn't found we return :nothing_found instead of just
+              # :command_not_found. Then we can give the user a more descriptive error.
+              {:error, {:command_not_found, name}} ->
+                {:error, {:nothing_found, bundle_error, {:command_not_found, name}}}
+              # We could also get an ambiguous command error, so we just pass that along.
+              error ->
+                error
+            end
+      end
+    end
   end
+
+  defp lookup_command(args) when is_list(args) do
+    # When requesting help for a command using the git style syntax we need to
+    # join args with a '-'.
+    Enum.join(args, "-")
+    |> lookup_command()
+  end
+  defp lookup_command(name) do
+    case Commands.with_status_by_any_name(name) do
+      [] ->
+        {:error, {:command_not_found, name}}
+      [%CommandVersion{} = command] ->
+        {:ok, command}
+      commands ->
+        # We preload here so we can go ahead and generate the fully qualified names for ambiguous commands.
+        commands = Commands.preloads_for_help(commands)
+        {:error, {:ambiguous, name, Enum.map(commands, &("#{&1.bundle_version.bundle.name}:#{&1.command.name}"))}}
+    end
+  end
+
+  defp lookup_bundle([name]),
+    do: lookup_bundle(name)
+  defp lookup_bundle(args) when is_list(args),
+    # Bundles cannot be specified with the special git style syntax. So if there
+    # are spaces in the bundle name it is invalid.
+    do: {:error, {:invalid_bundle, Enum.join(args, " ")}}
+  defp lookup_bundle(name) do
+    case Bundles.with_status_by_name(name) do
+      nil ->
+        {:error, {:bundle_not_found, name}}
+      %BundleVersion{} = bundle ->
+        {:ok, bundle}
+    end
+  end
+
+  defp error_msg({:command_not_found, name}),
+    do: "Command '#{name}' not found. Check the bundle and command name and try again."
+  # We won't actually get this error since we always do a command lookup if the
+  # bundle lookup fails, see lookup/1. But it is included for completeness.
+  defp error_msg({:bundle_not_found, name}),
+    do: "Bundle '#{name}' not found."
+  defp error_msg({:nothing_found, {:bundle_not_found, name}, {:command_not_found, name}}),
+    do: "Could not find a bundle or a command in any bundle with the name '#{name}'. Check the name and try again."
+  defp error_msg({:nothing_found, {:invalid_bundle, _bundle_name}, {:command_not_found, name}}),
+    do: "Could not find a command in any bundle with the name '#{name}'. Check the name and try again."
+  defp error_msg({:invalid_bundle, name}),
+    do: "Invalid bundle name '#{name}'. Check the name and try again."
+  defp error_msg({:ambiguous, name, commands}) do
+    """
+    Multiple bundles contain a command with the name '#{name}'.
+    Please specify which command by using the command's fully qualified name.
+
+    #{Enum.sort(commands) |> Enum.join("\n")}
+    """
+  end
+
 end

--- a/lib/cog/repository/commands.ex
+++ b/lib/cog/repository/commands.ex
@@ -53,6 +53,6 @@ defmodule Cog.Repository.Commands do
   end
 
   def preloads_for_help(command_versions) do
-    Repo.preload(command_versions, [:command, :bundle_version, options: :option_type])
+    Repo.preload(command_versions, [:command, bundle_version: :bundle, options: :option_type])
   end
 end

--- a/lib/cog/support/model_utilities.ex
+++ b/lib/cog/support/model_utilities.ex
@@ -218,7 +218,9 @@ defmodule Cog.Support.ModelUtilities do
   Create a command with the given name
   """
   def command(name, params \\ %{}) do
-    bundle_version = bundle_version("test-bundle")
+    bundle_name = Map.get(params, :bundle_name, "test-bundle")
+
+    bundle_version = bundle_version(bundle_name)
     bundle = bundle_version.bundle
 
     command = %Command{}

--- a/test/commands/help_test.exs
+++ b/test/commands/help_test.exs
@@ -1,25 +1,181 @@
 defmodule Cog.Test.Commands.HelpTest do
   use Cog.CommandCase, command_module: Cog.Commands.Help
 
-  alias Cog.Support.ModelUtilities
+  import Cog.Support.ModelUtilities, only: [command: 2,
+                                            bundle_version: 1]
 
-  test "listing bundles" do
-    ModelUtilities.command("test-command")
+  describe "general help" do
 
-    request = new_req()
-    {:ok, response} = send_req(request)
+    setup :with_command
 
-    assert %{enabled: [%{name: "operable"}],
-             disabled: [%{name: "test-bundle"}]} = response
+    test "listing bundles" do
+      response = new_req()
+                 |> send_req()
+                 |> unwrap()
+
+      assert %{enabled: [%{name: "operable"}],
+               disabled: [%{name: "test-bundle"}]} = response
+    end
+
+    test "showing docs for a command" do
+      response = new_req(args: ["test-bundle:test-command"])
+                 |> send_req()
+                 |> unwrap()
+
+      assert %{name: "test-command",
+               description: "Does test command things"} = response
+    end
+
+    test "showing docs for a command using the git style syntax" do
+      response = new_req(args: ["test", "command"])
+                 |> send_req()
+                 |> unwrap()
+
+      assert %{name: "test-command",
+               description: "Does test command things"} = response
+    end
+
+    test "showing docs for a bundle" do
+      response = new_req(args: ["test-bundle"])
+                 |> send_req()
+                 |> unwrap()
+
+      assert(%{name: "test-bundle"} = response)
+    end
+
+    test "shows an error when a command does not exist" do
+      error = new_req(args: ["test-bundle:does-not-exist"])
+              |> send_req()
+              |> unwrap_error()
+
+      error_msg = "Command 'test-bundle:does-not-exist' not found. Check the bundle and command name and try again." 
+
+      assert(error_msg == error)
+    end
+
   end
 
-  test "showing docs for a command" do
-    ModelUtilities.command("test-command", %{description: "Does test command things", arguments: "[test-arg]"})
+  describe "non-fully qualified commands" do
 
-    request = new_req(args: ["test-bundle:test-command"])
-    {:ok, response} = send_req(request)
+    setup :with_command
 
-    assert %{name: "test-command",
-             description: "Does test command things"} = response
+    test "showing docs for a command" do
+      response = new_req(args: ["test-command"])
+                 |> send_req()
+                 |> unwrap()
+
+      assert(%{name: "test-command",
+               description: "Does test command things"} = response)
+    end
+
+    test "shows bundle docs when a command and bundle name are ambiguous" do
+      bundle_version("test-ambiguous")
+
+      response = new_req(args: ["test-ambiguous"])
+                 |> send_req()
+                 |> unwrap()
+
+      # The existance of the 'cog_bundle_version' key denotes this as a bundle version.
+      assert(%{cog_bundle_version: _,
+               name: "test-ambiguous"} = response)
+    end
+
+    test "shows an error when a bundle or comamnd isn't found" do
+      error = new_req(args: ["does-not-exist"])
+              |> send_req()
+              |> unwrap_error()
+
+      assert(error == "Could not find a bundle or a command in any bundle with the name 'does-not-exist'. Check the name and try again.")
+    end
+
+    test "shows an error when a command is ambiguous" do
+      command("test-command",
+              %{bundle_name: "other-test-bundle",
+                description: "Does test command things", arguments: "[test-arg]"})
+
+      error = new_req(args: ["test-command"])
+              |> send_req()
+              |> unwrap_error()
+
+      error_msg = """
+      Multiple bundles contain a command with the name 'test-command'.
+      Please specify which command by using the command's fully qualified name.
+
+      other-test-bundle:test-command
+      test-bundle:test-command
+      """
+
+      assert(error_msg == error)
+    end
+
+  end
+
+  describe "git style syntax" do
+
+    setup :with_command
+
+    test "fully qualified command" do
+      response = new_req(args: ["test-bundle:test", "command"])
+                 |> send_req()
+                 |> unwrap()
+
+      assert %{name: "test-command",
+               description: "Does test command things"} = response
+    end
+
+    test "just the command" do
+      response = new_req(args: ["test", "command"])
+                 |> send_req()
+                 |> unwrap()
+
+      assert %{name: "test-command",
+               description: "Does test command things"} = response
+    end
+
+    test "shows an error for ambiguous commands" do
+      command("test-command",
+              %{bundle_name: "other-test-bundle",
+                description: "Does test command things", arguments: "[test-arg]"})
+
+      error = new_req(args: ["test", "command"])
+              |> send_req()
+              |> unwrap_error()
+
+      error_msg = """
+      Multiple bundles contain a command with the name 'test-command'.
+      Please specify which command by using the command's fully qualified name.
+
+      other-test-bundle:test-command
+      test-bundle:test-command
+      """
+
+      assert(error_msg == error)
+    end
+
+    test "shows an error when the bundle name has a space in fully qualified names" do
+      error = new_req(args: ["test", "bundle:test", "command"])
+            |> send_req()
+            |> unwrap_error()
+
+      assert(error == "Invalid bundle name 'test bundle'. Check the name and try again.")
+    end
+
+    test "shows an error when a command cannot be found" do
+      error = new_req(args: ["does", "not", "exist"])
+              |> send_req()
+              |> unwrap_error()
+
+      assert(error == "Could not find a command in any bundle with the name 'does-not-exist'. Check the name and try again.")
+    end
+
+  end
+
+  #### Setup Functions ####
+
+  defp with_command(_) do
+    [command: command("test-command",
+                      %{bundle_name: "test-bundle",
+                        description: "Does test command things",
+                        arguments: "[test-arg]"})]
   end
 end


### PR DESCRIPTION
Adds support for passing just the command name without the bundle and improves error messaging a bit.

resolves #1109 