### PR TITLE
Make command tests more unit testy

### DIFF
--- a/test/commands/help_test.exs
+++ b/test/commands/help_test.exs
@@ -1,32 +1,25 @@
 defmodule Cog.Test.Commands.HelpTest do
-  use Cog.AdapterCase, adapter: "test"
+  use Cog.CommandCase, command_module: Cog.Commands.Help
 
-  @moduletag :skip
-
-  alias Cog.Support.ModelUtilities
-
-  setup do
-    user = user("vanstee", first_name: "Patrick", last_name: "Van Stee")
-    |> with_chat_handle_for("test")
-
-    {:ok, %{user: user}}
-  end
-
-  test "listing bundles", %{user: user} do
+  test "listing bundles" do
     ModelUtilities.command("test-command")
 
-    [response] = send_message(user, "@bot: operable:help")
+    request = new_req()
+    {:ok, response} = send_req(request)
 
-    assert %{enabled: [%{name: "operable"}],
-             disabled: [%{name: "test-bundle"}]} = response
+    decoded = Poison.decode!(response)
+    assert %{"enabled" => [%{"name" => "operable"}],
+             "disabled" => [%{"name" => "test-bundle"}]} = decoded
   end
 
-  test "showing docs for a command", %{user: user} do
+  test "showing docs for a command" do
     ModelUtilities.command("test-command", %{description: "Does test command things", arguments: "[test-arg]"})
 
-    [response] = send_message(user, "@bot: operable:help test-bundle:test-command")
+    request = new_req(args: ["test-bundle:test-command"])
+    {:ok, response} = send_req(request)
 
-    assert %{name: "test-command",
-             description: "Does test command things"} = response
+    decoded = Poison.decode!(response)
+    assert %{"name" => "test-command",
+             "description" => "Does test command things"} = decoded
   end
 end

--- a/test/commands/help_test.exs
+++ b/test/commands/help_test.exs
@@ -1,15 +1,16 @@
 defmodule Cog.Test.Commands.HelpTest do
   use Cog.CommandCase, command_module: Cog.Commands.Help
 
+  alias Cog.Support.ModelUtilities
+
   test "listing bundles" do
     ModelUtilities.command("test-command")
 
     request = new_req()
     {:ok, response} = send_req(request)
 
-    decoded = Poison.decode!(response)
-    assert %{"enabled" => [%{"name" => "operable"}],
-             "disabled" => [%{"name" => "test-bundle"}]} = decoded
+    assert %{enabled: [%{name: "operable"}],
+             disabled: [%{name: "test-bundle"}]} = response
   end
 
   test "showing docs for a command" do
@@ -18,8 +19,7 @@ defmodule Cog.Test.Commands.HelpTest do
     request = new_req(args: ["test-bundle:test-command"])
     {:ok, response} = send_req(request)
 
-    decoded = Poison.decode!(response)
-    assert %{"name" => "test-command",
-             "description" => "Does test command things"} = decoded
+    assert %{name: "test-command",
+             description: "Does test command things"} = response
   end
 end

--- a/test/commands/sort_test.exs
+++ b/test/commands/sort_test.exs
@@ -1,30 +1,31 @@
 defmodule Cog.Test.Commands.SortTest do
   use Cog.CommandCase, command_module: Cog.Commands.Sort
 
-  setup do
-    seed = [%{a: 1},
-            %{a: 3},
-            %{a: 2}]
+  test "basic sorting" do
+    # Add some items to the memory service
+    inv_id = "basic_sorting_test_id"
+    memory_accum(inv_id, %{a: 1})
+    memory_accum(inv_id, %{a: 3})
 
-    {:ok, %{seed: seed}}
-  end
+    # Then we'll make our request with the last item
+    # We don't have to set the invocation step here because by default `req/1`
+    # sets it to "last".
+    {:ok, response} = new_req(cog_env: %{a: 2}, invocation_id: inv_id)
+    |> send_req()
 
-  test "basic sorting", %{seed: seed} do
-    request = Enum.map(seed, &(new_req(cog_env: &1)))
-
-    # When you send a list of requests you get a list of responses back
-    # We only care about the last one though, the rest should be nil
-    {:ok, response} = send_req(request) |> List.last
-
+    # Assert that things are in the proper order.
     assert [%{a: 1},
             %{a: 2},
             %{a: 3}] = response
   end
 
-  test "sorting in descending order", %{seed: seed} do
-    request = Enum.map(seed, &(new_req(cog_env: &1, options: %{"desc" => true})))
+  test "sorting in descending order" do
+    inv_id = "sorting_desc_test_id"
+    memory_accum(inv_id, %{a: 1})
+    memory_accum(inv_id, %{a: 3})
 
-    {:ok, response} = send_req(request) |> List.last
+    {:ok, response} = new_req(cog_env: %{a: 2}, invocation_id: inv_id, options: %{"desc" => true})
+    |> send_req()
 
     assert [%{a: 3},
             %{a: 2},
@@ -32,15 +33,48 @@ defmodule Cog.Test.Commands.SortTest do
   end
 
   test "sorting by specific fields" do
-    seed = [%{a: 3, b: 4},
-            %{a: 1, b: 4},
-            %{a: 2, b: 6}]
-    request = Enum.map(seed, &(new_req(cog_env: &1, args: ["b", "a"])))
+    inv_id = "sorting_by_specific_field_test_id"
+    memory_accum(inv_id, %{a: 3, b: 4})
+    memory_accum(inv_id, %{a: 1, b: 4})
 
-    {:ok, response} = send_req(request) |> List.last
+    {:ok, response} = new_req(cog_env: %{a: 2, b: 6}, invocation_id: inv_id, args: ["b", "a"])
+    |> send_req()
 
     assert [%{a: 1, b: 4},
             %{a: 3, b: 4},
             %{a: 2, b: 6}] = response
+  end
+
+  test "as requests come in they are accumulated" do
+    inv_id = "memory_service_sort_test"
+    # The memory service encodes maps and stringifys the keys, so we have to
+    # use the '=>' syntax.
+    first_payload = %{"a" => 2}
+    second_payload = %{"a" => 3}
+    last_payload = %{"a" => 1}
+
+    # Assert that we get nil back for our first request
+    assert {:ok, nil} == new_req(cog_env: first_payload, invocation_step: "first", invocation_id: inv_id)
+           |> send_req()
+
+    # Assert that the correct value was stored
+    assert [first_payload] == memory_fetch(inv_id)
+
+    # Assert that we get nil back for our second request
+    # Only the first and last invocation steps are set, the rest are nil.
+    assert {:ok, nil} == new_req(cog_env: second_payload, invocation_step: nil, invocation_id: inv_id)
+           |> send_req()
+
+    # Assert that everything is accumulating properly
+    assert [first_payload, second_payload] == memory_fetch(inv_id)
+
+    # Our last request should return a result instead of nil
+    # I'm setting the invocation_step to 'last' here for clarity, but the helper actually uses
+    # 'last' as the default.
+    refute {:ok, nil} == new_req(cog_env: last_payload, invocation_step: "last", invocation_id: inv_id)
+           |> send_req()
+
+    # Assert that the memory service contains no data
+    assert %{"error" => "key not found"} == memory_fetch(inv_id)
   end
 end

--- a/test/commands/sort_test.exs
+++ b/test/commands/sort_test.exs
@@ -1,27 +1,49 @@
 defmodule Cog.Test.Commands.SortTest do
-  use Cog.AdapterCase, adapter: "test"
-
-  @moduletag :skip
+  use Cog.CommandCase, command_module: Cog.Commands.Sort
 
   setup do
-    user = user("jfrost", first_name: "Jim", last_name: "Frost")
-    |> with_chat_handle_for("test")
+    seed = [%{"a" => 1},
+            %{"a" => 3},
+            %{"a" => 2}]
 
-    {:ok, %{user: user}}
+    {:ok, %{seed: seed}}
   end
 
-  test "basic sorting", %{user: user} do
-    response = send_message(user, ~s(@bot: seed '[{"a": 1}, {"a": 3}, {"a": 2}]' | sort))
-    assert response == [%{a: 1}, %{a: 2}, %{a: 3}]
+  test "basic sorting", %{seed: seed} do
+    request = Enum.map(seed, &(new_req(cog_env: &1)))
+
+    # When you send a list of requests you get a list of responses back
+    # We only care about the last one though, the rest should be nil
+    {:ok, response} = send_req(request) |> List.last
+
+    decoded = Poison.decode!(response)
+    assert [%{"a" => 1},
+            %{"a" => 2},
+            %{"a" => 3}] = decoded
   end
 
-  test "sorting in descending order", %{user: user} do
-    response = send_message(user, ~s(@bot: seed '[{"a": 1}, {"a": 3}, {"a": 2}]' | sort --desc))
-    assert response == [%{a: 3}, %{a: 2}, %{a: 1}]
+  test "sorting in descending order", %{seed: seed} do
+    request = Enum.map(seed, &(new_req(cog_env: &1, options: %{"desc" => true})))
+
+    {:ok, response} = send_req(request) |> List.last
+
+    decoded = Poison.decode!(response)
+    assert [%{"a" => 3},
+            %{"a" => 2},
+            %{"a" => 1}] = decoded
   end
 
-  test "sorting by specific fields", %{user: user} do
-    response = send_message(user, ~s(@bot: seed '[{"a": 3, "b": 4}, {"a": 1, "b": 4}, {"a": 2, "b": 6}]' | sort b a))
-    assert response == [%{a: 1, b: 4}, %{a: 3, b: 4}, %{a: 2, b: 6}]
+  test "sorting by specific fields" do
+    seed = [%{"a" => 3, "b" => 4},
+            %{"a" => 1, "b" => 4},
+            %{"a" => 2, "b" => 6}]
+    request = Enum.map(seed, &(new_req(cog_env: &1, args: ["b", "a"])))
+
+    {:ok, response} = send_req(request) |> List.last
+
+    decoded = Poison.decode!(response)
+    assert [%{"a" => 1, "b" => 4},
+            %{"a" => 3, "b" => 4},
+            %{"a" => 2, "b" => 6}] = decoded
   end
 end

--- a/test/commands/sort_test.exs
+++ b/test/commands/sort_test.exs
@@ -2,9 +2,9 @@ defmodule Cog.Test.Commands.SortTest do
   use Cog.CommandCase, command_module: Cog.Commands.Sort
 
   setup do
-    seed = [%{"a" => 1},
-            %{"a" => 3},
-            %{"a" => 2}]
+    seed = [%{a: 1},
+            %{a: 3},
+            %{a: 2}]
 
     {:ok, %{seed: seed}}
   end
@@ -16,10 +16,9 @@ defmodule Cog.Test.Commands.SortTest do
     # We only care about the last one though, the rest should be nil
     {:ok, response} = send_req(request) |> List.last
 
-    decoded = Poison.decode!(response)
-    assert [%{"a" => 1},
-            %{"a" => 2},
-            %{"a" => 3}] = decoded
+    assert [%{a: 1},
+            %{a: 2},
+            %{a: 3}] = response
   end
 
   test "sorting in descending order", %{seed: seed} do
@@ -27,23 +26,21 @@ defmodule Cog.Test.Commands.SortTest do
 
     {:ok, response} = send_req(request) |> List.last
 
-    decoded = Poison.decode!(response)
-    assert [%{"a" => 3},
-            %{"a" => 2},
-            %{"a" => 1}] = decoded
+    assert [%{a: 3},
+            %{a: 2},
+            %{a: 1}] = response
   end
 
   test "sorting by specific fields" do
-    seed = [%{"a" => 3, "b" => 4},
-            %{"a" => 1, "b" => 4},
-            %{"a" => 2, "b" => 6}]
+    seed = [%{a: 3, b: 4},
+            %{a: 1, b: 4},
+            %{a: 2, b: 6}]
     request = Enum.map(seed, &(new_req(cog_env: &1, args: ["b", "a"])))
 
     {:ok, response} = send_req(request) |> List.last
 
-    decoded = Poison.decode!(response)
-    assert [%{"a" => 1, "b" => 4},
-            %{"a" => 3, "b" => 4},
-            %{"a" => 2, "b" => 6}] = decoded
+    assert [%{a: 1, b: 4},
+            %{a: 3, b: 4},
+            %{a: 2, b: 6}] = response
   end
 end

--- a/test/support/command_case.ex
+++ b/test/support/command_case.ex
@@ -4,68 +4,90 @@ defmodule Cog.CommandCase do
   Test case for internal Cog commands
   """
 
-  use ExUnit.CaseTemplate
+  use ExUnit.CaseTemplate, async: true
 
-  using command_module: command_module do
+  using opts do
     quote location: :keep do
-      alias Cog.Support.ModelUtilities
-      alias unquote(command_module)
+      import unquote(__MODULE__)
 
-      @command_name Module.split(unquote(command_module)) |> List.last |> String.downcase
+      @command_module Keyword.fetch!(unquote(opts), :command_module)
+      @command_name Module.split(@command_module) |> List.last |> String.downcase
 
-      defp new_req(opts \\ []) do
-        %Cog.Messages.Command{invocation_id: Keyword.get(opts, :invocation_id, "fake_invocation_id"),
-                              command: Keyword.get(opts, :command, @command_name),
-                              args: Keyword.get(opts, :args, []),
-                              options: Keyword.get(opts, :options, %{}),
-                              cog_env: Keyword.get(opts, :cog_env, %{}),
-                              invocation_step: Keyword.get(opts, :invocation_step, "last"),
-                              reply_to: Keyword.get(opts, :reply_to, "fake_reply_to"),
-                              requestor: Keyword.get(opts, :requestor, %Cog.Chat.User{}),
-                              room: Keyword.get(opts, :room, %Cog.Chat.Room{}),
-                              service_token: Keyword.get(opts, :service_token, service_token()),
-                              services_root: Keyword.get(opts, :services_root, Cog.ServiceEndpoint.public_url()),
-                              user: Keyword.get(opts, :user, %{})}
-      end
+      @moduletag commands: @command_name
 
-      defp send_req(module \\ unquote(command_module), req)
-      defp send_req(module, %Cog.Messages.Command{}=req) do
-        case module.handle_message(req, %{}) do
-          {:reply, _reply_to, _template, nil, _state} ->
-            {:ok, nil}
-          {:reply, _reply_to, nil, _state} ->
-            {:ok, nil}
-          {:reply, _reply_to, _template, reply, _state} ->
-            {:ok, Poison.encode!(reply)}
-          {:reply, _reply_to, reply, _state} ->
-            {:ok, Poison.encode!(reply)}
-          {:error, _reply_to, error_message, _state} ->
-            {:error, error_message}
-        end
-      end
-      defp send_req(module, reqs) when is_list(reqs) do
-        Enum.map(reqs, &(%{&1 | invocation_step: nil}))
-        |> List.update_at(0, &(%{&1 | invocation_step: "first"}))
-        |> List.update_at(-1, &(%{&1 | invocation_step: "last"}))
-        |> Enum.map(&(send_req(module, &1)))
-      end
+      # So we don't have to keep passing the command name and command module
+      def send_req(req),
+        do: send_req(@command_module, req)
 
-      defp service_token do
-        case Process.get(:service_token) do
-          nil ->
-            token = Cog.Command.Service.Tokens.new()
-            Process.put(:service_token, token)
-            token
-          token ->
-            token
-        end
-      end
-
+      def new_req(opts \\ []),
+        do: new_req(@command_name, opts)
     end
   end
 
   setup do
+    # We manually checkout the DB connection each time.
+    # This allows us to run tests async.
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Cog.Repo)
     :ok
   end
+
+  def new_req(command, opts) do
+    %Cog.Messages.Command{
+      invocation_id: Keyword.get(opts, :invocation_id, "fake_invocation_id"),
+      command: Keyword.get(opts, :command, command),
+      args: Keyword.get(opts, :args, []),
+      options: Keyword.get(opts, :options, %{}),
+      cog_env: Keyword.get(opts, :cog_env, %{}),
+      invocation_step: Keyword.get(opts, :invocation_step, "last"),
+      reply_to: Keyword.get(opts, :reply_to, "fake_reply_to"),
+      requestor: Keyword.get(opts, :requestor, %Cog.Chat.User{}),
+      room: Keyword.get(opts, :room, %Cog.Chat.Room{}),
+      service_token: Keyword.get(opts, :service_token, service_token()),
+      services_root: Keyword.get(opts, :services_root, Cog.ServiceEndpoint.public_url()),
+      user: Keyword.get(opts, :user, %{})}
+  end
+
+  def send_req(module, %Cog.Messages.Command{}=req) do
+    case module.handle_message(req, %{}) do
+      {:reply, _reply_to, _template, nil, _state} ->
+        {:ok, nil}
+      {:reply, _reply_to, nil, _state} ->
+        {:ok, nil}
+      {:reply, _reply_to, _template, reply, _state} ->
+        # We're encoding and then decoding here because that's basically what happens
+        # normally when the message is sent over the bus. It also serves to strip a
+        # lot of the cruft from the reply and makes it more closely resemble what it
+        # would normally.
+        reply = Poison.encode!(reply)
+        |> Poison.decode!(keys: :atoms)
+        {:ok, reply}
+      {:reply, _reply_to, reply, _state} ->
+        reply = Poison.encode!(reply)
+        |> Poison.decode!(keys: :atoms)
+        {:ok, reply}
+      {:error, _reply_to, error_message, _state} ->
+        {:error, error_message}
+    end
+  end
+  # If we get a list of reqs then we set the invocation_step for each and map over them
+  def send_req(module, reqs) when is_list(reqs) do
+    Enum.map(reqs, &(%{&1 | invocation_step: nil}))
+    |> List.update_at(0, &(%{&1 | invocation_step: "first"}))
+    |> List.update_at(-1, &(%{&1 | invocation_step: "last"}))
+    |> Enum.map(&(send_req(module, &1)))
+  end
+
+  # Service token is unique per process, so we create one with the first `new_req`
+  # and store that in the process dictionary for any additional reqs
+  defp service_token do
+    case Process.get(:service_token) do
+      nil ->
+        token = Cog.Command.Service.Tokens.new()
+        Process.put(:service_token, token)
+        token
+      token ->
+        token
+    end
+  end
+
 end

--- a/test/support/command_case.ex
+++ b/test/support/command_case.ex
@@ -1,0 +1,49 @@
+defmodule Cog.CommandCase do
+
+  @moduledoc """
+  Test case for internal Cog commands
+  """
+
+  use ExUnit.CaseTemplate
+
+  using command_module: command_module do
+    quote do
+      alias Cog.Support.ModelUtilities
+      alias unquote(command_module)
+
+      @command_name Module.split(unquote(command_module)) |> List.last |> String.downcase
+
+      defp new_req(opts \\ []) do
+        %Cog.Messages.Command{invocation_id: Keyword.get(opts, :invocation_id, "fake_invocation_id"),
+                              command: Keyword.get(opts, :command, @command_name),
+                              args: Keyword.get(opts, :args, []),
+                              options: Keyword.get(opts, :options, %{}),
+                              cog_env: Keyword.get(opts, :cog_env, %{}),
+                              invocation_step: Keyword.get(opts, :invocation_step, "last"),
+                              reply_to: Keyword.get(opts, :reply_to, "fake_reply_to"),
+                              requestor: Keyword.get(opts, :requestor, %Cog.Chat.User{}),
+                              room: Keyword.get(opts, :room, %Cog.Chat.Room{}),
+                              service_token: Keyword.get(opts, :service_token, "fake_service_token"),
+                              services_root: Keyword.get(opts, :services_root, "fake_services_root"),
+                              user: Keyword.get(opts, :user, %{})}
+      end
+
+      defp send_req(module \\ unquote(command_module), %Cog.Messages.Command{}=req) do
+        case module.handle_message(req, %{}) do
+          {:reply, _reply_to, _template, reply, _state} ->
+            {:ok, Poison.encode!(reply)}
+          {:reply, _reply_to, reply, _state} ->
+            {:ok, Poison.encode!(reply)}
+          {:error, _reply_to, error_message, _state} ->
+            {:error, error_message}
+        end
+      end
+
+    end
+  end
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Cog.Repo)
+    :ok
+  end
+end

--- a/test/support/command_case.ex
+++ b/test/support/command_case.ex
@@ -7,7 +7,7 @@ defmodule Cog.CommandCase do
   use ExUnit.CaseTemplate
 
   using command_module: command_module do
-    quote do
+    quote location: :keep do
       alias Cog.Support.ModelUtilities
       alias unquote(command_module)
 
@@ -23,19 +23,41 @@ defmodule Cog.CommandCase do
                               reply_to: Keyword.get(opts, :reply_to, "fake_reply_to"),
                               requestor: Keyword.get(opts, :requestor, %Cog.Chat.User{}),
                               room: Keyword.get(opts, :room, %Cog.Chat.Room{}),
-                              service_token: Keyword.get(opts, :service_token, "fake_service_token"),
-                              services_root: Keyword.get(opts, :services_root, "fake_services_root"),
+                              service_token: Keyword.get(opts, :service_token, service_token()),
+                              services_root: Keyword.get(opts, :services_root, Cog.ServiceEndpoint.public_url()),
                               user: Keyword.get(opts, :user, %{})}
       end
 
-      defp send_req(module \\ unquote(command_module), %Cog.Messages.Command{}=req) do
+      defp send_req(module \\ unquote(command_module), req)
+      defp send_req(module, %Cog.Messages.Command{}=req) do
         case module.handle_message(req, %{}) do
+          {:reply, _reply_to, _template, nil, _state} ->
+            {:ok, nil}
+          {:reply, _reply_to, nil, _state} ->
+            {:ok, nil}
           {:reply, _reply_to, _template, reply, _state} ->
             {:ok, Poison.encode!(reply)}
           {:reply, _reply_to, reply, _state} ->
             {:ok, Poison.encode!(reply)}
           {:error, _reply_to, error_message, _state} ->
             {:error, error_message}
+        end
+      end
+      defp send_req(module, reqs) when is_list(reqs) do
+        Enum.map(reqs, &(%{&1 | invocation_step: nil}))
+        |> List.update_at(0, &(%{&1 | invocation_step: "first"}))
+        |> List.update_at(-1, &(%{&1 | invocation_step: "last"}))
+        |> Enum.map(&(send_req(module, &1)))
+      end
+
+      defp service_token do
+        case Process.get(:service_token) do
+          nil ->
+            token = Cog.Command.Service.Tokens.new()
+            Process.put(:service_token, token)
+            token
+          token ->
+            token
         end
       end
 


### PR DESCRIPTION
This adds a new test case, `Cog.CommandCase` that basically just calls the `handle_message` function in the command module. Tests can now run async. 

I rewrote the `help` and `sort` tests to see how well it works with standard commands and commands that use the memory service.

depends on #1121 
part if #1122 