### PR TITLE
fix embedded command -h flag

### DIFF
--- a/lib/cog/commands/helpers.ex
+++ b/lib/cog/commands/helpers.ex
@@ -19,7 +19,7 @@ defmodule Cog.Commands.Helpers do
         bundle_name = Cog.Util.Misc.embedded_bundle
         command_name = Cog.Command.GenCommand.Base.command_name(__MODULE__)
 
-        command_version = bundle_name <> ":" <> command_name
+        [command_version] = bundle_name <> ":" <> command_name
         |> Cog.Repository.Commands.with_status_by_any_name
         |> Cog.Repository.Commands.preloads_for_help
 


### PR DESCRIPTION
`Cog.Repository.Commands.with_status_by_any_name/1` was returning a list but `Cog.CommandVersionHelpView.render/2` expected a single version. That was causing commands that use the `-h` flag to crash.

For now I'm just matching on a one item list because that's all that we should ever get in this particular case. But we should probably soon drop the special handling of help in embedded commands and start leveraging git style subcommands and the help command.

resolves #1154 