### PR TITLE
bundle not found error

### DIFF
--- a/lib/cog/command/command_resolver.ex
+++ b/lib/cog/command/command_resolver.ex
@@ -24,6 +24,8 @@ defmodule Cog.Command.CommandResolver do
           {:pipeline, pipeline}
         :not_found ->
           {:error, :not_found}
+        {:bundle_not_found, bundle_name} ->
+          {:error, {:bundle_not_found, bundle_name}}
         {:not_enabled, bundle_name} ->
           {:error, {:not_enabled, bundle_name}}
         {:not_in_bundle, bundle_name} ->
@@ -54,8 +56,14 @@ defmodule Cog.Command.CommandResolver do
   def lookup(bundle_name, command_name, _user, enabled_bundles) do
     case Map.get(enabled_bundles, bundle_name) do
       nil ->
-        # No enabled version of the requested bundle was found
-        {:not_enabled, bundle_name}
+        case Bundles.bundle_by_name(bundle_name) do
+          nil ->
+            # No bundle found
+            {:bundle_not_found, bundle_name}
+          _bundle ->
+            # Bundle exists but isn't enabled
+            {:not_enabled, bundle_name}
+        end
       version ->
         case Bundles.command_for_bundle_version(command_name, bundle_name, version) do
           nil ->

--- a/mix.lock
+++ b/mix.lock
@@ -54,7 +54,7 @@
   "phoenix_html": {:hex, :phoenix_html, "2.7.0", "19e12e2044340c2e43df206a06d059677c59ea1868bd1c35165438d592cd420b", [:mix], [{:plug, "~> 1.0", [hex: :plug, optional: false]}]},
   "phoenix_live_reload": {:hex, :phoenix_live_reload, "1.0.5", "829218c4152ba1e9848e2bf8e161fcde6b4ec679a516259442561d21fde68d0b", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}, {:phoenix, "~> 1.0 or ~> 1.2-rc", [hex: :phoenix, optional: false]}]},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.1", "c10ddf6237007c804bf2b8f3c4d5b99009b42eca3a0dfac04ea2d8001186056a", [:mix], []},
-  "piper": {:git, "https://github.com/operable/piper.git", "1d52b32f41226398fdb37baca7398bbf0b93c1a3", []},
+  "piper": {:git, "https://github.com/operable/piper.git", "8449ba8f2d4291a98686461b968757583081ecda", []},
   "plug": {:hex, :plug, "1.2.2", "cfbda521b54c92ab8ddffb173fbaabed8d8fc94bec07cd9bb58a84c1c501b0bd", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},

--- a/test/cog/command/command_resolver_test.exs
+++ b/test/cog/command/command_resolver_test.exs
@@ -127,6 +127,36 @@ defmodule Cog.Command.CommandResolver.Test do
     assert result == :not_found
   end
 
+  test "returns an error when the bundle is not found" do
+    user = user("testuser")
+    result = CommandResolver.lookup("fake-bundle", "fake-command", user, enabled_bundles)
+    assert result == {:bundle_not_found, "fake-bundle"}
+  end
+
+  test "returns an error when a command is not in the specified bundle" do
+    user = user("testuser")
+    result = CommandResolver.lookup("operable", "not-a-real-command", user, enabled_bundles)
+    assert result == {:not_in_bundle, "operable"}
+  end
+
+  test "returns an error when a bundle is not enabled" do
+    bundle_name = "disabled_bundle"
+    config = %{
+      "name" => bundle_name,
+      "version" => "0.0.1",
+      "commands" => %{
+        "disabled_echo" => %{
+          "module" => "Cog.Commands.Echo",
+          "documentation" => "does stuff"}}}
+    Cog.Repository.Bundles.install(%{"name" => bundle_name,
+                                     "version" => "0.0.1",
+                                     "config_file" => config})
+
+    user = user("testuser")
+
+    result = CommandResolver.lookup(bundle_name, "disabled_echo", user, enabled_bundles)
+    assert result == {:not_enabled, bundle_name}
+  end
 
   test "appropriately versioned rules and site rules are returned in the parser metadata" do
     user = user("test-user")


### PR DESCRIPTION
Adds a new error when the specified bundle can't be found.

resolves #1155 
depends on https://github.com/operable/piper/pull/37