### PR TITLE
Make common error template configurable

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -74,6 +74,8 @@ config :cog, Cog.Command.Pipeline,
 config :cog, Cog.Command.Service,
   data_path: data_dir("service_data")
 
+config :cog, :custom_template_dir, System.get_env("COG_CUSTOM_TEMPLATE_DIR")
+
 # Set these to zero (0) to disable caching
 config :cog, :command_cache_ttl, {60, :sec}
 config :cog, :command_rule_ttl, {10, :sec}

--- a/test/cog/template/new/evaluator_test.exs
+++ b/test/cog/template/new/evaluator_test.exs
@@ -1,0 +1,78 @@
+defmodule Cog.Template.New.EvaluatorTest do
+  use ExUnit.Case
+
+  @moduletag templates: :evaluator
+
+  alias Cog.Template.New.Evaluator
+
+  setup do
+    # We manually checkout the DB connection each time.
+    # This allows us to run tests async.
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Cog.Repo)
+    :ok
+  end
+
+  describe "custom common templates" do
+
+    setup :with_fake_data
+
+    test "error template evaluates normally when there is no custom template dir", %{data: data} do
+      expected_directives =
+        [%{children:
+           [%{name: :newline},
+            %{name: :newline},
+            %{name: :text, text: "The specific error was:"},
+            %{name: :newline}, %{name: :newline},
+            %{name: :fixed_width_block, text: "this is an error"}],
+          color: "#ff3333",
+          name: :attachment,
+          title: "Command Error",
+          fields: [%{short: false, title: "Started",
+                     value: "2016-11-18T20:52:23Z"},
+                    %{short: false, title: "Pipeline ID", value: "fake_id"},
+                    %{short: false, title: "Pipeline", value: "fake pipeline"},
+                    %{short: false, title: "Caller", value: "fake_user"}]}]
+
+      results = Evaluator.evaluate("error", data)
+
+      assert(^expected_directives = results)
+    end
+
+    test "error template is replaced when a custom template is available", %{data: data} do
+      # Save the original value for the custom_template_dir so we can replace it later
+      orig_dir = Application.get_env(:cog, :custom_template_dir)
+      on_exit(fn ->
+        Application.put_env(:cog, :custom_template_dir, orig_dir)
+      end)
+
+      # Update the config value
+      Application.put_env(:cog, :custom_template_dir, "fake/dir/path")
+
+      # We'll just mock File.read so we don't have to mess with the file system
+      :meck.new(File, [:passthrough])
+      :meck.expect(File, :read, fn
+                     ("fake/dir/path/error.greenbar") ->
+                       :meck.unload(File)
+                       {:ok, "fake template body"}
+      end)
+
+      # Finally we can call the evaluator
+      results = Evaluator.evaluate("error", data)
+
+      # Make sure the evaluator called File
+      assert([%{name: :text, text: "fake template body"}] = results)
+    end
+
+  end
+
+  #### Setup Functions ####
+
+  defp with_fake_data(_) do
+    [data: %{"id" => "fake_id",
+             "started" => "2016-11-18T20:52:23Z",
+             "initiator" => "fake_user",
+             "pipeline_text" => "fake pipeline",
+             "error_message" => "this is an error"}]
+
+  end
+end


### PR DESCRIPTION
The common error template is now configurable via the env var `COG_CUSTOM_TEMPLATE_DIR`. The var should point to a directory that contains a file named `error.greenbar` that will replace the standard `error.greenbar`.

I went the directory route so we can make additional templates configurable more easily in the future. Common templates that are configurable are white listed. Currently the only configurable template is the standard error template.

Documentation to come.

part of #1142