### PR TITLE
Rename back to Cog.Command.Seed

### DIFF
--- a/lib/cog/commands/seed.ex
+++ b/lib/cog/commands/seed.ex
@@ -1,4 +1,4 @@
-defmodule Cog.Commands.Seed do
+defmodule Cog.Command.Seed do
   use Cog.Command.GenCommand.Base, bundle: Cog.Util.Misc.embedded_bundle
 
   alias Cog.Messages.Command

--- a/test/commands/seed_test.exs
+++ b/test/commands/seed_test.exs
@@ -1,5 +1,5 @@
 defmodule Cog.Test.Commands.SeedTest do
-  use Cog.CommandCase, command_module: Cog.Commands.Seed
+  use Cog.CommandCase, command_module: Cog.Command.Seed
 
   test "basic seeding" do
     {:ok, response} = new_req(args: [~s([{"a": 1}, {"a": 3}, {"a": 2}])])


### PR DESCRIPTION
While it is true that this module really should be renamed
`Cog.Commands.Seed` (note plural), it requires a bump to the embedded
bundle version; otherwise existing installations will be unable to
start.

While we could bump the version, it's better to roll back this change,
reserving version bumps for more meaningful changes.

(Incidentally, the `Cog.Command.Raw` module also needs changing in this
same way. Something for the future.)

For reference, this commit reverts
d6a22b6aabb2913931ff4477e5e515eca6bf2107, as well as part of
abd259a3ea6ef2e7da37bf11ab8510f693c92c82.

Fixes #1169 