### PR TITLE
Remove Adz

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -92,12 +92,23 @@ config :cog, :max_alias_expansion, 5
 # ========================================================================
 # Logging
 
-log_opts = [metadata: [:module, :line], format: {Adz, :text}]
+common_metadata = [:module, :line]
+common_log_format = "$dateT$time $metadata[$level] $levelpad$message\n"
 
 config :logger,
-  backends: [:console, {LoggerFileBackend, :cog_log}],
-  console: log_opts,
-  cog_log: log_opts ++ [path: data_dir("cog.log")]
+  utc_log: true,
+  level: :info,
+  backends: [:console,
+             {LoggerFileBackend, :flywheel_log}]
+
+config :logger, :console,
+  metadata: common_metadata,
+  format: common_log_format
+
+config :logger, :cog_log,
+  metadata: common_metadata,
+  format: common_log_format,
+  path: data_dir("cog.log")
 
 if System.get_env("COG_SASL_LOG") != nil do
 config :logger,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,7 +1,7 @@
 use Mix.Config
 import Cog.Config.Helpers
 
-config :logger, :console,
+config :logger,
   level: :debug
 
 config :lager, :handlers,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,8 +1,5 @@
 use Mix.Config
 
-config :logger, :console,
-  level: :info
-
 config :lager, :handlers,
   [{LagerLogger, [level: :error]}]
 

--- a/config/staging.exs
+++ b/config/staging.exs
@@ -1,8 +1,5 @@
 use Mix.Config
 
-config :logger, :console,
-  level: :info
-
 config :lager, :handlers,
   [{LagerLogger, [level: :error]}]
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,8 +1,5 @@
 use Mix.Config
 
-config :logger, :console,
-  level: :info
-
 config :lager, :handlers,
   [{LagerLogger, [level: :error]}]
 

--- a/lib/carrier/messaging/connection.ex
+++ b/lib/carrier/messaging/connection.ex
@@ -1,6 +1,6 @@
 defmodule Carrier.Messaging.Connection do
 
-  use Adz
+  require Logger
 
   alias Carrier.Messaging.Messages.MqttCall
   alias Carrier.Messaging.Messages.MqttCast

--- a/lib/carrier/messaging/gen_mqtt.ex
+++ b/lib/carrier/messaging/gen_mqtt.ex
@@ -2,7 +2,7 @@ defmodule Carrier.Messaging.GenMqtt do
 
   @infinity_timeout 3600000 # one hour in millis
 
-  use Adz
+  require Logger
   use GenServer
   alias Carrier.Messaging.Connection
   alias Carrier.Messaging.Messages.MqttCall

--- a/lib/cog/bundle/embedded.ex
+++ b/lib/cog/bundle/embedded.ex
@@ -4,7 +4,7 @@ defmodule Cog.Bundle.Embedded do
   """
 
   use Supervisor
-  use Adz
+  require Logger
 
   alias Cog.Bundle.Config
   alias Cog.Repository

--- a/lib/cog/chat/http/connector.ex
+++ b/lib/cog/chat/http/connector.ex
@@ -5,7 +5,7 @@ defmodule Cog.Chat.Http.Connector do
   alias Cog.Chat.Http.Provider
 
   use GenServer
-  use Adz
+  require Logger
 
   def start_link,
     do: GenServer.start_link(__MODULE__, [], name: __MODULE__)

--- a/lib/cog/command/pipeline/destination.ex
+++ b/lib/cog/command/pipeline/destination.ex
@@ -10,7 +10,7 @@ defmodule Cog.Command.Pipeline.Destination do
              output_level: :full,
              adapter: nil,
              room: nil]
-  use Adz
+  require Logger
   alias Cog.Chat.Adapter
 
   @doc """

--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -109,7 +109,7 @@ defmodule Cog.Command.Pipeline.Executor do
 
   @behaviour :gen_fsm
 
-  use Adz
+  require Logger
 
   def start_link(request),
     do: :gen_fsm.start_link(__MODULE__, [request], [])

--- a/lib/cog/relay/info.ex
+++ b/lib/cog/relay/info.ex
@@ -14,7 +14,7 @@ defmodule Cog.Relay.Info do
 
   defstruct [mq_conn: nil]
 
-  use Adz
+  require Logger
   use GenServer
 
   alias Carrier.Messaging

--- a/lib/cog/relay/relays.ex
+++ b/lib/cog/relay/relays.ex
@@ -5,7 +5,7 @@ defmodule Cog.Relay.Relays do
   defstruct [mq_conn: nil,
              tracker: Tracker.new]
 
-  use Adz
+  require Logger
   use GenServer
 
   alias Carrier.Messaging

--- a/mix.exs
+++ b/mix.exs
@@ -60,7 +60,6 @@ defmodule Cog.Mixfile do
     [
       # Operable Code
       ########################################################################
-      {:adz, github: "operable/adz"},
       {:conduit, github: "operable/conduit"},
       {:fumanchu, github: "operable/fumanchu"},
       {:greenbar, github: "operable/greenbar"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,4 @@
-%{"adz": {:git, "https://github.com/operable/adz.git", "f990b73588f4a4bff40a07b3e7747f9999c10202", []},
-  "bamboo": {:hex, :bamboo, "0.7.0", "2722e395a396dfedc12d300c900f65b216f7d7bf9d430c5dd0235690997878b7", [:mix], [{:httpoison, "~> 0.9", [hex: :httpoison, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}, {:poison, ">= 1.5.0", [hex: :poison, optional: false]}]},
+%{"bamboo": {:hex, :bamboo, "0.7.0", "2722e395a396dfedc12d300c900f65b216f7d7bf9d430c5dd0235690997878b7", [:mix], [{:httpoison, "~> 0.9", [hex: :httpoison, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}, {:poison, ">= 1.5.0", [hex: :poison, optional: false]}]},
   "bamboo_smtp": {:hex, :bamboo_smtp, "1.2.1", "47181e338cbee9d028e94f2bc5829816b26d719d8213b07d0fa107d95b591947", [:mix], [{:bamboo, "~> 0.7.0", [hex: :bamboo, optional: false]}, {:gen_smtp, "~> 0.11.0", [hex: :gen_smtp, optional: false]}]},
   "bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
   "certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},


### PR DESCRIPTION
We can get what we want out of Adz by using using stock Logger.

The significant change is that the module and line number of the log
sites are now given as key/value pairs, instead of `module:line`.

Additionally, timestamps are given in UTC, and it is much easier to add arbitrary new key/value pairs to the output in the future.

Previously, output looked like this:

```
2016-11-18T21:13:43.0641  (Cog.Command.Service.Memory:74) [info] Dead pipeline token clean up interval set to 30 seconds.
2016-11-18T21:13:43.0642  (Cog.Command.PermissionsCache:35) [info] Ready. Cache TTL is 10 seconds.
2016-11-18T21:13:43.0646  (Cog.Command.Pipeline.Initializer:31) [info] Ready.
2016-11-18T21:13:43.0732  (Phoenix.Endpoint.CowboyHandler:101) [info] Running Cog.Endpoint with Cowboy using http://localhost:4000
2016-11-18T21:13:43.0742  (Phoenix.Endpoint.CowboyHandler:101) [info] Running Cog.TriggerEndpoint with Cowboy using http://localhost:4001
2016-11-18T21:13:43.0746  (Phoenix.Endpoint.CowboyHandler:101) [info] Running Cog.ServiceEndpoint with Cowboy using http://localhost:4002
2016-11-18T21:13:43.0750  (Cog.Chat.Adapter:159) [info] Starting
2016-11-18T21:13:48.0350  (Cog.Chat.Slack.Connector:29) [info] Connected to Slack with handle 'marvin'.
2016-11-18T21:13:48.0350  (Cog.Chat.Adapter:277) [info] Chat provider 'slack' (Elixir.Cog.Chat.Slack.Provider) initialized.
2016-11-18T21:13:48.0354  (Cog.Chat.Adapter:277) [info] Chat provider 'http' (Elixir.Cog.Chat.Http.Provider) initialized.
2016-11-18T21:13:48.0357  (Cog:65) [info] Database schema is up-to-date
2016-11-18T21:13:48.0360  (Cog:50) [info] Ensuring common templates are up-to-date
```

Now, it looks like this:

```
2016-11-19T02:17:06.191 module=Cog.Command.Service.Memory line=74 [info]  Dead pipeline token clean up interval set to 30 seconds.
2016-11-19T02:17:06.191 module=Cog.Command.PermissionsCache line=35 [info]  Ready. Cache TTL is 10 seconds.
2016-11-19T02:17:06.198 module=Cog.Command.Pipeline.Initializer line=31 [info]  Ready.
2016-11-19T02:17:06.271 module=Phoenix.Endpoint.CowboyHandler line=101 [info]  Running Cog.Endpoint with Cowboy using http://localhost:4000
2016-11-19T02:17:06.275 module=Phoenix.Endpoint.CowboyHandler line=101 [info]  Running Cog.TriggerEndpoint with Cowboy using http://localhost:4001
2016-11-19T02:17:06.280 module=Phoenix.Endpoint.CowboyHandler line=101 [info]  Running Cog.ServiceEndpoint with Cowboy using http://localhost:4002
2016-11-19T02:17:06.284 module=Cog.Chat.Adapter line=159 [info]  Starting
2016-11-19T02:17:07.861 module=Cog.Chat.Slack.Connector line=29 [info]  Connected to Slack with handle 'marvin'.
2016-11-19T02:17:07.862 module=Cog.Chat.Adapter line=277 [info]  Chat provider 'slack' (Elixir.Cog.Chat.Slack.Provider) initialized.
2016-11-19T02:17:07.866 module=Cog.Chat.Adapter line=277 [info]  Chat provider 'http' (Elixir.Cog.Chat.Http.Provider) initialized.
2016-11-19T02:17:07.870 module=Cog line=65 [info]  Database schema is up-to-date
2016-11-19T02:17:07.872 module=Cog line=50 [info]  Ensuring common templates are up-to-date

```

Fixes #1171