### PR TITLE
Tweak error reply output

### DIFF
--- a/lib/cog/chat/hipchat/template_processor.ex
+++ b/lib/cog/chat/hipchat/template_processor.ex
@@ -8,10 +8,11 @@ defmodule Cog.Chat.HipChat.TemplateProcessor do
   end
 
   defp process_directive(%{"name" => "attachment"}=attachment) do
-    @attachment_fields
+    rendered_body = @attachment_fields
     |> Enum.reduce([], &(render_attachment(&1, &2, attachment)))
     |> List.flatten
     |> Enum.join
+    rendered_body <> "<br/>"
   end
   defp process_directive(%{"name" => "text", "text" => text}),
     do: text
@@ -82,7 +83,7 @@ defmodule Cog.Chat.HipChat.TemplateProcessor do
       nil ->
         acc
       footer ->
-        ["<br/>#{footer}<br/>"|acc]
+        ["<br/>#{footer}"|acc]
     end
   end
   defp render_attachment("children", acc, attachment) do
@@ -99,9 +100,9 @@ defmodule Cog.Chat.HipChat.TemplateProcessor do
         acc
       fields ->
         rendered_fields = fields
-        |> Enum.map(fn(%{"title" => title, "value" => value}) -> "<strong>#{title}:</strong> #{value}<br/>" end)
+        |> Enum.map(fn(%{"title" => title, "value" => value}) -> "<strong>#{title}:</strong><br/>#{value}<br/><br/>" end)
         |> Enum.join
-        [rendered_fields <> "<br/>"|acc]
+        [rendered_fields|acc]
     end
   end
   defp render_attachment("pretext", acc, attachment) do
@@ -127,9 +128,9 @@ defmodule Cog.Chat.HipChat.TemplateProcessor do
       title ->
         case Map.get(attachment, "title_url") do
           nil ->
-            ["<strong>#{title}</strong><br/><br/>"|acc]
+            ["<strong>#{title}</strong><br/>"|acc]
           url ->
-            ["<a href=\"#{url}\">title</a><br/><br/>"|acc]
+            ["<strong><a href=\"#{url}\">title</a></strong><br/>"|acc]
         end
     end
   end

--- a/lib/cog/chat/hipchat/template_processor.ex
+++ b/lib/cog/chat/hipchat/template_processor.ex
@@ -91,7 +91,7 @@ defmodule Cog.Chat.HipChat.TemplateProcessor do
       nil ->
         acc
       children ->
-        [render(children) <> "<br/><br/>"|acc]
+        [render(children) <> "<br/>"|acc]
     end
   end
   defp render_attachment("fields", acc, attachment) do

--- a/lib/cog/chat/hipchat/template_processor.ex
+++ b/lib/cog/chat/hipchat/template_processor.ex
@@ -1,7 +1,7 @@
 defmodule Cog.Chat.HipChat.TemplateProcessor do
   require Logger
 
-  @attachment_fields ["footer", "children", "fields", "pretext", "author", "title"]
+  @attachment_fields ["footer", "fields", "children", "pretext", "author", "title"]
 
   def render(directives) do
     render_directives(directives)
@@ -91,7 +91,7 @@ defmodule Cog.Chat.HipChat.TemplateProcessor do
       nil ->
         acc
       children ->
-        [render(children)|acc]
+        [render(children) <> "<br/><br/>"|acc]
     end
   end
   defp render_attachment("fields", acc, attachment) do

--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -613,7 +613,6 @@ defmodule Cog.Command.Pipeline.Executor do
   # emits a pipeline failure audit event, and terminates the pipeline.
   defp fail_pipeline_with_error({reason, _detail}=error, state) do
     data = user_error(error, state)
-
     ReplyHelper.send("error",
                      data,
                      state.request.room,

--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -583,14 +583,14 @@ defmodule Cog.Command.Pipeline.Executor do
       %{invocations: [%Ast.Invocation{} = planning_failure|_]} ->
         to_string(planning_failure)
       _ ->
-        false
+        ""
     end
 
     execution_failure = case state do
       %{current_plan: %Plan{invocation_text: execution_failure}} ->
         to_string(execution_failure)
       _ ->
-        false
+        ""
     end
 
     %{"id" => id,

--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -1,5 +1,7 @@
 defmodule Cog.Command.Pipeline.Executor do
 
+  require Logger
+
   alias Carrier.Messaging.Connection
   alias Cog.AuditMessage
   alias Cog.Chat.Adapter, as: ChatAdapter
@@ -577,13 +579,18 @@ defmodule Cog.Command.Pipeline.Executor do
     pipeline_text = state.request.text
     error_message = ErrorResponse.render(error)
 
-    {planning_failure, execution_failure} = case state do
-      %{current_plan: %Plan{invocation_text: planning_failure}} ->
-        {to_string(planning_failure), false}
-      %{invocations: [%Ast.Invocation{} = execution_failure|_]} ->
-        {false, to_string(execution_failure)}
+    planning_failure = case state do
+      %{invocations: [%Ast.Invocation{} = planning_failure|_]} ->
+        to_string(planning_failure)
       _ ->
-        {false, false}
+        false
+    end
+
+    execution_failure = case state do
+      %{current_plan: %Plan{invocation_text: execution_failure}} ->
+        to_string(execution_failure)
+      _ ->
+        false
     end
 
     %{"id" => id,

--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -613,6 +613,7 @@ defmodule Cog.Command.Pipeline.Executor do
   # emits a pipeline failure audit event, and terminates the pipeline.
   defp fail_pipeline_with_error({reason, _detail}=error, state) do
     data = user_error(error, state)
+
     ReplyHelper.send("error",
                      data,
                      state.request.room,

--- a/lib/cog/error_response.ex
+++ b/lib/cog/error_response.ex
@@ -14,7 +14,7 @@ defmodule Cog.ErrorResponse do
     do: "No rules match the supplied invocation of '#{current_invocation}'. Check your args and options, then confirm that the proper rules are in place."
   def render({:denied, {%Ast.Rule{}=rule, current_invocation}}) do
     perms = Enum.map(Ast.Rule.permissions_used(rule), &("'#{&1}'")) |> Enum.join(", ")
-    "Sorry, you aren't allowed to execute '#{current_invocation}' :(\n You will need at least one of the following permissions to run this command: #{perms}."
+    "Sorry, you aren't allowed to execute '#{current_invocation}'.\nYou will need at least one of the following permissions to run this command: #{perms}."
   end
   def render({:no_relays, bundle_name}) do # TODO: Add version, too?
     "No Cog Relays supporting the `#{bundle_name}` bundle are currently online. " <>

--- a/lib/cog/template/new/evaluator.ex
+++ b/lib/cog/template/new/evaluator.ex
@@ -152,6 +152,8 @@ defmodule Cog.Template.New.Evaluator do
 
   # public for tests _only_
   def do_evaluate(name, source, data) do
+    IO.puts "in do_evaluate: #{inspect data}"
+    IO.puts "in do_evaluate: #{inspect source}"
     {:ok, engine} = Engine.new
     engine
     |> Engine.compile!(name, source)

--- a/lib/cog/template/new/evaluator.ex
+++ b/lib/cog/template/new/evaluator.ex
@@ -152,8 +152,6 @@ defmodule Cog.Template.New.Evaluator do
 
   # public for tests _only_
   def do_evaluate(name, source, data) do
-    IO.puts "in do_evaluate: #{inspect data}"
-    IO.puts "in do_evaluate: #{inspect source}"
     {:ok, engine} = Engine.new
     engine
     |> Engine.compile!(name, source)

--- a/priv/templates/common/error.greenbar
+++ b/priv/templates/common/error.greenbar
@@ -25,8 +25,8 @@
 ```
 ~end~
 ~end~
-~if cond=$execution_failure == ""~
 ~end~
+~if cond=$execution_failure == ""~
 ~if cond=$planning_failure == ""~
 ~attachment title="Pipeline Error" color="#ff3333" Caller=$initiator Pipeline=$pipeline_text "Pipeline ID"=$id Started=$started~
 

--- a/priv/templates/common/error.greenbar
+++ b/priv/templates/common/error.greenbar
@@ -1,29 +1,38 @@
-~if cond=$execution_failure~
-~attachment title="Command Error" color="#ff3333"~
-The pipeline failed executing the command:
-
-```
-~$execution_failure~
-```
-~end~
-~end~
-
-~if cond=$planning_failure~
-~attachment title="Pipeline Error" color="#ff3333"~
-The pipeline failed planning the invocation:
-
-```
-~$planning_failure~
-```
-~end~
-~end~
-
-~attachment title="Error Message" color="#ff3333"~
+~if cond=$execution_failure != ""~
+~if cond=$planning_failure == ""~
+~attachment title="Command Execution Error" color="#ff3333" "Failed Executing"=$execution_failure Caller=$initiator Pipeline=$pipeline_text "Pipeline ID"=$id Started=$started~
 
 ```
 ~$error_message~
 ```
 ~end~
+~end~
+~if cond=$planning_failure != ""~
+~attachment title="Command Execution Error" color="#ff3333" "Failed Executing"=$execution_failure "Failed Planning"=$planning_failure Caller=$initiator Pipeline=$pipeline_text "Pipeline ID"=$id Started=$started~
 
-~attachment color="#ff3333" Caller=$initiator Pipeline=$pipeline_text "Pipeline ID"=$id Started=$started~
+```
+~$error_message~
+```
+~end~
+~end~
+~end~
+~if cond=$planning_failure != ""~
+~if cond=$execution_failure == ""~
+~attachment title="Pipeline Error" color="#ff3333" Caller=$initiator "Failed Planning"=$planning_failure Pipeline=$pipeline_text "Pipeline ID"=$id Started=$started~
+
+```
+~$error_message~
+```
+~end~
+~end~
+~end~
+~if cond=$execution_failure == ""~
+~if cond=$planning_failure == ""~
+~attachment title="Pipeline Error" color="#ff3333" Caller=$initiator Pipeline=$pipeline_text "Pipeline ID"=$id Started=$started~
+
+```
+~$error_message~
+```
+~end~
+~end~
 ~end~

--- a/priv/templates/common/error.greenbar
+++ b/priv/templates/common/error.greenbar
@@ -25,8 +25,8 @@
 ```
 ~end~
 ~end~
-~end~
 ~if cond=$execution_failure == ""~
+~end~
 ~if cond=$planning_failure == ""~
 ~attachment title="Pipeline Error" color="#ff3333" Caller=$initiator Pipeline=$pipeline_text "Pipeline ID"=$id Started=$started~
 

--- a/priv/templates/common/error.greenbar
+++ b/priv/templates/common/error.greenbar
@@ -1,23 +1,29 @@
-~attachment title="Command Error" color="#ff3333" Caller=$initiator Pipeline=$pipeline_text "Pipeline ID"=$id Started=$started~
-~if cond=$planning_failure ~
-The pipeline failed planning the invocation:
-~br~
-```
-~$planning_failure~
-```
-~end~
 ~if cond=$execution_failure~
+~attachment title="Command Error" color="#ff3333"~
 The pipeline failed executing the command:
-~br~
+
 ```
 ~$execution_failure~
 ```
 ~end~
-~br~
-~br~
-The specific error was:
-~br~
+~end~
+
+~if cond=$planning_failure~
+~attachment title="Pipeline Error" color="#ff3333"~
+The pipeline failed planning the invocation:
+
+```
+~$planning_failure~
+```
+~end~
+~end~
+
+~attachment title="Error Message" color="#ff3333"~
+
 ```
 ~$error_message~
 ```
+~end~
+
+~attachment color="#ff3333" Caller=$initiator Pipeline=$pipeline_text "Pipeline ID"=$id Started=$started~
 ~end~

--- a/test/cog/chat/hipchat/templates/common/error_test.exs
+++ b/test/cog/chat/hipchat/templates/common/error_test.exs
@@ -14,9 +14,6 @@ defmodule Cog.Chat.HipChat.Templates.Common.ErrorTest do
     rendered = Cog.Chat.HipChat.TemplateProcessor.render(directives)
 
     assert "<strong>Pipeline Error</strong><br/>" <>
-      "The pipeline failed planning the invocation:<br/>" <>
-      "<pre>I can't plan this!</pre><br/>" <>
-      "<strong>Error Message</strong><br/>" <>
       "<pre>bad stuff happened</pre><br/>" <>
       "<strong>Started:</strong><br/>" <>
       "some time in the past<br/>" <>
@@ -26,6 +23,8 @@ defmodule Cog.Chat.HipChat.Templates.Common.ErrorTest do
       "<br/>" <>
       "<strong>Pipeline:</strong><br/>" <>
       "echo foo<br/>" <>
+      "<strong>Failed Planning:</strong><br/>" <>
+      "<pre>I can't plan this!</pre><br/>" <>
       "<br/>" <>
       "<strong>Caller:</strong><br/>" <>
       "somebody<br/><br/><br/>" == rendered

--- a/test/cog/chat/hipchat/templates/common/error_test.exs
+++ b/test/cog/chat/hipchat/templates/common/error_test.exs
@@ -8,13 +8,14 @@ defmodule Cog.Chat.HipChat.Templates.Common.ErrorTest do
              "pipeline_text" => "echo foo",
              "error_message" => "bad stuff happened",
              "planning_failure" => "I can't plan this!",
-             "execution_failure" => false}
+             "execution_failure" => ""}
 
     directives = directives_for_template(:common, "error", data)
     rendered = Cog.Chat.HipChat.TemplateProcessor.render(directives)
-
-    assert "<strong>Pipeline Error</strong><br/>" <>
+    expected =
+      "<strong>Pipeline Error</strong><br/>" <>
       "<pre>bad stuff happened</pre><br/>" <>
+      "<br/>" <>
       "<strong>Started:</strong><br/>" <>
       "some time in the past<br/>" <>
       "<br/>" <>
@@ -23,11 +24,14 @@ defmodule Cog.Chat.HipChat.Templates.Common.ErrorTest do
       "<br/>" <>
       "<strong>Pipeline:</strong><br/>" <>
       "echo foo<br/>" <>
+      "<br/>" <>
       "<strong>Failed Planning:</strong><br/>" <>
-      "<pre>I can't plan this!</pre><br/>" <>
+      "I can't plan this!<br/>" <>
       "<br/>" <>
       "<strong>Caller:</strong><br/>" <>
-      "somebody<br/><br/><br/>" == rendered
+      "somebody<br/><br/><br/>"
+
+    assert expected == rendered
   end
 
   test "error template; execution failure" do
@@ -37,16 +41,14 @@ defmodule Cog.Chat.HipChat.Templates.Common.ErrorTest do
              "initiator" => "somebody",
              "pipeline_text" => "echo foo",
              "error_message" => "bad stuff happened",
-             "planning_failure" => false,
+             "planning_failure" => "",
              "execution_failure" => "I can't execute this!"}
     directives = directives_for_template(:common, "error", data)
     rendered = Cog.Chat.HipChat.TemplateProcessor.render(directives)
-
-    assert "<strong>Command Error</strong><br/>" <>
-      "The pipeline failed executing the command:<br/>" <>
-      "<pre>I can't execute this!</pre><br/>" <>
-      "<strong>Error Message</strong><br/>" <>
+    expected =
+      "<strong>Command Execution Error</strong><br/>" <>
       "<pre>bad stuff happened</pre><br/>" <>
+      "<br/>" <>
       "<strong>Started:</strong><br/>" <>
       "some time in the past<br/>" <>
       "<br/>" <>
@@ -56,10 +58,15 @@ defmodule Cog.Chat.HipChat.Templates.Common.ErrorTest do
       "<strong>Pipeline:</strong><br/>" <>
       "echo foo<br/>" <>
       "<br/>" <>
+      "<strong>Failed Executing:</strong><br/>" <>
+      "I can't execute this!<br/>" <>
+      "<br/>" <>
       "<strong>Caller:</strong><br/>" <>
       "somebody<br/>" <>
       "<br/>" <>
-      "<br/>" == rendered
+      "<br/>"
+
+      assert expected == rendered
   end
 
 end

--- a/test/cog/chat/hipchat/templates/common/error_test.exs
+++ b/test/cog/chat/hipchat/templates/common/error_test.exs
@@ -15,7 +15,6 @@ defmodule Cog.Chat.HipChat.Templates.Common.ErrorTest do
     expected =
       "<strong>Pipeline Error</strong><br/>" <>
       "<pre>bad stuff happened</pre><br/>" <>
-      "<br/>" <>
       "<strong>Started:</strong><br/>" <>
       "some time in the past<br/>" <>
       "<br/>" <>
@@ -48,7 +47,6 @@ defmodule Cog.Chat.HipChat.Templates.Common.ErrorTest do
     expected =
       "<strong>Command Execution Error</strong><br/>" <>
       "<pre>bad stuff happened</pre><br/>" <>
-      "<br/>" <>
       "<strong>Started:</strong><br/>" <>
       "some time in the past<br/>" <>
       "<br/>" <>

--- a/test/cog/chat/hipchat/templates/common/error_test.exs
+++ b/test/cog/chat/hipchat/templates/common/error_test.exs
@@ -12,14 +12,23 @@ defmodule Cog.Chat.HipChat.Templates.Common.ErrorTest do
 
     directives = directives_for_template(:common, "error", data)
     rendered = Cog.Chat.HipChat.TemplateProcessor.render(directives)
-    assert "<strong>Command Error</strong><br/><br/>" <>
-      "<strong>Started:</strong> some time in the past<br/>" <>
-      "<strong>Pipeline ID:</strong> deadbeef<br/>" <>
-      "<strong>Pipeline:</strong> echo foo<br/>" <>
-      "<strong>Caller:</strong> somebody<br/><br/>" <>
-      "The pipeline failed planning the invocation:<br/><br/>" <>
-      "<pre>I can't plan this!</pre><br/><br/>" <>
-      "The specific error was:<br/><br/><pre>bad stuff happened</pre>" == rendered
+
+    assert "<strong>Pipeline Error</strong><br/>" <>
+      "The pipeline failed planning the invocation:<br/>" <>
+      "<pre>I can't plan this!</pre><br/>" <>
+      "<strong>Error Message</strong><br/>" <>
+      "<pre>bad stuff happened</pre><br/>" <>
+      "<strong>Started:</strong><br/>" <>
+      "some time in the past<br/>" <>
+      "<br/>" <>
+      "<strong>Pipeline ID:</strong><br/>" <>
+      "deadbeef<br/>" <>
+      "<br/>" <>
+      "<strong>Pipeline:</strong><br/>" <>
+      "echo foo<br/>" <>
+      "<br/>" <>
+      "<strong>Caller:</strong><br/>" <>
+      "somebody<br/><br/><br/>" == rendered
   end
 
   test "error template; execution failure" do
@@ -33,14 +42,25 @@ defmodule Cog.Chat.HipChat.Templates.Common.ErrorTest do
              "execution_failure" => "I can't execute this!"}
     directives = directives_for_template(:common, "error", data)
     rendered = Cog.Chat.HipChat.TemplateProcessor.render(directives)
-    assert "<strong>Command Error</strong><br/><br/>" <>
-      "<strong>Started:</strong> some time in the past<br/>" <>
-      "<strong>Pipeline ID:</strong> deadbeef<br/>" <>
-      "<strong>Pipeline:</strong> echo foo<br/>" <>
-      "<strong>Caller:</strong> somebody<br/><br/>" <>
-      "The pipeline failed executing the command:<br/><br/>" <>
-      "<pre>I can't execute this!</pre><br/><br/>" <>
-      "The specific error was:<br/><br/><pre>bad stuff happened</pre>" == rendered
+
+    assert "<strong>Command Error</strong><br/>" <>
+      "The pipeline failed executing the command:<br/>" <>
+      "<pre>I can't execute this!</pre><br/>" <>
+      "<strong>Error Message</strong><br/>" <>
+      "<pre>bad stuff happened</pre><br/>" <>
+      "<strong>Started:</strong><br/>" <>
+      "some time in the past<br/>" <>
+      "<br/>" <>
+      "<strong>Pipeline ID:</strong><br/>" <>
+      "deadbeef<br/>" <>
+      "<br/>" <>
+      "<strong>Pipeline:</strong><br/>" <>
+      "echo foo<br/>" <>
+      "<br/>" <>
+      "<strong>Caller:</strong><br/>" <>
+      "somebody<br/>" <>
+      "<br/>" <>
+      "<br/>" == rendered
   end
 
 end

--- a/test/cog/chat/slack/templates/common/error_test.exs
+++ b/test/cog/chat/slack/templates/common/error_test.exs
@@ -11,16 +11,20 @@ defmodule Cog.Chat.Slack.Templates.Common.ErrorTest do
              "execution_failure" => false}
 
     directives = directives_for_template(:common, "error", data)
-    {"", [rendered]} = Cog.Chat.Slack.TemplateProcessor.render(directives)
-    assert """
-    The pipeline failed planning the invocation:
+    {"", rendered} = Cog.Chat.Slack.TemplateProcessor.render(directives)
 
-    ```I can't plan this!```
+    expected = [
+      "The pipeline failed planning the invocation:\n```I can't plan this!```",
+      "```bad stuff happened```",
+      ""
+    ]
 
-    The specific error was:
-
-    ```bad stuff happened```
-    """ |> String.strip == Map.get(rendered, "text")
+    expected
+    |> Enum.with_index
+    |> Enum.each(
+         fn({text, idx}) ->
+           assert text == Enum.at(rendered, idx) |> Map.get("text")
+         end)
   end
 
   test "error template; execution failure" do
@@ -33,16 +37,21 @@ defmodule Cog.Chat.Slack.Templates.Common.ErrorTest do
              "planning_failure" => false,
              "execution_failure" => "I can't execute this!"}
     directives = directives_for_template(:common, "error", data)
-    {"", [rendered]} = Cog.Chat.Slack.TemplateProcessor.render(directives)
-    assert """
-    The pipeline failed executing the command:
+    {"", rendered} = Cog.Chat.Slack.TemplateProcessor.render(directives)
 
-    ```I can't execute this!```
 
-    The specific error was:
+    expected = [
+      "The pipeline failed executing the command:\n```I can't execute this!```",
+      "```bad stuff happened```",
+      ""
+    ]
 
-    ```bad stuff happened```
-    """ |> String.strip  == Map.get(rendered, "text")
+    expected
+    |> Enum.with_index
+    |> Enum.each(
+         fn({text, idx}) ->
+           assert text == Enum.at(rendered, idx) |> Map.get("text")
+         end)
   end
 
 end

--- a/test/cog/chat/slack/templates/common/error_test.exs
+++ b/test/cog/chat/slack/templates/common/error_test.exs
@@ -8,23 +8,13 @@ defmodule Cog.Chat.Slack.Templates.Common.ErrorTest do
              "pipeline_text" => "echo foo",
              "error_message" => "bad stuff happened",
              "planning_failure" => "I can't plan this!",
-             "execution_failure" => false}
+             "execution_failure" => ""}
 
     directives = directives_for_template(:common, "error", data)
-    {"", rendered} = Cog.Chat.Slack.TemplateProcessor.render(directives)
+    {"", [rendered]} = Cog.Chat.Slack.TemplateProcessor.render(directives)
 
-    expected = [
-      "The pipeline failed planning the invocation:\n```I can't plan this!```",
-      "```bad stuff happened```",
-      ""
-    ]
-
-    expected
-    |> Enum.with_index
-    |> Enum.each(
-         fn({text, idx}) ->
-           assert text == Enum.at(rendered, idx) |> Map.get("text")
-         end)
+    expected = "```bad stuff happened```"
+    assert ^expected = Map.get(rendered, "text")
   end
 
   test "error template; execution failure" do
@@ -34,24 +24,15 @@ defmodule Cog.Chat.Slack.Templates.Common.ErrorTest do
              "initiator" => "somebody",
              "pipeline_text" => "echo foo",
              "error_message" => "bad stuff happened",
-             "planning_failure" => false,
+             "planning_failure" => "",
              "execution_failure" => "I can't execute this!"}
     directives = directives_for_template(:common, "error", data)
-    {"", rendered} = Cog.Chat.Slack.TemplateProcessor.render(directives)
+    {"", [rendered]} = Cog.Chat.Slack.TemplateProcessor.render(directives)
 
+    IO.inspect rendered
 
-    expected = [
-      "The pipeline failed executing the command:\n```I can't execute this!```",
-      "```bad stuff happened```",
-      ""
-    ]
-
-    expected
-    |> Enum.with_index
-    |> Enum.each(
-         fn({text, idx}) ->
-           assert text == Enum.at(rendered, idx) |> Map.get("text")
-         end)
+    expected = "```bad stuff happened```"
+    assert ^expected = Map.get(rendered, "text")
   end
 
 end

--- a/test/cog/template/new/common_test.exs
+++ b/test/cog/template/new/common_test.exs
@@ -1,3 +1,4 @@
+
 defmodule Cog.Template.New.CommonTest do
   use Cog.TemplateCase
 
@@ -17,25 +18,31 @@ defmodule Cog.Template.New.CommonTest do
                         "error_message" => "bad stuff happened",
                         "planning_failure" => "I can't plan this!",
                         "execution_failure" => false},
-      [%{"name" => "attachment", "children" => [
-          %{"name" => "text", "text" => "The pipeline failed planning the invocation:"}, %{"name" => "newline"},
-          %{"name" => "newline"},
-          %{"name" => "fixed_width_block", "text" => "I can't plan this!"},
-          %{"name" => "newline"},
-          %{"name" => "newline"},
-          %{"name" => "text", "text" => "The specific error was:"},
-          %{"name" => "newline"},
-          %{"name" => "newline"},
-          %{"name" => "fixed_width_block", "text" => "bad stuff happened"}
-        ],
-         "color" => "#ff3333",
-         "fields" => [
-           %{"short" => false, "title" => "Started", "value" => "some time in the past"},
-           %{"short" => false, "title" => "Pipeline ID", "value" => "deadbeef"},
-           %{"short" => false, "title" => "Pipeline", "value" => "echo foo"},
-           %{"short" => false, "title" => "Caller", "value" => "somebody"}
-         ],
-         "title" => "Command Error"}])
+                      [%{"name" => "attachment",
+                         "title" => "Pipeline Error",
+                         "color" => "#ff3333",
+                         "children" => [
+                           %{"name" => "text", "text" => "The pipeline failed planning the invocation:"},
+                           %{"name" => "newline"},
+                           %{"name" => "fixed_width_block", "text" => "I can't plan this!"}
+                         ],
+                         "fields" => []},
+                       %{"name" => "attachment",
+                         "title" => "Error Message",
+                         "color" => "#ff3333",
+                         "children" => [
+                           %{"name" => "fixed_width_block", "text" => "bad stuff happened"}
+                         ],
+                         "fields" => []},
+                       %{"name" => "attachment",
+                         "color" => "#ff3333",
+                         "children" => [],
+                         "fields" => [
+                           %{"short" => false, "title" => "Started", "value" => "some time in the past"},
+                           %{"short" => false, "title" => "Pipeline ID", "value" => "deadbeef"},
+                           %{"short" => false, "title" => "Pipeline", "value" => "echo foo"},
+                           %{"short" => false, "title" => "Caller", "value" => "somebody"}
+                         ]}])
   end
 
   test "error template directives; execution failure" do
@@ -47,23 +54,31 @@ defmodule Cog.Template.New.CommonTest do
                         "error_message" => "bad stuff happened",
                         "planning_failure" => false,
                         "execution_failure" => "I can't execute this!"},
-      [%{"name" => "attachment",
-        "children" => [
-          %{"name" => "text", "text" => "The pipeline failed executing the command:"},
-          %{"name" => "newline"},
-          %{"name" => "newline"},
-          %{"name" => "fixed_width_block", "text" => "I can't execute this!"},
-          %{"name" => "newline"},
-          %{"name" => "newline"},
-          %{"name" => "text", "text" => "The specific error was:"},
-          %{"name" => "newline"},
-          %{"name" => "newline"},
-          %{"name" => "fixed_width_block", "text" => "bad stuff happened"}], "color" => "#ff3333", "fields" => [
-          %{"short" => false, "title" => "Started", "value" => "some time in the past"},
-          %{"short" => false, "title" => "Pipeline ID", "value" => "deadbeef"},
-          %{"short" => false, "title" => "Pipeline", "value" => "echo foo"},
-          %{"short" => false, "title" => "Caller", "value" => "somebody"}],
-        "title" => "Command Error"}])
+                      [%{"name" => "attachment",
+                         "title" => "Command Error",
+                         "color" => "#ff3333",
+                         "children" => [
+                           %{"name" => "text", "text" => "The pipeline failed executing the command:"},
+                           %{"name" => "newline"},
+                           %{"name" => "fixed_width_block", "text" => "I can't execute this!"}
+                         ],
+                         "fields" => []},
+                       %{"name" => "attachment",
+                         "title" => "Error Message",
+                         "color" => "#ff3333",
+                         "children" => [
+                           %{"name" => "fixed_width_block", "text" => "bad stuff happened"}
+                         ],
+                         "fields" => []},
+                       %{"name" => "attachment",
+                         "color" => "#ff3333",
+                         "children" => [],
+                         "fields" => [
+                           %{"short" => false, "title" => "Started", "value" => "some time in the past"},
+                           %{"short" => false, "title" => "Pipeline ID", "value" => "deadbeef"},
+                           %{"short" => false, "title" => "Pipeline", "value" => "echo foo"},
+                           %{"short" => false, "title" => "Caller", "value" => "somebody"}
+                         ]}])
   end
 
 end

--- a/test/cog/template/new/common_test.exs
+++ b/test/cog/template/new/common_test.exs
@@ -17,30 +17,18 @@ defmodule Cog.Template.New.CommonTest do
                         "pipeline_text" => "echo foo",
                         "error_message" => "bad stuff happened",
                         "planning_failure" => "I can't plan this!",
-                        "execution_failure" => false},
+                        "execution_failure" => ""},
                       [%{"name" => "attachment",
                          "title" => "Pipeline Error",
                          "color" => "#ff3333",
                          "children" => [
-                           %{"name" => "text", "text" => "The pipeline failed planning the invocation:"},
-                           %{"name" => "newline"},
-                           %{"name" => "fixed_width_block", "text" => "I can't plan this!"}
-                         ],
-                         "fields" => []},
-                       %{"name" => "attachment",
-                         "title" => "Error Message",
-                         "color" => "#ff3333",
-                         "children" => [
                            %{"name" => "fixed_width_block", "text" => "bad stuff happened"}
                          ],
-                         "fields" => []},
-                       %{"name" => "attachment",
-                         "color" => "#ff3333",
-                         "children" => [],
                          "fields" => [
                            %{"short" => false, "title" => "Started", "value" => "some time in the past"},
                            %{"short" => false, "title" => "Pipeline ID", "value" => "deadbeef"},
                            %{"short" => false, "title" => "Pipeline", "value" => "echo foo"},
+                           %{"short" => false, "title" => "Failed Planning", "value" => "I can't plan this!"},
                            %{"short" => false, "title" => "Caller", "value" => "somebody"}
                          ]}])
   end
@@ -52,32 +40,20 @@ defmodule Cog.Template.New.CommonTest do
                         "initiator" => "somebody",
                         "pipeline_text" => "echo foo",
                         "error_message" => "bad stuff happened",
-                        "planning_failure" => false,
+                        "planning_failure" => "",
                         "execution_failure" => "I can't execute this!"},
                       [%{"name" => "attachment",
-                         "title" => "Command Error",
-                         "color" => "#ff3333",
-                         "children" => [
-                           %{"name" => "text", "text" => "The pipeline failed executing the command:"},
-                           %{"name" => "newline"},
-                           %{"name" => "fixed_width_block", "text" => "I can't execute this!"}
-                         ],
-                         "fields" => []},
-                       %{"name" => "attachment",
-                         "title" => "Error Message",
+                         "title" => "Command Execution Error",
                          "color" => "#ff3333",
                          "children" => [
                            %{"name" => "fixed_width_block", "text" => "bad stuff happened"}
                          ],
-                         "fields" => []},
-                       %{"name" => "attachment",
-                         "color" => "#ff3333",
-                         "children" => [],
                          "fields" => [
                            %{"short" => false, "title" => "Started", "value" => "some time in the past"},
                            %{"short" => false, "title" => "Pipeline ID", "value" => "deadbeef"},
                            %{"short" => false, "title" => "Pipeline", "value" => "echo foo"},
-                           %{"short" => false, "title" => "Caller", "value" => "somebody"}
+                           %{"short" => false, "title" => "Failed Executing", "value" => "I can't execute this!"},
+                           %{"short" => false, "title" => "Caller", "value" => "somebody"},
                          ]}])
   end
 

--- a/test/cog/template/new/evaluator_test.exs
+++ b/test/cog/template/new/evaluator_test.exs
@@ -18,19 +18,20 @@ defmodule Cog.Template.New.EvaluatorTest do
 
     test "error template evaluates normally when there is no custom template dir", %{data: data} do
       expected_directives =
-        [%{children: [%{name: :fixed_width_block, text: "this is an error"}],
-             color: "#ff3333", fields: [], name: :attachment,
-             title: "Error Message"},
-           %{children: [], color: "#ff3333",
-             fields: [%{short: false, title: "Started",
-                value: "2016-11-18T20:52:23Z"},
-              %{short: false, title: "Pipeline ID", value: "fake_id"},
-              %{short: false, title: "Pipeline", value: "fake pipeline"},
-              %{short: false, title: "Caller", value: "fake_user"}],
-             name: :attachment}]
+        [%{name: :attachment,
+           title: "Pipeline Error",
+           color: "#ff3333",
+           children: [
+             %{name: :fixed_width_block, text: "this is an error"}
+           ],
+           fields: [
+             %{short: false, title: "Started", value: "2016-11-18T20:52:23Z"},
+             %{short: false, title: "Pipeline ID", value: "fake_id"},
+             %{short: false, title: "Pipeline", value: "fake pipeline"},
+             %{short: false, title: "Caller", value: "fake_user"}
+           ]}]
 
       results = Evaluator.evaluate("error", data)
-
       assert(^expected_directives = results)
     end
 
@@ -68,7 +69,9 @@ defmodule Cog.Template.New.EvaluatorTest do
              "started" => "2016-11-18T20:52:23Z",
              "initiator" => "fake_user",
              "pipeline_text" => "fake pipeline",
-             "error_message" => "this is an error"}]
+             "error_message" => "this is an error",
+             "execution_failure" => "",
+             "planning_failure" => ""}]
 
   end
 end

--- a/test/cog/template/new/evaluator_test.exs
+++ b/test/cog/template/new/evaluator_test.exs
@@ -18,20 +18,16 @@ defmodule Cog.Template.New.EvaluatorTest do
 
     test "error template evaluates normally when there is no custom template dir", %{data: data} do
       expected_directives =
-        [%{children:
-           [%{name: :newline},
-            %{name: :newline},
-            %{name: :text, text: "The specific error was:"},
-            %{name: :newline}, %{name: :newline},
-            %{name: :fixed_width_block, text: "this is an error"}],
-          color: "#ff3333",
-          name: :attachment,
-          title: "Command Error",
-          fields: [%{short: false, title: "Started",
-                     value: "2016-11-18T20:52:23Z"},
-                    %{short: false, title: "Pipeline ID", value: "fake_id"},
-                    %{short: false, title: "Pipeline", value: "fake pipeline"},
-                    %{short: false, title: "Caller", value: "fake_user"}]}]
+        [%{children: [%{name: :fixed_width_block, text: "this is an error"}],
+             color: "#ff3333", fields: [], name: :attachment,
+             title: "Error Message"},
+           %{children: [], color: "#ff3333",
+             fields: [%{short: false, title: "Started",
+                value: "2016-11-18T20:52:23Z"},
+              %{short: false, title: "Pipeline ID", value: "fake_id"},
+              %{short: false, title: "Pipeline", value: "fake pipeline"},
+              %{short: false, title: "Caller", value: "fake_user"}],
+             name: :attachment}]
 
       results = Evaluator.evaluate("error", data)
 

--- a/test/integration/command_test.exs
+++ b/test/integration/command_test.exs
@@ -134,7 +134,7 @@ defmodule Integration.CommandTest do
   test "running a pipeline with a variable that resolves to a command fails with a parse error", %{user: user} do
     response = send_message(user, ~s(@bot: echo "echo" | $body[0] foo))
 
-    assert_error_message_contains(response, "The specific error was:\n\nillegal characters \"$\"")
+    assert_error_message_contains(response, "illegal characters \"$\"")
   end
 
   test "reading the path to filter a certain path", %{user: user} do

--- a/test/integration/hipchat_test.exs
+++ b/test/integration/hipchat_test.exs
@@ -29,7 +29,7 @@ defmodule Integration.HipChatTest do
     message = "@#{@bot}: operable:st-echo test"
     {:ok, reply} = ChatClient.chat_wait!(client, [room: @ci_room, message: message,
                                                   reply_from: @bot_name, timeout: @timeout])
-    assert String.contains?(reply.text, "<strong>Pipeline:</strong><br/>operable:st-echo test<br/><br/>")
+    assert String.contains?(reply.text, "<strong>Pipeline:</strong><br />operable:st-echo test<br /><br />")
     assert String.contains?(reply.text, "You will need at least one of the following permissions to run this command: " <>
       "'operable:st-echo'")
     assert reply.location.type == :channel
@@ -53,7 +53,7 @@ defmodule Integration.HipChatTest do
 
     message = "@#{@bot}: operable:st-echo \"this is a test\" | operable:st-thorn $body"
     {:ok, reply} = ChatClient.chat_wait!(client, [room: @ci_room, message: message, reply_from: @bot_name, timeout: @timeout])
-    assert String.contains?(reply.text, "<strong>Pipeline:</strong><br/>operable:st-echo \"this is a test\" | operable:st-thorn $body<br/><br/>")
+    assert String.contains?(reply.text, "<strong>Pipeline:</strong><br />operable:st-echo \"this is a test\" | operable:st-thorn $body<br /><br />")
     assert String.contains?(reply.text, "You will need at least one of the following permissions to run this command: " <>
       "'operable:st-thorn'.")
     assert reply.location.type == :channel

--- a/test/integration/hipchat_test.exs
+++ b/test/integration/hipchat_test.exs
@@ -29,7 +29,7 @@ defmodule Integration.HipChatTest do
     message = "@#{@bot}: operable:st-echo test"
     {:ok, reply} = ChatClient.chat_wait!(client, [room: @ci_room, message: message,
                                                   reply_from: @bot_name, timeout: @timeout])
-    assert String.contains?(reply.text, "<strong>Pipeline:</strong> operable:st-echo test")
+    assert String.contains?(reply.text, "<strong>Pipeline:</strong><br/>operable:st-echo test<br/><br/>")
     assert String.contains?(reply.text, "You will need at least one of the following permissions to run this command: " <>
       "'operable:st-echo'")
     assert reply.location.type == :channel
@@ -53,7 +53,7 @@ defmodule Integration.HipChatTest do
 
     message = "@#{@bot}: operable:st-echo \"this is a test\" | operable:st-thorn $body"
     {:ok, reply} = ChatClient.chat_wait!(client, [room: @ci_room, message: message, reply_from: @bot_name, timeout: @timeout])
-    assert String.contains?(reply.text, "<strong>Pipeline:</strong> operable:st-echo \"this is a test\" | operable:st-thorn $body")
+    assert String.contains?(reply.text, "<strong>Pipeline:</strong><br/>operable:st-echo \"this is a test\" | operable:st-thorn $body<br/><br/>")
     assert String.contains?(reply.text, "You will need at least one of the following permissions to run this command: " <>
       "'operable:st-thorn'.")
     assert reply.location.type == :channel

--- a/test/integration/slack_test.exs
+++ b/test/integration/slack_test.exs
@@ -33,14 +33,8 @@ defmodule Integration.SlackTest do
     {:ok, reply} = ChatClient.chat_wait!(client, [room: @ci_room, message: message,
                                                    reply_from: @bot])
     expected = """
-    The pipeline failed executing the command:
-
-    ```operable:st-echo test```
-
-    The specific error was:
-
-    ```Sorry, you aren't allowed to execute 'operable:st-echo test' :(
-     You will need at least one of the following permissions to run this command: 'operable:st-echo'.```
+    ```Sorry, you aren't allowed to execute 'operable:st-echo test'.
+    You will need at least one of the following permissions to run this command: 'operable:st-echo'.```
     """ |> String.strip
 
     assert reply.text == expected
@@ -66,13 +60,7 @@ defmodule Integration.SlackTest do
     message = "@#{@bot}: operable:st-echo \"this is a test\" | operable:st-thorn $body"
     {:ok, reply} = ChatClient.chat_wait!(client, [room: @ci_room, message: message, reply_from: @bot])
     expected = """
-    "The pipeline failed executing the command:
-
-    ```operable:st-thorn $body```
-
-    The specific error was:
-
-    ```Sorry, you aren't allowed to execute 'operable:st-thorn $body' :(
+    ```Sorry, you aren't allowed to execute 'operable:st-thorn $body'.
      You will need at least one of the following permissions to run this command: 'operable:st-thorn'.```
      """ |> String.strip
     assert reply.text == expected

--- a/test/integration/slack_test.exs
+++ b/test/integration/slack_test.exs
@@ -129,8 +129,7 @@ defmodule Integration.SlackTest do
     assert reply.location.type == :im
     # Since Cog responds when direct messaging it we have to assert
     # that both our marker text and message test exist.
-    #assert_response "here
-    blah", [after: marker, count: 2], "@#{@user}"
+    # assert_response "here\nblah", [after: marker, count: 2], "@#{@user}"
   end
 
   test "redirecting to a specific user", %{user: user, client: client} do

--- a/test/integration/slack_test.exs
+++ b/test/integration/slack_test.exs
@@ -1,9 +1,9 @@
 defmodule Integration.SlackTest do
   use Cog.Test.Support.ProviderCase, provider: :slack
 
-  @user "ash"
+  @user "botci"
 
-  @bot "ash"
+  @bot "deckard"
 
   @ci_room "ci_bot_testing"
 

--- a/test/integration/slack_test.exs
+++ b/test/integration/slack_test.exs
@@ -1,9 +1,9 @@
 defmodule Integration.SlackTest do
   use Cog.Test.Support.ProviderCase, provider: :slack
 
-  @user "botci"
+  @user "ash"
 
-  @bot "deckard"
+  @bot "ash"
 
   @ci_room "ci_bot_testing"
 
@@ -42,6 +42,7 @@ defmodule Integration.SlackTest do
     ```Sorry, you aren't allowed to execute 'operable:st-echo test' :(
      You will need at least one of the following permissions to run this command: 'operable:st-echo'.```
     """ |> String.strip
+
     assert reply.text == expected
     assert reply.location.type == :channel
     assert reply.location.name == @ci_room
@@ -65,14 +66,14 @@ defmodule Integration.SlackTest do
     message = "@#{@bot}: operable:st-echo \"this is a test\" | operable:st-thorn $body"
     {:ok, reply} = ChatClient.chat_wait!(client, [room: @ci_room, message: message, reply_from: @bot])
     expected = """
-    The pipeline failed executing the command:
+    "The pipeline failed executing the command:
 
     ```operable:st-thorn $body```
 
     The specific error was:
 
     ```Sorry, you aren't allowed to execute 'operable:st-thorn $body' :(
-      You will need at least one of the following permissions to run this command: 'operable:st-thorn'.```
+     You will need at least one of the following permissions to run this command: 'operable:st-thorn'.```
      """ |> String.strip
     assert reply.text == expected
     assert reply.location.type == :channel
@@ -128,7 +129,8 @@ defmodule Integration.SlackTest do
     assert reply.location.type == :im
     # Since Cog responds when direct messaging it we have to assert
     # that both our marker text and message test exist.
-    #assert_response "here\nblah", [after: marker, count: 2], "@#{@user}"
+    #assert_response "here
+    blah", [after: marker, count: 2], "@#{@user}"
   end
 
   test "redirecting to a specific user", %{user: user, client: client} do


### PR DESCRIPTION
This PR does a few things:

1. It flips the logic that we used to select planning vs. execution errors. I believe we have had these inverted for some time and effectively every error message was being reported as "The pipeline failed planning the invocation" even when it was a command execution failure. See screenshots below for before/after to better illustrate.
2. Updated the error greenbar template to break into multiple attachments in order to handle the 5 line attachment limit in Slack. This allow the first 5 lines of the error message to be visible by default instead of the previous case which often resulted in broken formatting.
3. Updated the HipChat attachment rendering to bring it more in-line with Slack initially for similar error output.

**Before:**

![before](https://cloud.githubusercontent.com/assets/1198/20656211/47c01660-b4f8-11e6-91d1-d6b5a86a2b3c.png)

**After:**

![after](https://cloud.githubusercontent.com/assets/1198/20656213/4e1da126-b4f8-11e6-99ab-64f263c8590f.png)

**HipChat:**

![hipchat_error](https://cloud.githubusercontent.com/assets/1198/20658335/f9a9d42c-b509-11e6-954c-dbbc02e82b20.png)
