### PR TITLE
return an error when trying to revoke cog-admin from the cog-admin group

### DIFF
--- a/lib/cog/repository/groups.ex
+++ b/lib/cog/repository/groups.ex
@@ -185,7 +185,7 @@ defmodule Cog.Repository.Groups do
 
       case result do
         {:ok, group} ->
-          group
+          Repo.preload(group, @preloads)
         {:error, error} ->
           Repo.rollback(error)
       end

--- a/test/controllers/v1/role_grant_controller_test.exs
+++ b/test/controllers/v1/role_grant_controller_test.exs
@@ -104,7 +104,7 @@ defmodule Cog.V1.RoleGrantController.Test do
     conn = api_request(requestor, :post, "/v1/groups/#{group.id}/roles",
                        body: %{"roles" => %{"grant" => [existing.name,
                                                         "does_not_exist"]}})
-    assert json_response(conn, 422) == %{"errors" => %{"not_found" => %{"roles" => ["does_not_exist"]}}}
+    assert json_response(conn, 422) == %{"error" => "Cannot find one or more specified roles: does_not_exist"}
 
     refute_role_is_granted(group, existing)
   end
@@ -200,7 +200,7 @@ defmodule Cog.V1.RoleGrantController.Test do
     conn = api_request(requestor, :post, "/v1/groups/#{group.id}/roles",
                        body: %{"roles" => %{"revoke" => [existing.name,
                                                          "does_not_exist"]}})
-    assert json_response(conn, 422) == %{"errors" => %{"not_found" => %{"roles" => ["does_not_exist"]}}}
+    assert json_response(conn, 422) == %{"error" => "Cannot find one or more specified roles: does_not_exist"}
 
     # Still got it
     assert_role_is_granted(group, existing)
@@ -243,9 +243,8 @@ defmodule Cog.V1.RoleGrantController.Test do
     conn = api_request(requestor, :post, "/v1/groups/#{admin_group.id}/roles",
                        body: %{"roles" => %{"revoke" => [admin_role.name]}})
 
-    # TODO: Ideally, I'd like an error here instead... this'll change
-    # when we get to https://github.com/operable/cog/issues/825
-    assert %{"roles" => [%{"name" => unquote(Cog.Util.Misc.admin_role)}]} = json_response(conn, 200)
+    error_msg = "Cannot remove '#{unquote(Cog.Util.Misc.admin_role)}' role from '#{unquote(Cog.Util.Misc.admin_group)}' group"
+    assert %{"error" => ^error_msg} = json_response(conn, 422)
 
     assert_role_is_granted(admin_group, admin_role)
   end

--- a/web/controllers/v1/role_grant_controller.ex
+++ b/web/controllers/v1/role_grant_controller.ex
@@ -1,8 +1,8 @@
 defmodule Cog.V1.RoleGrantController do
   use Cog.Web, :controller
 
-  alias Cog.Models.Role
-  alias Cog.Models.Group
+  alias Cog.Repository.Groups
+  alias Cog.Repo
 
   plug Cog.Plug.Authentication
 
@@ -10,74 +10,44 @@ defmodule Cog.V1.RoleGrantController do
 
   plug :put_view, Cog.V1.RoleView
 
-  def manage_group_roles(conn, params),
-    do: manage_roles(conn, Group, params)
-
-  # Grant or revoke an arbitrary number of roles (specified as
-  # names) from the identified entity (i.e., the thing of
-  # type `type` the given `id`). Returns a detail list of all
-  # *directly*-granted roles the thing has has following the
-  # grant / revoke actions.
-  defp manage_roles(conn, type, %{"id" => id, "roles" => role_spec}) do
-    result = Repo.transaction(fn() ->
-      permittable = Repo.get!(type, id)
-
-      roles_to_grant  = lookup_or_fail(role_spec, "grant")
-      roles_to_revoke = lookup_or_fail(role_spec, "revoke")
-
-      permittable
-      |> grant(roles_to_grant)
-      |> revoke(roles_to_revoke)
-      |> Repo.preload([roles: [permissions: :bundle]])
-    end)
+  def manage_group_roles(conn, %{"roles" => role_spec}=params) do
+    result = params
+    |> Map.put("members", prep_role_spec(role_spec))
+    |> Map.delete("roles")
+    |> Groups.manage_membership()
 
     case result do
-      {:ok, permittable} ->
-        conn
-        |> render("index.json", roles: permittable.roles)
+      {:ok, group} ->
+        # TODO: We should probably be handling preloads in the repository.
+        # Because we manage roles through the group repository we get a group
+        # back. I didn't want to add a bunch of unnecessary info to every call
+        # to the group repository just to render roles here. So for now, we'll
+        # just do the preload here.
+        roles = Repo.preload(group, [roles: [permissions: :bundle]])
+                |> Map.get(:roles)
+        render(conn, "index.json", roles: roles)
       {:error, {:not_found, {"roles", names}}} ->
         conn
         |> put_status(:unprocessable_entity)
-        |> json(%{"errors" => %{"not_found" => %{"roles" => names}}})
+        |> json(%{error: "Cannot find one or more specified roles: #{Enum.join(names, ", ")}"})
+      {:error, {:permanent_role_grant, role_name, group_name}} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{error: "Cannot remove '#{role_name}' role from '#{group_name}' group"})
     end
   end
 
-  defp lookup_or_fail(role_spec, operation) do
-    names = get_in(role_spec, [operation]) || []
-    case lookup_all(names) do
-      {:ok, roles} -> roles
-      {:error, reason} ->
-        Repo.rollback(reason)
-    end
-  end
-
-  defp lookup_all([]), do: {:ok, []} # Don't bother with a DB lookup
-  defp lookup_all(names) do
-    results = Repo.all(from r in Role, where: r.name in ^names)
-    |> Repo.preload(permissions: :bundle)
-
-    # make sure we got a result for each name given
-    case length(results) == length(names) do
-      true ->
-        # Each name corresponds to an entity in the database
-        {:ok, results}
-      false ->
-        # We got at least one name that doesn't map to any existing
-        # role. Find out what's missing and report back
-        retrieved_names = Enum.map(results, &Map.get(&1, :name))
-        bad_names = names -- retrieved_names
-        {:error, {:not_found, {"roles", bad_names}}}
-    end
-  end
-
-  defp grant(user, permissions) do
-    Enum.each(permissions, &Permittable.grant_to(user, &1))
-    user
-  end
-
-  defp revoke(user, permissions) do
-    Enum.each(permissions, &Permittable.revoke_from(user, &1))
-    user
-  end
+  # Cog.Repository.Groups.manage_membership/1 expects the action to be
+  # "add" or "remove", but cog-api sends "grant" or "revoke". We should
+  # probably standardize on one or the other, but for now, and to avoid
+  # breaking apps that call the api, we'll just support all 4 actions.
+  defp prep_role_spec(%{"grant" => roles}),
+    do: %{"roles" => %{"add" => roles}}
+  defp prep_role_spec(%{"revoke" => roles}),
+    do: %{"roles" => %{"remove" => roles}}
+  defp prep_role_spec(%{"add" => roles}),
+    do: %{"roles" => %{"add" => roles}}
+  defp prep_role_spec(%{"remove" => roles}),
+    do: %{"roles" => %{"remove" => roles}}
 
 end


### PR DESCRIPTION
Cog will now return an error when trying to remove the cog-admin role from the cog-admin group. Updates to flywheel, cogctl and cog-api to follow.

Note: Roles looks like it could use a refactor. Things have moved on a bit from when this code was first written. In addition to the error messaging, this PR moves the bulk of the grant/revoke role logic out of the controller and leverages the repository in preparation for a more complete refactor.

part of #825 