### PR TITLE
Improved error template + HipChat attachment rendering

### DIFF
--- a/lib/cog/chat/hipchat/template_processor.ex
+++ b/lib/cog/chat/hipchat/template_processor.ex
@@ -1,17 +1,18 @@
 defmodule Cog.Chat.HipChat.TemplateProcessor do
   require Logger
 
-  @attachment_fields ["footer", "children", "fields", "pretext", "author", "title"]
+  @attachment_fields ["footer", "fields", "children", "pretext", "author", "title"]
 
   def render(directives) do
     render_directives(directives)
   end
 
   defp process_directive(%{"name" => "attachment"}=attachment) do
-    @attachment_fields
+    rendered_body = @attachment_fields
     |> Enum.reduce([], &(render_attachment(&1, &2, attachment)))
     |> List.flatten
     |> Enum.join
+    rendered_body <> "<br/>"
   end
   defp process_directive(%{"name" => "text", "text" => text}),
     do: text
@@ -82,7 +83,7 @@ defmodule Cog.Chat.HipChat.TemplateProcessor do
       nil ->
         acc
       footer ->
-        ["<br/>#{footer}<br/>"|acc]
+        ["<br/>#{footer}"|acc]
     end
   end
   defp render_attachment("children", acc, attachment) do
@@ -90,7 +91,7 @@ defmodule Cog.Chat.HipChat.TemplateProcessor do
       nil ->
         acc
       children ->
-        [render(children)|acc]
+        [render(children) <> "<br/>"|acc]
     end
   end
   defp render_attachment("fields", acc, attachment) do
@@ -99,9 +100,9 @@ defmodule Cog.Chat.HipChat.TemplateProcessor do
         acc
       fields ->
         rendered_fields = fields
-        |> Enum.map(fn(%{"title" => title, "value" => value}) -> "<strong>#{title}:</strong> #{value}<br/>" end)
+        |> Enum.map(fn(%{"title" => title, "value" => value}) -> "<strong>#{title}:</strong><br/>#{value}<br/><br/>" end)
         |> Enum.join
-        [rendered_fields <> "<br/>"|acc]
+        [rendered_fields|acc]
     end
   end
   defp render_attachment("pretext", acc, attachment) do
@@ -127,9 +128,9 @@ defmodule Cog.Chat.HipChat.TemplateProcessor do
       title ->
         case Map.get(attachment, "title_url") do
           nil ->
-            ["<strong>#{title}</strong><br/><br/>"|acc]
+            ["<strong>#{title}</strong><br/>"|acc]
           url ->
-            ["<a href=\"#{url}\">title</a><br/><br/>"|acc]
+            ["<strong><a href=\"#{url}\">title</a></strong><br/>"|acc]
         end
     end
   end

--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -577,13 +577,18 @@ defmodule Cog.Command.Pipeline.Executor do
     pipeline_text = state.request.text
     error_message = ErrorResponse.render(error)
 
-    {planning_failure, execution_failure} = case state do
-      %{current_plan: %Plan{invocation_text: planning_failure}} ->
-        {to_string(planning_failure), false}
-      %{invocations: [%Ast.Invocation{} = execution_failure|_]} ->
-        {false, to_string(execution_failure)}
+    planning_failure = case state do
+      %{invocations: [%Ast.Invocation{} = planning_failure|_]} ->
+        to_string(planning_failure)
       _ ->
-        {false, false}
+        ""
+    end
+
+    execution_failure = case state do
+      %{current_plan: %Plan{invocation_text: execution_failure}} ->
+        to_string(execution_failure)
+      _ ->
+        ""
     end
 
     %{"id" => id,

--- a/lib/cog/error_response.ex
+++ b/lib/cog/error_response.ex
@@ -14,7 +14,7 @@ defmodule Cog.ErrorResponse do
     do: "No rules match the supplied invocation of '#{current_invocation}'. Check your args and options, then confirm that the proper rules are in place."
   def render({:denied, {%Ast.Rule{}=rule, current_invocation}}) do
     perms = Enum.map(Ast.Rule.permissions_used(rule), &("'#{&1}'")) |> Enum.join(", ")
-    "Sorry, you aren't allowed to execute '#{current_invocation}' :(\n You will need at least one of the following permissions to run this command: #{perms}."
+    "Sorry, you aren't allowed to execute '#{current_invocation}'.\nYou will need at least one of the following permissions to run this command: #{perms}."
   end
   def render({:no_relays, bundle_name}) do # TODO: Add version, too?
     "No Cog Relays supporting the `#{bundle_name}` bundle are currently online. " <>

--- a/priv/templates/common/error.greenbar
+++ b/priv/templates/common/error.greenbar
@@ -1,4 +1,13 @@
+#
+# CASE 1: COMMAND EXECUTION FAILURE
+#
+# Command execution returned an error either with or without an additional
+# planning error for failures further in the pipeline.
+#
 ~if cond=$execution_failure != ""~
+#
+# No additional pipeline stages after the failed command
+#
 ~if cond=$planning_failure == ""~
 ~attachment title="Command Execution Error" color="#ff3333" "Failed Executing"=$execution_failure Caller=$initiator Pipeline=$pipeline_text "Pipeline ID"=$id Started=$started~
 
@@ -7,6 +16,10 @@
 ```
 ~end~
 ~end~
+#
+# There are additional stages in the pipeline after the failed execution that
+# will not be executed due to the command execution failure.
+#
 ~if cond=$planning_failure != ""~
 ~attachment title="Command Execution Error" color="#ff3333" "Failed Executing"=$execution_failure "Failed Planning"=$planning_failure Caller=$initiator Pipeline=$pipeline_text "Pipeline ID"=$id Started=$started~
 
@@ -16,6 +29,13 @@
 ~end~
 ~end~
 ~end~
+#
+# CASE 2: PIPELINE PLAN FAILURE
+#
+# Display Pipeline Plan failures as long as there is no execution failure
+# message set. If there is also an execution failure, we skip because we would
+# have handled it above.
+#
 ~if cond=$planning_failure != ""~
 ~if cond=$execution_failure == ""~
 ~attachment title="Pipeline Error" color="#ff3333" Caller=$initiator "Failed Planning"=$planning_failure Pipeline=$pipeline_text "Pipeline ID"=$id Started=$started~
@@ -26,6 +46,12 @@
 ~end~
 ~end~
 ~end~
+#
+# CASE 3: GENERAL ERROR
+#
+# This case is for errors that don't also have an execution or planning failure
+# message included. This is generally things like an invalid command.
+#
 ~if cond=$execution_failure == ""~
 ~if cond=$planning_failure == ""~
 ~attachment title="Pipeline Error" color="#ff3333" Caller=$initiator Pipeline=$pipeline_text "Pipeline ID"=$id Started=$started~

--- a/priv/templates/common/error.greenbar
+++ b/priv/templates/common/error.greenbar
@@ -1,23 +1,38 @@
-~attachment title="Command Error" color="#ff3333" Caller=$initiator Pipeline=$pipeline_text "Pipeline ID"=$id Started=$started~
-~if cond=$planning_failure ~
-The pipeline failed planning the invocation:
-~br~
-```
-~$planning_failure~
-```
-~end~
-~if cond=$execution_failure~
-The pipeline failed executing the command:
-~br~
-```
-~$execution_failure~
-```
-~end~
-~br~
-~br~
-The specific error was:
-~br~
+~if cond=$execution_failure != ""~
+~if cond=$planning_failure == ""~
+~attachment title="Command Execution Error" color="#ff3333" "Failed Executing"=$execution_failure Caller=$initiator Pipeline=$pipeline_text "Pipeline ID"=$id Started=$started~
+
 ```
 ~$error_message~
 ```
+~end~
+~end~
+~if cond=$planning_failure != ""~
+~attachment title="Command Execution Error" color="#ff3333" "Failed Executing"=$execution_failure "Failed Planning"=$planning_failure Caller=$initiator Pipeline=$pipeline_text "Pipeline ID"=$id Started=$started~
+
+```
+~$error_message~
+```
+~end~
+~end~
+~end~
+~if cond=$planning_failure != ""~
+~if cond=$execution_failure == ""~
+~attachment title="Pipeline Error" color="#ff3333" Caller=$initiator "Failed Planning"=$planning_failure Pipeline=$pipeline_text "Pipeline ID"=$id Started=$started~
+
+```
+~$error_message~
+```
+~end~
+~end~
+~end~
+~if cond=$execution_failure == ""~
+~if cond=$planning_failure == ""~
+~attachment title="Pipeline Error" color="#ff3333" Caller=$initiator Pipeline=$pipeline_text "Pipeline ID"=$id Started=$started~
+
+```
+~$error_message~
+```
+~end~
+~end~
 ~end~

--- a/test/cog/chat/hipchat/templates/common/error_test.exs
+++ b/test/cog/chat/hipchat/templates/common/error_test.exs
@@ -8,18 +8,29 @@ defmodule Cog.Chat.HipChat.Templates.Common.ErrorTest do
              "pipeline_text" => "echo foo",
              "error_message" => "bad stuff happened",
              "planning_failure" => "I can't plan this!",
-             "execution_failure" => false}
+             "execution_failure" => ""}
 
     directives = directives_for_template(:common, "error", data)
     rendered = Cog.Chat.HipChat.TemplateProcessor.render(directives)
-    assert "<strong>Command Error</strong><br/><br/>" <>
-      "<strong>Started:</strong> some time in the past<br/>" <>
-      "<strong>Pipeline ID:</strong> deadbeef<br/>" <>
-      "<strong>Pipeline:</strong> echo foo<br/>" <>
-      "<strong>Caller:</strong> somebody<br/><br/>" <>
-      "The pipeline failed planning the invocation:<br/><br/>" <>
-      "<pre>I can't plan this!</pre><br/><br/>" <>
-      "The specific error was:<br/><br/><pre>bad stuff happened</pre>" == rendered
+    expected =
+      "<strong>Pipeline Error</strong><br/>" <>
+      "<pre>bad stuff happened</pre><br/>" <>
+      "<strong>Started:</strong><br/>" <>
+      "some time in the past<br/>" <>
+      "<br/>" <>
+      "<strong>Pipeline ID:</strong><br/>" <>
+      "deadbeef<br/>" <>
+      "<br/>" <>
+      "<strong>Pipeline:</strong><br/>" <>
+      "echo foo<br/>" <>
+      "<br/>" <>
+      "<strong>Failed Planning:</strong><br/>" <>
+      "I can't plan this!<br/>" <>
+      "<br/>" <>
+      "<strong>Caller:</strong><br/>" <>
+      "somebody<br/><br/><br/>"
+
+    assert expected == rendered
   end
 
   test "error template; execution failure" do
@@ -29,18 +40,31 @@ defmodule Cog.Chat.HipChat.Templates.Common.ErrorTest do
              "initiator" => "somebody",
              "pipeline_text" => "echo foo",
              "error_message" => "bad stuff happened",
-             "planning_failure" => false,
+             "planning_failure" => "",
              "execution_failure" => "I can't execute this!"}
     directives = directives_for_template(:common, "error", data)
     rendered = Cog.Chat.HipChat.TemplateProcessor.render(directives)
-    assert "<strong>Command Error</strong><br/><br/>" <>
-      "<strong>Started:</strong> some time in the past<br/>" <>
-      "<strong>Pipeline ID:</strong> deadbeef<br/>" <>
-      "<strong>Pipeline:</strong> echo foo<br/>" <>
-      "<strong>Caller:</strong> somebody<br/><br/>" <>
-      "The pipeline failed executing the command:<br/><br/>" <>
-      "<pre>I can't execute this!</pre><br/><br/>" <>
-      "The specific error was:<br/><br/><pre>bad stuff happened</pre>" == rendered
+    expected =
+      "<strong>Command Execution Error</strong><br/>" <>
+      "<pre>bad stuff happened</pre><br/>" <>
+      "<strong>Started:</strong><br/>" <>
+      "some time in the past<br/>" <>
+      "<br/>" <>
+      "<strong>Pipeline ID:</strong><br/>" <>
+      "deadbeef<br/>" <>
+      "<br/>" <>
+      "<strong>Pipeline:</strong><br/>" <>
+      "echo foo<br/>" <>
+      "<br/>" <>
+      "<strong>Failed Executing:</strong><br/>" <>
+      "I can't execute this!<br/>" <>
+      "<br/>" <>
+      "<strong>Caller:</strong><br/>" <>
+      "somebody<br/>" <>
+      "<br/>" <>
+      "<br/>"
+
+      assert expected == rendered
   end
 
 end

--- a/test/cog/chat/slack/templates/common/error_test.exs
+++ b/test/cog/chat/slack/templates/common/error_test.exs
@@ -8,19 +8,13 @@ defmodule Cog.Chat.Slack.Templates.Common.ErrorTest do
              "pipeline_text" => "echo foo",
              "error_message" => "bad stuff happened",
              "planning_failure" => "I can't plan this!",
-             "execution_failure" => false}
+             "execution_failure" => ""}
 
     directives = directives_for_template(:common, "error", data)
     {"", [rendered]} = Cog.Chat.Slack.TemplateProcessor.render(directives)
-    assert """
-    The pipeline failed planning the invocation:
 
-    ```I can't plan this!```
-
-    The specific error was:
-
-    ```bad stuff happened```
-    """ |> String.strip == Map.get(rendered, "text")
+    expected = "```bad stuff happened```"
+    assert ^expected = Map.get(rendered, "text")
   end
 
   test "error template; execution failure" do
@@ -30,19 +24,15 @@ defmodule Cog.Chat.Slack.Templates.Common.ErrorTest do
              "initiator" => "somebody",
              "pipeline_text" => "echo foo",
              "error_message" => "bad stuff happened",
-             "planning_failure" => false,
+             "planning_failure" => "",
              "execution_failure" => "I can't execute this!"}
     directives = directives_for_template(:common, "error", data)
     {"", [rendered]} = Cog.Chat.Slack.TemplateProcessor.render(directives)
-    assert """
-    The pipeline failed executing the command:
 
-    ```I can't execute this!```
+    IO.inspect rendered
 
-    The specific error was:
-
-    ```bad stuff happened```
-    """ |> String.strip  == Map.get(rendered, "text")
+    expected = "```bad stuff happened```"
+    assert ^expected = Map.get(rendered, "text")
   end
 
 end

--- a/test/cog/chat/slack/templates/common/error_test.exs
+++ b/test/cog/chat/slack/templates/common/error_test.exs
@@ -29,8 +29,6 @@ defmodule Cog.Chat.Slack.Templates.Common.ErrorTest do
     directives = directives_for_template(:common, "error", data)
     {"", [rendered]} = Cog.Chat.Slack.TemplateProcessor.render(directives)
 
-    IO.inspect rendered
-
     expected = "```bad stuff happened```"
     assert ^expected = Map.get(rendered, "text")
   end

--- a/test/cog/template/new/common_test.exs
+++ b/test/cog/template/new/common_test.exs
@@ -1,3 +1,4 @@
+
 defmodule Cog.Template.New.CommonTest do
   use Cog.TemplateCase
 
@@ -16,26 +17,20 @@ defmodule Cog.Template.New.CommonTest do
                         "pipeline_text" => "echo foo",
                         "error_message" => "bad stuff happened",
                         "planning_failure" => "I can't plan this!",
-                        "execution_failure" => false},
-      [%{"name" => "attachment", "children" => [
-          %{"name" => "text", "text" => "The pipeline failed planning the invocation:"}, %{"name" => "newline"},
-          %{"name" => "newline"},
-          %{"name" => "fixed_width_block", "text" => "I can't plan this!"},
-          %{"name" => "newline"},
-          %{"name" => "newline"},
-          %{"name" => "text", "text" => "The specific error was:"},
-          %{"name" => "newline"},
-          %{"name" => "newline"},
-          %{"name" => "fixed_width_block", "text" => "bad stuff happened"}
-        ],
-         "color" => "#ff3333",
-         "fields" => [
-           %{"short" => false, "title" => "Started", "value" => "some time in the past"},
-           %{"short" => false, "title" => "Pipeline ID", "value" => "deadbeef"},
-           %{"short" => false, "title" => "Pipeline", "value" => "echo foo"},
-           %{"short" => false, "title" => "Caller", "value" => "somebody"}
-         ],
-         "title" => "Command Error"}])
+                        "execution_failure" => ""},
+                      [%{"name" => "attachment",
+                         "title" => "Pipeline Error",
+                         "color" => "#ff3333",
+                         "children" => [
+                           %{"name" => "fixed_width_block", "text" => "bad stuff happened"}
+                         ],
+                         "fields" => [
+                           %{"short" => false, "title" => "Started", "value" => "some time in the past"},
+                           %{"short" => false, "title" => "Pipeline ID", "value" => "deadbeef"},
+                           %{"short" => false, "title" => "Pipeline", "value" => "echo foo"},
+                           %{"short" => false, "title" => "Failed Planning", "value" => "I can't plan this!"},
+                           %{"short" => false, "title" => "Caller", "value" => "somebody"}
+                         ]}])
   end
 
   test "error template directives; execution failure" do
@@ -45,25 +40,21 @@ defmodule Cog.Template.New.CommonTest do
                         "initiator" => "somebody",
                         "pipeline_text" => "echo foo",
                         "error_message" => "bad stuff happened",
-                        "planning_failure" => false,
+                        "planning_failure" => "",
                         "execution_failure" => "I can't execute this!"},
-      [%{"name" => "attachment",
-        "children" => [
-          %{"name" => "text", "text" => "The pipeline failed executing the command:"},
-          %{"name" => "newline"},
-          %{"name" => "newline"},
-          %{"name" => "fixed_width_block", "text" => "I can't execute this!"},
-          %{"name" => "newline"},
-          %{"name" => "newline"},
-          %{"name" => "text", "text" => "The specific error was:"},
-          %{"name" => "newline"},
-          %{"name" => "newline"},
-          %{"name" => "fixed_width_block", "text" => "bad stuff happened"}], "color" => "#ff3333", "fields" => [
-          %{"short" => false, "title" => "Started", "value" => "some time in the past"},
-          %{"short" => false, "title" => "Pipeline ID", "value" => "deadbeef"},
-          %{"short" => false, "title" => "Pipeline", "value" => "echo foo"},
-          %{"short" => false, "title" => "Caller", "value" => "somebody"}],
-        "title" => "Command Error"}])
+                      [%{"name" => "attachment",
+                         "title" => "Command Execution Error",
+                         "color" => "#ff3333",
+                         "children" => [
+                           %{"name" => "fixed_width_block", "text" => "bad stuff happened"}
+                         ],
+                         "fields" => [
+                           %{"short" => false, "title" => "Started", "value" => "some time in the past"},
+                           %{"short" => false, "title" => "Pipeline ID", "value" => "deadbeef"},
+                           %{"short" => false, "title" => "Pipeline", "value" => "echo foo"},
+                           %{"short" => false, "title" => "Failed Executing", "value" => "I can't execute this!"},
+                           %{"short" => false, "title" => "Caller", "value" => "somebody"},
+                         ]}])
   end
 
 end

--- a/test/cog/template/new/evaluator_test.exs
+++ b/test/cog/template/new/evaluator_test.exs
@@ -18,23 +18,20 @@ defmodule Cog.Template.New.EvaluatorTest do
 
     test "error template evaluates normally when there is no custom template dir", %{data: data} do
       expected_directives =
-        [%{children:
-           [%{name: :newline},
-            %{name: :newline},
-            %{name: :text, text: "The specific error was:"},
-            %{name: :newline}, %{name: :newline},
-            %{name: :fixed_width_block, text: "this is an error"}],
-          color: "#ff3333",
-          name: :attachment,
-          title: "Command Error",
-          fields: [%{short: false, title: "Started",
-                     value: "2016-11-18T20:52:23Z"},
-                    %{short: false, title: "Pipeline ID", value: "fake_id"},
-                    %{short: false, title: "Pipeline", value: "fake pipeline"},
-                    %{short: false, title: "Caller", value: "fake_user"}]}]
+        [%{name: :attachment,
+           title: "Pipeline Error",
+           color: "#ff3333",
+           children: [
+             %{name: :fixed_width_block, text: "this is an error"}
+           ],
+           fields: [
+             %{short: false, title: "Started", value: "2016-11-18T20:52:23Z"},
+             %{short: false, title: "Pipeline ID", value: "fake_id"},
+             %{short: false, title: "Pipeline", value: "fake pipeline"},
+             %{short: false, title: "Caller", value: "fake_user"}
+           ]}]
 
       results = Evaluator.evaluate("error", data)
-
       assert(^expected_directives = results)
     end
 
@@ -72,7 +69,9 @@ defmodule Cog.Template.New.EvaluatorTest do
              "started" => "2016-11-18T20:52:23Z",
              "initiator" => "fake_user",
              "pipeline_text" => "fake pipeline",
-             "error_message" => "this is an error"}]
+             "error_message" => "this is an error",
+             "execution_failure" => "",
+             "planning_failure" => ""}]
 
   end
 end

--- a/test/integration/command_test.exs
+++ b/test/integration/command_test.exs
@@ -134,7 +134,7 @@ defmodule Integration.CommandTest do
   test "running a pipeline with a variable that resolves to a command fails with a parse error", %{user: user} do
     response = send_message(user, ~s(@bot: echo "echo" | $body[0] foo))
 
-    assert_error_message_contains(response, "The specific error was:\n\nillegal characters \"$\"")
+    assert_error_message_contains(response, "illegal characters \"$\"")
   end
 
   test "reading the path to filter a certain path", %{user: user} do

--- a/test/integration/hipchat_test.exs
+++ b/test/integration/hipchat_test.exs
@@ -29,7 +29,7 @@ defmodule Integration.HipChatTest do
     message = "@#{@bot}: operable:st-echo test"
     {:ok, reply} = ChatClient.chat_wait!(client, [room: @ci_room, message: message,
                                                   reply_from: @bot_name, timeout: @timeout])
-    assert String.contains?(reply.text, "<strong>Pipeline:</strong> operable:st-echo test")
+    assert String.contains?(reply.text, "<strong>Pipeline:</strong><br />operable:st-echo test<br /><br />")
     assert String.contains?(reply.text, "You will need at least one of the following permissions to run this command: " <>
       "'operable:st-echo'")
     assert reply.location.type == :channel
@@ -53,7 +53,7 @@ defmodule Integration.HipChatTest do
 
     message = "@#{@bot}: operable:st-echo \"this is a test\" | operable:st-thorn $body"
     {:ok, reply} = ChatClient.chat_wait!(client, [room: @ci_room, message: message, reply_from: @bot_name, timeout: @timeout])
-    assert String.contains?(reply.text, "<strong>Pipeline:</strong> operable:st-echo \"this is a test\" | operable:st-thorn $body")
+    assert String.contains?(reply.text, "<strong>Pipeline:</strong><br />operable:st-echo \"this is a test\" | operable:st-thorn $body<br /><br />")
     assert String.contains?(reply.text, "You will need at least one of the following permissions to run this command: " <>
       "'operable:st-thorn'.")
     assert reply.location.type == :channel

--- a/test/integration/slack_test.exs
+++ b/test/integration/slack_test.exs
@@ -33,15 +33,10 @@ defmodule Integration.SlackTest do
     {:ok, reply} = ChatClient.chat_wait!(client, [room: @ci_room, message: message,
                                                    reply_from: @bot])
     expected = """
-    The pipeline failed executing the command:
-
-    ```operable:st-echo test```
-
-    The specific error was:
-
-    ```Sorry, you aren't allowed to execute 'operable:st-echo test' :(
-     You will need at least one of the following permissions to run this command: 'operable:st-echo'.```
+    ```Sorry, you aren't allowed to execute 'operable:st-echo test'.
+    You will need at least one of the following permissions to run this command: 'operable:st-echo'.```
     """ |> String.strip
+
     assert reply.text == expected
     assert reply.location.type == :channel
     assert reply.location.name == @ci_room
@@ -65,14 +60,8 @@ defmodule Integration.SlackTest do
     message = "@#{@bot}: operable:st-echo \"this is a test\" | operable:st-thorn $body"
     {:ok, reply} = ChatClient.chat_wait!(client, [room: @ci_room, message: message, reply_from: @bot])
     expected = """
-    The pipeline failed executing the command:
-
-    ```operable:st-thorn $body```
-
-    The specific error was:
-
-    ```Sorry, you aren't allowed to execute 'operable:st-thorn $body' :(
-      You will need at least one of the following permissions to run this command: 'operable:st-thorn'.```
+    ```Sorry, you aren't allowed to execute 'operable:st-thorn $body'.
+     You will need at least one of the following permissions to run this command: 'operable:st-thorn'.```
      """ |> String.strip
     assert reply.text == expected
     assert reply.location.type == :channel
@@ -128,7 +117,7 @@ defmodule Integration.SlackTest do
     assert reply.location.type == :im
     # Since Cog responds when direct messaging it we have to assert
     # that both our marker text and message test exist.
-    #assert_response "here\nblah", [after: marker, count: 2], "@#{@user}"
+    # assert_response "here\nblah", [after: marker, count: 2], "@#{@user}"
   end
 
   test "redirecting to a specific user", %{user: user, client: client} do

--- a/test/support/slack_client.ex
+++ b/test/support/slack_client.ex
@@ -87,7 +87,7 @@ end
 defmodule Cog.Test.Support.SlackClient do
 
   # To avoid Slack throttling
-  @api_wait_interval 750
+  @api_wait_interval 1100
 
   @default_timeout 5000
 


### PR DESCRIPTION
This PR does a few things:

1. Updates the attachment rendering for HipChat to be more consistent with Slack.
2. It flips the logic that we used to select planning vs. execution errors. I believe we have had these inverted for some time and effectively every error message was being reported as "The pipeline failed planning the invocation" even when it was a command execution failure. The screenshots below illustrate the problem
3. Updated the greenbar template for errors to move the error message to the top so that it isn't hidden by a _more_ link by Slack. Also moved the display of the failed command or pipeline plan to fields within the attachment instead of rendering them to text in the body of the error, also to prevent truncation. Screenshots below.
4. Increase the wait time between Slack API requests from 750ms to 1100ms to more consistently avoid the Slack rate limit. Sadness intensifies.

**Before:**

![before](https://cloud.githubusercontent.com/assets/1198/20683457/14d7b618-b57a-11e6-836f-f7cbdbcf3adf.png)

**After:**

![after](https://cloud.githubusercontent.com/assets/1198/20683533/5e298a62-b57a-11e6-91bb-24a3514da7dc.png)

**HipChat:**

![hipchat](https://cloud.githubusercontent.com/assets/1198/20684304/51aad446-b57d-11e6-9139-ecc463ec5af9.png)

