### PR TITLE
Tweak help output for bundles and commands.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -30,7 +30,7 @@ end
 # NOTE: Do not change this value unless you know what you're doing.
 # ========================================================================
 
-config :cog, :embedded_bundle_version, "0.15.0"
+config :cog, :embedded_bundle_version, "0.15.1"
 
 # ========================================================================
 # Chat Adapters

--- a/priv/templates/embedded/help-bundle.greenbar
+++ b/priv/templates/embedded/help-bundle.greenbar
@@ -12,6 +12,16 @@ __Description__
 ~br~
 ~end~
 
+~if cond=$bundle.commands not_empty?~
+__Commands__
+~br~
+~each var=$bundle.commands as=command~
+* `~$command.name~`~if cond=$command.description~ - ~$command.description~~end~
+
+~end~
+~br~
+~end~
+
 ~if cond=$bundle.config~
 __Configuration__
 ~br~
@@ -22,17 +32,7 @@ __Configuration__
 ~end~
 
 ~each var=$bundle.config.env as=env_var~
-* ~$env_var.var~~if cond=$env_var.description~ - ~$env_var.description~~end~
-
-~end~
-~br~
-~end~
-
-~if cond=$bundle.commands not_empty?~
-__Commands__
-~br~
-~each var=$bundle.commands as=command~
-* ~$command.name~~if cond=$command.description~ - ~$command.description~~end~
+* `~$env_var.var~`~if cond=$env_var.description~ - ~$env_var.description~~end~
 
 ~end~
 ~br~

--- a/priv/templates/embedded/help-command.greenbar
+++ b/priv/templates/embedded/help-command.greenbar
@@ -30,7 +30,7 @@ __Synopsis__
 __Required Options__
 ~br~
 ~each var=$command.required_options as=option~
-* ~$option.flag~ ~if cond=$option.description~ - ~$option.description~ ~end~
+* `~$option.flag~` ~if cond=$option.description~ - ~$option.description~ ~end~
 
 ~end~
 ~br~
@@ -40,7 +40,7 @@ __Required Options__
 __Options__
 ~br~
 ~each var=$command.options as=option~
-* ~$option.flag~ ~if cond=$option.description~ - ~$option.description~ ~end~
+* `~$option.flag~` ~if cond=$option.description~ - ~$option.description~ ~end~
 
 ~end~
 ~br~

--- a/test/cog/chat/hipchat/templates/embedded/help_bundle_test.exs
+++ b/test/cog/chat/hipchat/templates/embedded/help_bundle_test.exs
@@ -20,11 +20,11 @@ defmodule Cog.Chat.HipChat.Templates.Embedded.HelpBundleTest do
       "test-bundle - Does a thing<br/><br/>" <>
       "<strong>Description</strong><br/><br/>" <>
       "No really, it does a thing<br/><br/>" <>
+      "<strong>Commands</strong><br/><br/>" <>
+      "<ul><li><code>test-command</code> - does just one thing</li></ul><br/>" <>
       "<strong>Configuration</strong><br/><br/>" <>
       "Some notes about config<br/><br/>" <>
-      "<ul><li>VAR1 - description1</li><li>VAR2</li></ul><br/>" <>
-      "<strong>Commands</strong><br/><br/>" <>
-      "<ul><li>test-command - does just one thing</li></ul><br/>" <>
+      "<ul><li><code>VAR1</code> - description1</li><li><code>VAR2</code></li></ul><br/>" <>
       "<strong>Author</strong><br/><br/>" <>
       "vanstee<br/><br/>" <>
       "<strong>Homepage</strong><br/><br/>" <>
@@ -48,7 +48,7 @@ defmodule Cog.Chat.HipChat.Templates.Embedded.HelpBundleTest do
       "<strong>Description</strong><br/><br/>" <>
       "No really, it does a thing<br/><br/>" <>
       "<strong>Commands</strong><br/><br/>" <>
-      "<ul><li>test-command - does just one thing</li></ul><br/>" <>
+      "<ul><li><code>test-command</code> - does just one thing</li></ul><br/>" <>
       "<strong>Author</strong><br/><br/>" <>
       "vanstee<br/><br/>" <>
       "<strong>Homepage</strong><br/><br/>" <>

--- a/test/cog/chat/slack/templates/embedded/help_bundle_test.exs
+++ b/test/cog/chat/slack/templates/embedded/help_bundle_test.exs
@@ -25,16 +25,16 @@ defmodule Cog.Chat.Slack.Templates.Embedded.HelpBundleTest do
 
     No really, it does a thing
 
+    *Commands*
+
+    • `test-command` - does just one thing
+
     *Configuration*
 
     Some notes about config
 
-    • VAR1 - description1
-    • VAR2
-
-    *Commands*
-
-    • test-command - does just one thing
+    • `VAR1` - description1
+    • `VAR2`
 
     *Author*
 
@@ -69,7 +69,7 @@ defmodule Cog.Chat.Slack.Templates.Embedded.HelpBundleTest do
 
     *Commands*
 
-    • test-command - does just one thing
+    • `test-command` - does just one thing
 
     *Author*
 


### PR DESCRIPTION
* Bundle Help
  * Display command names in a fixed width font.
  * Move the Configuration section to the bottom, immediately before Author.
  * Display the name of config env vars in a fixed width font.
* Command Help
  * Display options and required options in a fixed width font.
* Bump embedded version bundle to pick up template changes.