### PR TITLE
support markdown links

### DIFF
--- a/lib/cog/chat/hipchat/template_processor.ex
+++ b/lib/cog/chat/hipchat/template_processor.ex
@@ -41,7 +41,7 @@ defmodule Cog.Chat.HipChat.TemplateProcessor do
   # inform the user inline that there was a problem and log a warning.
   defp process_directive(%{"name" => "link", "text" => text, "url" => url}=directive) when url in [nil, ""] do
     Logger.warn("Invalid link; #{inspect directive}")
-    ~s[(invalid link! text:"#{text}" url: "#{url}")]
+    ~s[(invalid link! text:"#{text}" url: "#{inspect url}")]
   end
   defp process_directive(%{"name" => "link", "text" => text, "url" => url}),
     do: "<a href='#{url}'>#{text}</a>"

--- a/lib/cog/chat/hipchat/template_processor.ex
+++ b/lib/cog/chat/hipchat/template_processor.ex
@@ -33,6 +33,8 @@ defmodule Cog.Chat.HipChat.TemplateProcessor do
     do: "<pre>#{text}</pre>"
   defp process_directive(%{"name" => "paragraph", "children" => children}),
     do: Enum.map_join(children, &process_directive/1) <> "<br/><br/>"
+  # If you try to render a link with nil or blank text, nothing is displayed to the user.
+  # This way at least a link is rendered.
   defp process_directive(%{"name" => "link", "text" => text, "url" => url}) when text in [nil, ""],
     do: "<a href='#{url}'>#{url}</a>"
   defp process_directive(%{"name" => "link", "text" => text, "url" => url}),

--- a/lib/cog/chat/hipchat/template_processor.ex
+++ b/lib/cog/chat/hipchat/template_processor.ex
@@ -33,6 +33,8 @@ defmodule Cog.Chat.HipChat.TemplateProcessor do
     do: "<pre>#{text}</pre>"
   defp process_directive(%{"name" => "paragraph", "children" => children}),
     do: Enum.map_join(children, &process_directive/1) <> "<br/><br/>"
+  defp process_directive(%{"name" => "link", "text" => text, "url" => url}) when text in [nil, ""],
+    do: "<a href='#{url}'>#{url}</a>"
   defp process_directive(%{"name" => "link", "text" => text, "url" => url}),
     do: "<a href='#{url}'>#{text}</a>"
 

--- a/lib/cog/chat/hipchat/template_processor.ex
+++ b/lib/cog/chat/hipchat/template_processor.ex
@@ -33,8 +33,8 @@ defmodule Cog.Chat.HipChat.TemplateProcessor do
     do: "<pre>#{text}</pre>"
   defp process_directive(%{"name" => "paragraph", "children" => children}),
     do: Enum.map_join(children, &process_directive/1) <> "<br/><br/>"
-  # If you try to render a link with nil or blank text, nothing is displayed to the user.
-  # This way at least a link is rendered.
+  # If you try to render a link with nil or blank text, HipChat displays nothing to the user.
+  # This way at least a link is rendered. This basically mirrors the default Slack behavior.
   defp process_directive(%{"name" => "link", "text" => text, "url" => url}) when text in [nil, ""],
     do: "<a href='#{url}'>#{url}</a>"
   defp process_directive(%{"name" => "link", "text" => text, "url" => url}),

--- a/lib/cog/chat/hipchat/template_processor.ex
+++ b/lib/cog/chat/hipchat/template_processor.ex
@@ -31,9 +31,10 @@ defmodule Cog.Chat.HipChat.TemplateProcessor do
     do: "<code>#{text}</code>"
   defp process_directive(%{"name" => "fixed_width_block", "text" => text}),
     do: "<pre>#{text}</pre>"
-  defp process_directive(%{"name" => "paragraph", "children" => children}) do
-      Enum.map_join(children, &process_directive/1) <> "<br/><br/>"
-  end
+  defp process_directive(%{"name" => "paragraph", "children" => children})
+      do: Enum.map_join(children, &process_directive/1) <> "<br/><br/>"
+  defp process_directive(%{"name" => "link", "text" => text, "url" => url}),
+    do: "<a href='#{url}'>#{text}</a>"
 
   defp process_directive(%{"name" => "newline"}), do: "<br/>"
 

--- a/lib/cog/chat/hipchat/template_processor.ex
+++ b/lib/cog/chat/hipchat/template_processor.ex
@@ -37,6 +37,12 @@ defmodule Cog.Chat.HipChat.TemplateProcessor do
   # This way at least a link is rendered. This basically mirrors the default Slack behavior.
   defp process_directive(%{"name" => "link", "text" => text, "url" => url}) when text in [nil, ""],
     do: "<a href='#{url}'>#{url}</a>"
+  # Rendering a link in HipChat with a nil or blank url will obviously result in an invalid link. We
+  # inform the user inline that there was a problem and log a warning.
+  defp process_directive(%{"name" => "link", "text" => text, "url" => url}=directive) when url in [nil, ""] do
+    Logger.warn("Invalid link; #{inspect directive}")
+    ~s[(invalid link! text:"#{text}" url: "#{url}")]
+  end
   defp process_directive(%{"name" => "link", "text" => text, "url" => url}),
     do: "<a href='#{url}'>#{text}</a>"
 

--- a/lib/cog/chat/hipchat/template_processor.ex
+++ b/lib/cog/chat/hipchat/template_processor.ex
@@ -31,8 +31,8 @@ defmodule Cog.Chat.HipChat.TemplateProcessor do
     do: "<code>#{text}</code>"
   defp process_directive(%{"name" => "fixed_width_block", "text" => text}),
     do: "<pre>#{text}</pre>"
-  defp process_directive(%{"name" => "paragraph", "children" => children})
-      do: Enum.map_join(children, &process_directive/1) <> "<br/><br/>"
+  defp process_directive(%{"name" => "paragraph", "children" => children}),
+    do: Enum.map_join(children, &process_directive/1) <> "<br/><br/>"
   defp process_directive(%{"name" => "link", "text" => text, "url" => url}),
     do: "<a href='#{url}'>#{text}</a>"
 

--- a/lib/cog/chat/slack/template_processor.ex
+++ b/lib/cog/chat/slack/template_processor.ex
@@ -57,8 +57,6 @@ defmodule Cog.Chat.Slack.TemplateProcessor do
     do: "`#{text}`"
   defp process_directive(%{"name" => "fixed_width_block", "text" => text}, _),
     do: "```#{text}```\n"
-  defp process_directive(%{"name" => "link", "text" => text, "url" => url}, _),
-    do: "<#{url}|#{text}>"
 
   # Tables _have_ to have a header
   defp process_directive(%{"name" => "table",
@@ -92,6 +90,8 @@ defmodule Cog.Chat.Slack.TemplateProcessor do
   end
   defp process_directive(%{"name" => "list_item", "children" => children}, bullet: bullet),
     do: "   #{bullet} #{Enum.map_join(children, &process_directive/1)}\n"
+  defp process_directive(%{"name" => "link", "text" => text, "url" => url}, _),
+    do: "<#{url}|#{text}>"
   defp process_directive(%{"name" => "link", "url" => url}, _) do
     "#{url}"
   end

--- a/lib/cog/chat/slack/template_processor.ex
+++ b/lib/cog/chat/slack/template_processor.ex
@@ -90,10 +90,8 @@ defmodule Cog.Chat.Slack.TemplateProcessor do
   end
   defp process_directive(%{"name" => "list_item", "children" => children}, bullet: bullet),
     do: "   #{bullet} #{Enum.map_join(children, &process_directive/1)}\n"
-  defp process_directive(%{"name" => "link", "text" => text, "url" => url}, _),
-    do: "<#{url}|#{text}>"
-  defp process_directive(%{"name" => "link", "url" => url}, _) do
-    "#{url}"
+  defp process_directive(%{"name" => "link", "text" => text, "url" => url}, _) do
+    "<#{url}|#{text}>"
   end
   defp process_directive(%{"text" => text}=directive, _) do
     Logger.warn("Unrecognized directive; formatting as plain text: #{inspect directive}")

--- a/lib/cog/chat/slack/template_processor.ex
+++ b/lib/cog/chat/slack/template_processor.ex
@@ -90,12 +90,8 @@ defmodule Cog.Chat.Slack.TemplateProcessor do
   end
   defp process_directive(%{"name" => "list_item", "children" => children}, bullet: bullet),
     do: "   #{bullet} #{Enum.map_join(children, &process_directive/1)}\n"
-  # This is technially the default behavior in Slack. If you try to create a link with blank
-  # text only the link is displayed and is clickable, but it is included here for clarity
-  # and to conform more closely to the hipchat implementation.
-  defp process_directive(%{"name" => "link", "text" => text, "url" => url}, _) when text in [nil, ""] do
-    "<#{url}|#{url}>"
-  end
+  # By default if a link is rendered with nil or blank text only the link is displayed. So
+  # we don't have to do anything special like we do in the HipChat processor.
   defp process_directive(%{"name" => "link", "text" => text, "url" => url}, _) do
     "<#{url}|#{text}>"
   end

--- a/lib/cog/chat/slack/template_processor.ex
+++ b/lib/cog/chat/slack/template_processor.ex
@@ -94,7 +94,7 @@ defmodule Cog.Chat.Slack.TemplateProcessor do
   # useful to a user. So instead we'll inform the user of the problem inline and log a warning.
   defp process_directive(%{"name" => "link", "text" => text, "url" => url}=directive, _) when url in [nil, ""] do
     Logger.warn("Invalid link; #{inspect directive}")
-    ~s[(invalid link! text:"#{text}" url: "#{url}")]
+    ~s[(invalid link! text:"#{text}" url: "#{inspect url}")]
   end
   # By default if a link is rendered with nil or blank text only the link is displayed. So
   # we don't have to do anything special like we do in the HipChat processor.

--- a/lib/cog/chat/slack/template_processor.ex
+++ b/lib/cog/chat/slack/template_processor.ex
@@ -90,6 +90,12 @@ defmodule Cog.Chat.Slack.TemplateProcessor do
   end
   defp process_directive(%{"name" => "list_item", "children" => children}, bullet: bullet),
     do: "   #{bullet} #{Enum.map_join(children, &process_directive/1)}\n"
+  # This is technially the default behavior in Slack. If you try to create a link with blank
+  # text only the link is displayed and is clickable, but it is included here for clarity
+  # and to conform more closely to the hipchat implementation.
+  defp process_directive(%{"name" => "link", "text" => text, "url" => url}, _) when text in [nil, ""] do
+    "<#{url}|#{url}>"
+  end
   defp process_directive(%{"name" => "link", "text" => text, "url" => url}, _) do
     "<#{url}|#{text}>"
   end

--- a/lib/cog/chat/slack/template_processor.ex
+++ b/lib/cog/chat/slack/template_processor.ex
@@ -57,6 +57,8 @@ defmodule Cog.Chat.Slack.TemplateProcessor do
     do: "`#{text}`"
   defp process_directive(%{"name" => "fixed_width_block", "text" => text}, _),
     do: "```#{text}```\n"
+  defp process_directive(%{"name" => "link", "text" => text, "url" => url}, _),
+    do: "<#{url}|#{text}>"
 
   # Tables _have_ to have a header
   defp process_directive(%{"name" => "table",

--- a/lib/cog/chat/slack/template_processor.ex
+++ b/lib/cog/chat/slack/template_processor.ex
@@ -90,6 +90,12 @@ defmodule Cog.Chat.Slack.TemplateProcessor do
   end
   defp process_directive(%{"name" => "list_item", "children" => children}, bullet: bullet),
     do: "   #{bullet} #{Enum.map_join(children, &process_directive/1)}\n"
+  # Rendering a link in Slack with a nil or blank url just results in '<|text>' which isn't super
+  # useful to a user. So instead we'll inform the user of the problem inline and log a warning.
+  defp process_directive(%{"name" => "link", "text" => text, "url" => url}=directive, _) when url in [nil, ""] do
+    Logger.warn("Invalid link; #{inspect directive}")
+    ~s[(invalid link! text:"#{text}" url: "#{url}")]
+  end
   # By default if a link is rendered with nil or blank text only the link is displayed. So
   # we don't have to do anything special like we do in the HipChat processor.
   defp process_directive(%{"name" => "link", "text" => text, "url" => url}, _) do

--- a/test/cog/chat/hipchat/template_processor_test.exs
+++ b/test/cog/chat/hipchat/template_processor_test.exs
@@ -118,4 +118,26 @@ defmodule Cog.Chat.HipChat.TemplateProcessorTest do
 
     assert expected == rendered
   end
+
+  test "handles link directive with a nil url" do
+    directives = [
+      %{"name" => "link", "text" => "a link", "url" => nil}
+    ]
+
+    rendered = TemplateProcessor.render(directives)
+    expected = "<a href=''>a link</a>"
+
+    assert expected == rendered
+  end
+
+  test "handles link directive with nil text" do
+    directives = [
+      %{"name" => "link", "text" => nil, "url" => "http://www.example.com"}
+    ]
+
+    rendered = TemplateProcessor.render(directives)
+    expected = "<a href='http://www.example.com'>http://www.example.com</a>"
+
+    assert expected == rendered
+  end
 end

--- a/test/cog/chat/hipchat/template_processor_test.exs
+++ b/test/cog/chat/hipchat/template_processor_test.exs
@@ -125,7 +125,7 @@ defmodule Cog.Chat.HipChat.TemplateProcessorTest do
     ]
 
     rendered = TemplateProcessor.render(directives)
-    expected = "(invalid link! text:\"a link\" url: \"\")"
+    expected = "(invalid link! text:\"a link\" url: \"nil\")"
 
     assert expected == rendered
   end

--- a/test/cog/chat/hipchat/template_processor_test.exs
+++ b/test/cog/chat/hipchat/template_processor_test.exs
@@ -125,7 +125,7 @@ defmodule Cog.Chat.HipChat.TemplateProcessorTest do
     ]
 
     rendered = TemplateProcessor.render(directives)
-    expected = "<a href=''>a link</a>"
+    expected = "(invalid link! text:\"a link\" url: \"\")"
 
     assert expected == rendered
   end

--- a/test/cog/chat/hipchat/template_processor_test.exs
+++ b/test/cog/chat/hipchat/template_processor_test.exs
@@ -107,4 +107,15 @@ defmodule Cog.Chat.HipChat.TemplateProcessorTest do
 
     assert expected == rendered
   end
+
+  test "handles link directives" do
+    directives = [
+      %{"name" => "link", "text" => "a link", "url" => "http://www.example.com"}
+    ]
+
+    rendered = TemplateProcessor.render(directives)
+    expected = "<a href='http://www.example.com'>a link</a>"
+
+    assert expected == rendered
+  end
 end

--- a/test/cog/chat/slack/template_processor_test.exs
+++ b/test/cog/chat/slack/template_processor_test.exs
@@ -111,4 +111,15 @@ defmodule Cog.Chat.Slack.TemplateProcessorTest do
 
     assert expected == rendered
   end
+
+  test "handles link directives" do
+    directives = [
+      %{"name" => "link", "text" => "a link", "url" => "http://www.example.com"}
+    ]
+
+    {rendered, _} = TemplateProcessor.render(directives)
+    expected = "<http://www.example.com|a link>"
+
+    assert expected == rendered
+  end
 end

--- a/test/cog/chat/slack/template_processor_test.exs
+++ b/test/cog/chat/slack/template_processor_test.exs
@@ -129,7 +129,7 @@ defmodule Cog.Chat.Slack.TemplateProcessorTest do
     ]
 
     {rendered, _} = TemplateProcessor.render(directives)
-    expected = "<|a link>"
+    expected = "(invalid link! text:\"a link\" url: \"\")"
 
     assert expected == rendered
   end

--- a/test/cog/chat/slack/template_processor_test.exs
+++ b/test/cog/chat/slack/template_processor_test.exs
@@ -122,4 +122,26 @@ defmodule Cog.Chat.Slack.TemplateProcessorTest do
 
     assert expected == rendered
   end
+
+  test "handles link directive with a nil url" do
+    directives = [
+      %{"name" => "link", "text" => "a link", "url" => nil}
+    ]
+
+    {rendered, _} = TemplateProcessor.render(directives)
+    expected = "<|a link>"
+
+    assert expected == rendered
+  end
+
+  test "handles link directive with nil text" do
+    directives = [
+      %{"name" => "link", "text" => nil, "url" => "http://www.example.com"}
+    ]
+
+    {rendered, _} = TemplateProcessor.render(directives)
+    expected = "<http://www.example.com|>"
+
+    assert expected == rendered
+  end
 end

--- a/test/cog/chat/slack/template_processor_test.exs
+++ b/test/cog/chat/slack/template_processor_test.exs
@@ -129,7 +129,7 @@ defmodule Cog.Chat.Slack.TemplateProcessorTest do
     ]
 
     {rendered, _} = TemplateProcessor.render(directives)
-    expected = "(invalid link! text:\"a link\" url: \"\")"
+    expected = "(invalid link! text:\"a link\" url: \"nil\")"
 
     assert expected == rendered
   end


### PR DESCRIPTION
This adds support for rendering the link directive to both hipchat and slack.

resolves #1076 

BLOCKED BY #1195 