### PR TITLE
Sane defaults cleanup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,6 @@ relay:
     - RELAY_DOCKER_CLEAN_INTERVAL=1m
     - RELAY_COG_HOST=cog
     - RELAY_DYNAMIC_CONFIG_ROOT=/tmp/bundle_configs
-    - RELAY_MANAGED_DYNAMIC_CONFIG=true
   links:
     - cog
   entrypoint: /usr/local/bin/relay

--- a/lib/cog/models/relay.ex
+++ b/lib/cog/models/relay.ex
@@ -32,8 +32,10 @@ defmodule Cog.Models.Relay do
 
   def allow_user_defined_id_on_insert(changeset) do
     case {Map.get(changeset.data, :id), get_field(changeset, :id)} do
-      {nil, _changed_id} ->
+      {nil, nil} ->
         changeset
+      {nil, user_defined_id} ->
+        put_change(changeset, :id, String.downcase(user_defined_id))
       {id, id} ->
         changeset
       _ ->


### PR DESCRIPTION
* Remove unnecessary env var now that `RELAY_MANAGED_DYNAMIC_CONFIG` defaults to true
* Downcase user provided relay ids