### PR TITLE
Use Regex.replace to format Slack messages

### DIFF
--- a/lib/cog/chat/slack/formatter.ex
+++ b/lib/cog/chat/slack/formatter.ex
@@ -1,5 +1,4 @@
 defmodule Cog.Chat.Slack.Formatter do
-
   @channel ~r/<\#(C.*)(\|(.*))?>/U
   @user    ~r/<\@(U.*)(\|(.*))?>/U
   @command ~r/<\!(.*)(\|(.*))?>/U
@@ -14,60 +13,38 @@ defmodule Cog.Chat.Slack.Formatter do
   end
 
   defp unescape_channels(message, slack) do
-    replace(message, @channel, fn original ->
-      case Regex.run(@channel, original) do
-        [^original, channel_id] ->
-          Slack.Lookups.lookup_channel_name(channel_id, slack)
-        [^original, _channel_id, _right, channel_name] ->
-          "#" <> channel_name
-      end
+    Regex.replace(@channel, message, fn
+      _match, channel_id, "", "" ->
+        Slack.Lookups.lookup_channel_name(channel_id, slack)
+      _match, _channel_id, _right, channel_name ->
+        "#" <> channel_name
     end)
   end
 
   defp unescape_users(message, slack) do
-    replace(message, @user, fn original ->
-      case Regex.run(@user, original) do
-        [^original, user_id] ->
-          Slack.Lookups.lookup_user_name(user_id, slack)
-        [^original, _user_id, _right, user_name] ->
-          "@" <> user_name
-      end
+    Regex.replace(@user, message, fn
+      _match, user_id, "", "" ->
+        Slack.Lookups.lookup_user_name(user_id, slack)
+      _match, _user_id, _right, user_name ->
+        "@" <> user_name
     end)
   end
 
   defp unescape_commands(message) do
-    replace(message, @command, fn original ->
-      case Regex.run(@command, original) do
-        [^original, command_name] ->
-          "@" <> command_name
-        [^original, _command_name, _right, label] ->
-          "@" <> label
-      end
+    Regex.replace(@command, message, fn
+      _match, command_name, "", "" ->
+        "@" <> command_name
+      _match, _command_name, _right, label ->
+        "@" <> label
     end)
   end
 
   defp unescape_links(message) do
-    replace(message, @link, fn original ->
-      case Regex.run(@link, original) do
-        [^original, full_link] ->
-          full_link
-        [^original, _full_link, _right, short_link] ->
-          short_link
-      end
+    Regex.replace(@link, message, fn
+      _match, full_link, "", "" ->
+        full_link
+      _match, _full_link, _right, short_link ->
+        short_link
     end)
-  end
-
-  defp replace(message, regex, replace_fun) do
-    case Regex.run(regex, message, return: :index) do
-      nil ->
-        message
-      [{start, length}|_] ->
-        original = String.slice(message, start, length)
-        replacement = replace_fun.(original)
-
-        {left, right} = String.split_at(message, start)
-        right = String.slice(right, length, String.length(right))
-        replace(left <> replacement <> right, regex, replace_fun)
-    end
   end
 end

--- a/test/integration/slack_test.exs
+++ b/test/integration/slack_test.exs
@@ -138,4 +138,9 @@ defmodule Integration.SlackTest do
     assert reply.text == "blah"
   end
 
+  test "formatting with unicode present", %{user: user, client: client} do
+    user |> with_permission("operable:echo")
+    {:ok, reply} = ChatClient.chat_wait!(client, [room: @ci_room, message: "@#{@bot} operable:echo \"ϻ https://google.com\"", reply_from: @bot])
+    assert reply.text == "ϻ <https://google.com>"
+  end
 end


### PR DESCRIPTION
`Regex.run` was returning incorrect indices when unicode was present. Instead of fixing that up, we can just switch to `Regex.replace`.

Fixes #1161 