### PR TITLE
Command output docs

### DIFF
--- a/lib/cog/models/command_version.ex
+++ b/lib/cog/models/command_version.ex
@@ -16,6 +16,7 @@ defmodule Cog.Models.CommandVersion do
     field :arguments, :string
     field :subcommands, :map
     field :documentation, :string
+    field :output, :map
     field :status, :string, virtual: true
 
     belongs_to :command, Command
@@ -27,7 +28,7 @@ defmodule Cog.Models.CommandVersion do
   end
 
   @required_fields ~w(command_id bundle_version_id)
-  @optional_fields ~w(description documentation long_description examples notes arguments subcommands)
+  @optional_fields ~w(description documentation long_description examples notes arguments subcommands output)
 
   summary_fields [:documentation]
   detail_fields [:documentation]

--- a/mix.lock
+++ b/mix.lock
@@ -63,7 +63,7 @@
   "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []},
   "romeo": {:git, "https://github.com/operable/romeo.git", "65106b94f134a12791ec63fa284b0ce5e9358538", [branch: "iq-bodies"]},
   "slack": {:git, "https://github.com/operable/Elixir-Slack.git", "4d6a3c4036ec4129e8d77e55cd1d3e62093cc001", []},
-  "spanner": {:git, "https://github.com/operable/spanner.git", "12dc8c0c4ac5040115e9ae286c9f8ee6f14d14b3", []},
+  "spanner": {:git, "https://github.com/operable/spanner.git", "23380d035347a1f3cd9a1b2669ca72839493c93a", []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
   "table_rex": {:hex, :table_rex, "0.8.3", "1c68dfc6886d6f118f5047b0449d6402ae0ac5709064789e578c2f4659f4064b", [:mix], []},
   "uuid": {:hex, :uuid, "1.1.5", "96cb36d86ee82f912efea4d50464a5df606bf3f1163d6bdbb302d98474969369", [], []},

--- a/mix.lock
+++ b/mix.lock
@@ -63,7 +63,7 @@
   "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []},
   "romeo": {:git, "https://github.com/operable/romeo.git", "65106b94f134a12791ec63fa284b0ce5e9358538", [branch: "iq-bodies"]},
   "slack": {:git, "https://github.com/operable/Elixir-Slack.git", "4d6a3c4036ec4129e8d77e55cd1d3e62093cc001", []},
-  "spanner": {:git, "https://github.com/operable/spanner.git", "23380d035347a1f3cd9a1b2669ca72839493c93a", []},
+  "spanner": {:git, "https://github.com/operable/spanner.git", "646eed9a885053d21bb43323e6551518b3b0cec2", []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
   "table_rex": {:hex, :table_rex, "0.8.3", "1c68dfc6886d6f118f5047b0449d6402ae0ac5709064789e578c2f4659f4064b", [:mix], []},
   "uuid": {:hex, :uuid, "1.1.5", "96cb36d86ee82f912efea4d50464a5df606bf3f1163d6bdbb302d98474969369", [], []},

--- a/priv/repo/migrations/20161202162538_add_output_to_command_versions.exs
+++ b/priv/repo/migrations/20161202162538_add_output_to_command_versions.exs
@@ -1,0 +1,9 @@
+defmodule Cog.Repo.Migrations.AddOutputToCommandVersions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:command_versions) do
+      add :output, :json, null: false, default: "{}"
+    end
+  end
+end

--- a/priv/templates/embedded/help-command.greenbar
+++ b/priv/templates/embedded/help-command.greenbar
@@ -65,6 +65,22 @@ __Examples__
 ~br~
 ~end~
 
+~if cond=$command.output not_empty?~
+__Output__
+~br~
+~if cond=$command.output.description bound?~
+~$command.output.description~
+~br~
+~end~
+~if cond=$command.output.example bound?~
+Example:
+
+```
+~$command.output.example~```
+~end~
+~br~
+~end~
+
 ~if cond=$command.notes~
 __Notes__
 ~br~

--- a/web/views/command_version_help_view.ex
+++ b/web/views/command_version_help_view.ex
@@ -13,6 +13,7 @@ defmodule Cog.CommandVersionHelpView do
       subcommands: render_subcommands(command_version),
       examples: command_version.examples,
       notes: command_version.notes,
+      output: render_output(command_version),
       bundle: %{
         author: command_version.bundle_version.author,
         homepage: command_version.bundle_version.homepage
@@ -101,5 +102,12 @@ defmodule Cog.CommandVersionHelpView do
       %{command: command,
         description: description}
     end)
+  end
+
+  def render_output(%CommandVersion{output: output}) do
+    %{description: output["description"],
+      example: output["example"]}
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Enum.into(%{})
   end
 end


### PR DESCRIPTION
Splits output documentation into description and example. Both or printed in the help docs for a command. The help command also now supports an `--output` flag which when used with a command name, only returns the json in the output example to the next command in the pipeline.