### PR TITLE
Render trigger pipelines correctly in chat output

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -30,7 +30,7 @@
   "getopt": {:git, "https://github.com/jcomellas/getopt.git", "68fe326f2c7585eb32a5b136dffc75428a53fc02", [branch: "master"]},
   "goldrush": {:hex, :goldrush, "0.1.8", "2024ba375ceea47e27ea70e14d2c483b2d8610101b4e852ef7f89163cdb6e649", [:rebar3], []},
   "gproc": {:hex, :gproc, "0.5.0", "2df2d886f8f8a7b81a4b04aa17972b5965bbc5bf0100ea6d8e8ac6a0e7389afe", [:rebar], []},
-  "greenbar": {:git, "https://github.com/operable/greenbar.git", "b0c57915d93eb993f48ca74143eed1450b8b1459", []},
+  "greenbar": {:git, "https://github.com/operable/greenbar.git", "e56d7e6004765613feddd8bb45114de35aad1cb7", []},
   "greenbar_markdown": {:git, "https://github.com/operable/greenbar_markdown.git", "ad6d027c92ef095a0461c08847d3eb999659c3a2", []},
   "hackney": {:hex, :hackney, "1.6.1", "ddd22d42db2b50e6a155439c8811b8f6df61a4395de10509714ad2751c6da817", [:rebar3], [{:certifi, "0.4.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.0", [hex: :ssl_verify_fun, optional: false]}]},
   "html_entities": {:hex, :html_entities, "0.3.0", "2f278ffc69c3f0cbd5996628fef37cf922fa715f3e04b9f38924c8adced3f25a", [:mix], []},

--- a/priv/templates/embedded/trigger-info.greenbar
+++ b/priv/templates/embedded/trigger-info.greenbar
@@ -3,7 +3,7 @@
 **Name**: ~$results[0].name~
 **Description**: ~$results[0].description~
 **Enabled?**: ~$results[0].enabled~
-**Pipeline**: ~$results[0].pipeline~
+**Pipeline**: `~$results[0].pipeline~`
 **As User**: ~$results[0].as_user~
 **Timeout (sec)**: ~$results[0].timeout_sec~
 **Invocation URL**: ~$results[0].invocation_url~
@@ -11,6 +11,6 @@
 ~if cond=length($results) > 1~
 | ID | Name | Description | Enabled? | Pipeline | As User | Timeout | Invocation URL |
 |----|------|-------------|----------|----------|---------|---------|----------------|
-~each var=$results~|~$item.id~|~$item.name~|~if cond=$item.description bound?~~$item.description~~end~|~$item.enabled~|~$item.pipeline~|~if cond=$item.as_user~~$item.as_user~~end~|~$item.timeout_sec~|~$item.invocation_url~|
+~each var=$results~|~$item.id~|~$item.name~|~if cond=$item.description bound?~~$item.description~~end~|~$item.enabled~|`~$item.pipeline~`|~if cond=$item.as_user~~$item.as_user~~end~|~$item.timeout_sec~|~$item.invocation_url~|
 ~end~
 ~end~

--- a/priv/templates/embedded/trigger-list.greenbar
+++ b/priv/templates/embedded/trigger-list.greenbar
@@ -1,4 +1,4 @@
 | ID | Name | Description | Enabled? | Pipeline | As User | Timeout | Invocation URL |
 |----|------|-------------|----------|----------|---------|---------|----------------|
-~each var=$results~|~$item.id~|~$item.name~|~if cond=$item.description bound?~~$item.description~~end~|~$item.enabled~|~$item.pipeline~|~if cond=$item.as_user~~$item.as_user~~end~|~$item.timeout_sec~|~$item.invocation_url~|
+~each var=$results~|~$item.id~|~$item.name~|~if cond=$item.description bound?~~$item.description~~end~|~$item.enabled~|`~$item.pipeline~`|~if cond=$item.as_user~~$item.as_user~~end~|~$item.timeout_sec~|~$item.invocation_url~|
 ~end~

--- a/test/cog/chat/hipchat/templates/embedded/trigger_info_test.exs
+++ b/test/cog/chat/hipchat/templates/embedded/trigger_info_test.exs
@@ -14,7 +14,7 @@ defmodule Cog.Chat.HipChat.Templates.Embedded.TriggerInfoTest do
       "<strong>Name</strong>: test_trigger<br/>" <>
       "<strong>Description</strong>: Tests things!<br/>" <>
       "<strong>Enabled?</strong>: true<br/>" <>
-      "<strong>Pipeline</strong>: echo 'Something just happened'<br/>" <>
+      "<strong>Pipeline</strong>: <code>echo 'Something just happened'</code><br/>" <>
       "<strong>As User</strong>: bobby_tables<br/>" <>
       "<strong>Timeout (sec)</strong>: 30<br/>" <>
       "<strong>Invocation URL</strong>: https://cog.mycompany.com/invoke_stuff"
@@ -34,7 +34,7 @@ defmodule Cog.Chat.HipChat.Templates.Embedded.TriggerInfoTest do
       "<strong>Name</strong>: test_trigger<br/>" <>
       "<strong>Description</strong>: <br/>" <>
       "<strong>Enabled?</strong>: true<br/>" <>
-      "<strong>Pipeline</strong>: echo 'Something just happened'<br/>" <>
+      "<strong>Pipeline</strong>: <code>echo 'Something just happened'</code><br/>" <>
       "<strong>As User</strong>: <br/>" <>
       "<strong>Timeout (sec)</strong>: 30<br/>" <>
       "<strong>Invocation URL</strong>: https://cog.mycompany.com/invoke_stuff"

--- a/test/cog/chat/slack/templates/embedded/trigger_info_test.exs
+++ b/test/cog/chat/slack/templates/embedded/trigger_info_test.exs
@@ -15,7 +15,7 @@ defmodule Cog.Chat.Slack.Templates.Embedded.TriggerInfoTest do
     *Name*: test_trigger
     *Description*: Tests things!
     *Enabled?*: true
-    *Pipeline*: echo 'Something just happened'
+    *Pipeline*: `echo 'Something just happened'`
     *As User*: bobby_tables
     *Timeout (sec)*: 30
     *Invocation URL*: https://cog.mycompany.com/invoke_stuff
@@ -35,7 +35,7 @@ defmodule Cog.Chat.Slack.Templates.Embedded.TriggerInfoTest do
     *ID*: abc123
     *Name*: test_trigger
     *Description*: \n*Enabled?*: true
-    *Pipeline*: echo 'Something just happened'
+    *Pipeline*: `echo 'Something just happened'`
     *As User*: \n*Timeout (sec)*: 30
     *Invocation URL*: https://cog.mycompany.com/invoke_stuff
     """ |> String.strip


### PR DESCRIPTION
Treat the pipeline as a fixed-width string, but use new Greenbar that
does not render fixed-width directives as such when already in a
fixed-width block. This ensures consistent results in Slack and
HipChat.

Fixes #1239