### PR TITLE
Record higher resolution timestamps in the audit log

### DIFF
--- a/lib/cog/events/util.ex
+++ b/lib/cog/events/util.ex
@@ -4,7 +4,7 @@ defmodule Cog.Events.Util do
   """
 
   # ISO-8601 UTC
-  @date_format "~.4.0w-~.2.0w-~.2.0wT~.2.0w:~.2.0w:~.2.0wZ"
+  @date_format "~.4.0w-~.2.0w-~.2.0wT~.2.0w:~.2.0w:~.2.0w.~wZ"
 
   @typedoc "Unique correlation ID"
   @type correlation_id :: String.t
@@ -32,9 +32,9 @@ defmodule Cog.Events.Util do
 
   """
   @spec ts_iso8601_utc(:erlang.timestamp) :: binary()
-  def ts_iso8601_utc(ts) do
+  def ts_iso8601_utc({_, _, microsecs}=ts) do
     {{year, month, day}, {hour, min, sec}} = :calendar.now_to_universal_time(ts)
-    :io_lib.format(@date_format, [year, month, day, hour, min, sec])
+    :io_lib.format(@date_format, [year, month, day, hour, min, sec, microsecs])
     |> IO.iodata_to_binary
   end
 


### PR DESCRIPTION
This updates the `timestamp` in audit logs to include microseconds as a decimal after the seconds part of the IS08601 formatted time. 

Example:
```json
"timestamp": "2016-12-15T16:28:34.332811Z"
```

Resolves #1253