### PR TITLE
Increase event timestamp precision and accuracy

### DIFF
--- a/lib/cog/events/util.ex
+++ b/lib/cog/events/util.ex
@@ -3,50 +3,14 @@ defmodule Cog.Events.Util do
   Various utility functions used for generating event data.
   """
 
-  # ISO-8601 UTC
-  @date_format "~.4.0w-~.2.0w-~.2.0wT~.2.0w:~.2.0w:~.2.0wZ"
-
   @typedoc "Unique correlation ID"
   @type correlation_id :: String.t
 
-  @doc """
-  Current time, as an ISO-8601 formatted string.
-
-  Example:
-
-      iex> Cog.Events.Util.now_iso8691_utc
-      "2016-01-15T01:48:20Z"
-
-  """
-  @spec now_iso8601_utc() :: binary()
-  def now_iso8601_utc,
-    do: ts_iso8601_utc(now)
-
-  @doc """
-  Formats a given timestamp as an ISO-8601 formatted string.
-
-  Example:
-
-      iex> Cog.Events.Util.ts_iso8691_utc(:os.timestamp())
-      "2016-01-15T01:48:20Z"
-
-  """
-  @spec ts_iso8601_utc(:erlang.timestamp) :: binary()
-  def ts_iso8601_utc(ts) do
-    {{year, month, day}, {hour, min, sec}} = :calendar.now_to_universal_time(ts)
-    :io_lib.format(@date_format, [year, month, day, hour, min, sec])
-    |> IO.iodata_to_binary
+  @doc "Microseconds between `start_time` and `current_time`."
+  def elapsed(start_time, current_time) do
+    DateTime.to_unix(current_time, :microseconds) -
+    DateTime.to_unix(start_time, :microseconds)
   end
-
-  @doc "Current time as an Erlang timestamp."
-  @spec now() :: :erlang.timestamp()
-  def now,
-    do: :os.timestamp
-
-  @doc "Microseconds between `start_time` and now."
-  @spec elapsed(:erlang.timestamp()) :: integer()
-  def elapsed(start_time),
-    do: :timer.now_diff(now, start_time)
 
   @doc """
   Generate a unique identifier for use as a correlation ID for events

--- a/web/plugs/util.ex
+++ b/web/plugs/util.ex
@@ -28,12 +28,12 @@ defmodule Cog.Plug.Util do
   """
   @spec stamp_start_time(%Conn{}) :: %Conn{}
   def stamp_start_time(%Conn{}=conn),
-    do: assign(conn, :start_time, Cog.Events.Util.now)
+    do: assign(conn, :start_time, DateTime.utc_now())
 
   @doc """
   Retrieve the timestamp when processing of the request began.
   """
-  @spec get_start_time(%Conn{}) :: :erlang.timestamp() | nil
+  @spec get_start_time(%Conn{}) :: DateTime.t | nil
   def get_start_time(%Conn{}=conn),
     do: conn.assigns[:start_time]
 


### PR DESCRIPTION
Previously, the timestamps we generated for Cog's event log had only
second resolution, despite the fact that events frequently occur at the
microsecond scale. This made it more complicated that it should be to
order events (e.g., when analyzing data using a log aggregator).

Now, we log using ISO8601 timestamps with microsecond resolution.

In the course of making this change, lots of time-related code was
removed, in favor of native Elixir code (which didn't exist when the
code was initially written). We still need to have custom code to
compute `DateTime` differences, though. Sigh.

It was also discovered that our elapsed microsecond event log data
didn't quite line up with the timestamps we were printing; this is
because we weren't being consistent with what we were using as our basis
of comparison. Now, all elapsed time computations are done within the
actual event creation code, instead of externally, and are all based on
a consistent "start time". This simplifies the executor a small bit. We
also no longer emit an info-level logging statement stating how long a
pipeline took to execute, but that information is available from the
event log (and *that* log is structured data, rather than plain text).

We get not only increased precision, but increased accuracy as well!
BONUS!

Fixes #1253