### PR TITLE
Refactor pipeline output disposition

### DIFF
--- a/lib/cog/command/reply_helper.ex
+++ b/lib/cog/command/reply_helper.ex
@@ -12,26 +12,16 @@ defmodule Cog.Command.ReplyHelper do
   provider), no template rendering is performed, and the raw data
   itself is sent instead.
   """
+
   def send(common_template, message_data, room, adapter, connection) do
-    # TODO: it'd be nice to generate directives only if necessary :/
-    # As it is, though, this will currently only happen if we're
-    # sending a common template to the HTTP provider, so we can deal
-    # with this later.
     directives = Evaluator.evaluate(common_template, message_data)
-    payload = choose_payload(adapter, directives, message_data)
-
-    publish(connection, adapter, room, payload)
-  end
-
-  def choose_payload(adapter, directives, message_data) do
-    if Adapter.is_chat_provider?(adapter) do
+    payload = if Adapter.is_chat_provider?(adapter) do
       directives
     else
       message_data
     end
-  end
 
-  def publish(connection, adapter, room, payload),
-    do: Adapter.send(connection, adapter, room, payload)
+    Adapter.send(connection, adapter, room, payload)
+  end
 
 end

--- a/test/cog/command/pipeline/destination_test.exs
+++ b/test/cog/command/pipeline/destination_test.exs
@@ -9,10 +9,10 @@ defmodule Cog.Command.Pipeline.DestinationTest do
                                            :origin_room,
                                            "test")
 
-    assert [%Destination{output_level: :full,
-                         raw: "here",
-                         adapter: "test",
-                         room: :origin_room}] = resolved
+    assert %{chat: [%Destination{classification: :chat,
+                                 raw: "here",
+                                 adapter: "test",
+                                 room: :origin_room}]} = resolved
   end
 
   test "'me' is resolved to current user" do
@@ -21,13 +21,13 @@ defmodule Cog.Command.Pipeline.DestinationTest do
                                           :origin_room,
                                           "test")
 
-    assert [%Destination{output_level: :full,
-                         raw: "me",
-                         adapter: "test",
-                         room: %Room{id: "user1_dm",
-                                     name: "user1",
-                                     provider: "test",
-                                     is_dm: true}}] == resolved
+    assert %{chat: [%Destination{classification: :chat,
+                                 raw: "me",
+                                 adapter: "test",
+                                 room: %Room{id: "user1_dm",
+                                             name: "user1",
+                                             provider: "test",
+                                             is_dm: true}}]} == resolved
   end
 
   test "a room is looked up properly" do
@@ -36,13 +36,13 @@ defmodule Cog.Command.Pipeline.DestinationTest do
                                            :origin_room,
                                            "test")
 
-    assert [%Destination{output_level: :full,
-                         raw: "some_other_place",
-                         adapter: "test",
-                         room: %Room{id: "some_other_place",
-                                     name: "some_other_place",
-                                     provider: "test",
-                                     is_dm: false}}] == resolved
+    assert %{chat: [%Destination{classification: :chat,
+                                 raw: "some_other_place",
+                                 adapter: "test",
+                                 room: %Room{id: "some_other_place",
+                                             name: "some_other_place",
+                                             provider: "test",
+                                             is_dm: false}}]} == resolved
   end
 
   test "a chat:// prefix is properly resolved" do
@@ -51,13 +51,13 @@ defmodule Cog.Command.Pipeline.DestinationTest do
                                            :origin_room,
                                            "test")
 
-    assert [%Destination{output_level: :full,
-                         raw: "chat://some_other_place",
-                         adapter: "test",
-                         room: %Room{id: "some_other_place",
-                                     name: "some_other_place",
-                                     provider: "test",
-                                     is_dm: false}}] == resolved
+    assert %{chat: [%Destination{classification: :chat,
+                                 raw: "chat://some_other_place",
+                                 adapter: "test",
+                                 room: %Room{id: "some_other_place",
+                                             name: "some_other_place",
+                                             provider: "test",
+                                             is_dm: false}}]} == resolved
   end
 
   test "no given destinations results in an implicit 'here'" do
@@ -66,10 +66,10 @@ defmodule Cog.Command.Pipeline.DestinationTest do
                                           :origin_room,
                                           "test")
 
-    assert [%Destination{output_level: :full,
-                         raw: "here",
-                         adapter: "test",
-                         room: :origin_room}] = resolved
+    assert %{chat: [%Destination{classification: :chat,
+                                 raw: "here",
+                                 adapter: "test",
+                                 room: :origin_room}]} = resolved
   end
 
   test "no given destinations results in an implicit full-output 'here' for non-chat adapters" do
@@ -78,10 +78,10 @@ defmodule Cog.Command.Pipeline.DestinationTest do
                                           :origin_room,
                                           "http")
 
-    assert [%Destination{output_level: :full,
-                         raw: "here",
-                         adapter: "http",
-                         room: :origin_room}] = resolved
+    assert %{trigger: [%Destination{classification: :trigger,
+                                    raw: "here",
+                                    adapter: "http",
+                                    room: :origin_room}]} = resolved
   end
 
   test "no explicit 'here' generates a status-only output 'here' for non-chat adapters" do
@@ -90,19 +90,19 @@ defmodule Cog.Command.Pipeline.DestinationTest do
                                           :origin_room,
                                           "http")
 
-    expected = [%Destination{output_level: :status_only,
-                             raw: "here",
-                             adapter: "http",
-                             room: :origin_room},
-                %Destination{output_level: :full,
-                             raw: "chat://#general",
-                             adapter: "test",
-                             room: %Room{id: "#general",
-                                         name: "#general",
-                                         provider: "test",
-                                         is_dm: false}}]
+    expected = %{status_only: [%Destination{classification: :status_only,
+                                            raw: "here",
+                                            adapter: "http",
+                                            room: :origin_room}],
+                 chat: [%Destination{classification: :chat,
+                                     raw: "chat://#general",
+                                     adapter: "test",
+                                     room: %Room{id: "#general",
+                                                 name: "#general",
+                                                 provider: "test",
+                                                 is_dm: false}}]}
 
-    assert Enum.sort(expected) == Enum.sort(resolved)
+    assert expected == resolved
   end
 
   test "explicit 'here' resolves as a full-output 'here' for non-chat adapters" do
@@ -113,19 +113,19 @@ defmodule Cog.Command.Pipeline.DestinationTest do
                                           :origin_room,
                                           "http")
 
-    expected = [%Destination{output_level: :full,
-                             raw: "chat://#general",
-                             adapter: "test",
-                             room: %Room{id: "#general",
-                                         name: "#general",
-                                         provider: "test",
-                                         is_dm: false}},
-                %Destination{output_level: :full,
-                             raw: "here",
-                             adapter: "http",
-                             room: :origin_room}]
+    expected = %{chat: [%Destination{classification: :chat,
+                                     raw: "chat://#general",
+                                     adapter: "test",
+                                     room: %Room{id: "#general",
+                                                 name: "#general",
+                                                 provider: "test",
+                                                 is_dm: false}}],
+                 trigger: [%Destination{classification: :trigger,
+                                         raw: "here",
+                                         adapter: "http",
+                                         room: :origin_room}]}
 
-    assert Enum.sort(expected) == Enum.sort(resolved)
+    assert expected == resolved
   end
 
 end


### PR DESCRIPTION
Now we formally classify redirection destinations according to how the
output needs to be rendered. We have three types of output currently:

* chat: a chat adapter destination. Output is rendered through
  Greenbar templates.
* trigger: output destined for trigger destinations. Output is *not*
  rendered through Greenbar, but embeded in a map with additional
  information. The keys are as follows:

  status: Either "success", "abort", or "error"
  pipeline_output: the output of the pipeline.
  message: explanatory message for "abort" or "error" responses.

  The only trigger adapter currently is the "http" adapter. The
  response statuses map to the following HTTP codes:

  success: 200
  error: 500
  abort: 422

* status_only: an abbreviated version of trigger-style output,
  containing only "status" and (optionally) "message" keys. The output
  of the pipeline is *not* included.

  Chat destinations cannot currently be "status-only"; this is reserved
  for trigger-initiated pipelines where the output is not explicitly
  redirected back to the requestor. HTTP requests must have a response,
  and this is how we ensure that the success or failure of the pipeline
  is reported back to the requestor.

By classifying our redirection destinations this way, we can express the
logic for rendering the outputs more explicitly. Furthermore, we can
generalize the output generation process so it will be easier to add
additional types of output disposition strategies in the future, should
the need arise. It also allows us to consolidate the various code paths
leading to response output.

Some other points:

* Anytime a pipeline results in an error, the result is only returned to
  the source of the request, regardless of which redirect destinations
  may be present. This was the behavior for only trigger-initiated
  pipelines previously, but now applies to all pipeline requests.
* Common templates are now referred to referred to internaly using a
  tagged tuple: `{:common, template_name}`.

Fixes #1243
