### PR TITLE
Relax validation constraints on chat users

### DIFF
--- a/lib/cog/chat/user.ex
+++ b/lib/cog/chat/user.ex
@@ -5,8 +5,8 @@ defmodule Cog.Chat.User do
   field :id, :string, required: true
   field :provider, :string, required: true
   field :email, :string, required: false
-  field :first_name, :string, required: true
-  field :last_name, :string, required: true
+  field :first_name, :string, required: false
+  field :last_name, :string, required: false
   field :handle, :string, required: true
   field :mention_name, :string, required: false
 


### PR DESCRIPTION
Chat users don't need first and last names in order to successfully
execute a pipeline.

Fixes #1245