### PR TITLE
Link triggers and their users via FK constraint

### DIFF
--- a/lib/cog/models/trigger.ex
+++ b/lib/cog/models/trigger.ex
@@ -5,11 +5,15 @@ defmodule Cog.Models.Trigger do
     field :name, :string
 
     field :pipeline, :string
-    field :as_user, :string, default: nil
     field :timeout_sec, :integer, default: 30
 
     field :enabled, :boolean, default: true
     field :description, :string, default: nil
+
+    # This references the username, rather than the user's UUID, for
+    # historical reasons; both are equally unique, and so it functions
+    # just as well.
+    belongs_to :user, Cog.Models.User,  foreign_key: :as_user, references: :username, type: :string
 
     timestamps
   end
@@ -23,6 +27,7 @@ defmodule Cog.Models.Trigger do
     |> validate_format(:name, ~r/\A[A-Za-z0-9\_\-\.]+\z/)
     |> validate_number(:timeout_sec, greater_than: 0)
     |> unique_constraint(:name, name: :triggers_name_index)
+    |> foreign_key_constraint(:as_user, name: :triggers_as_user_fkey)
   end
 
 end

--- a/lib/cog/models/user.ex
+++ b/lib/cog/models/user.ex
@@ -30,6 +30,8 @@ defmodule Cog.Models.User do
 
     has_many :tokens, Cog.Models.Token
 
+    has_many :triggers, Cog.Models.Trigger, foreign_key: :as_user, references: :username
+
     timestamps
   end
 
@@ -79,6 +81,13 @@ defmodule Cog.Models.User do
     |> validate_presence_on_insert(:password)
     |> encode_password
     |> unique_constraint(:username)
+  end
+
+  # Prevent deletion of the user if they're attached to any triggers
+  def delete_changeset(model) do
+    model
+    |> change
+    |> no_assoc_constraint(:triggers)
   end
 
   def validate_presence_on_insert(changeset, :password) do

--- a/lib/cog/repository/users.ex
+++ b/lib/cog/repository/users.ex
@@ -118,9 +118,11 @@ defmodule Cog.Repository.Users do
   @doc """
   Deletes a user
   """
-  @spec delete(%User{}) :: {:ok, %User{}} | {:error, :not_found}
+  @spec delete(%User{}) :: {:ok, %User{}} | {:error, :not_found | Ecto.Changeset.t}
   def delete(%User{}=user) do
-    Repo.delete(user)
+    user
+    |> User.delete_changeset
+    |> Repo.delete
   end
 
   @doc """

--- a/priv/repo/migrations/20161220162331_trigger_user_referential_integrity.exs
+++ b/priv/repo/migrations/20161220162331_trigger_user_referential_integrity.exs
@@ -1,0 +1,13 @@
+defmodule Cog.Repo.Migrations.TriggerUserReferentialIntegrity do
+  use Ecto.Migration
+
+  def change do
+    execute """
+    ALTER TABLE triggers
+    ADD CONSTRAINT triggers_as_user_fkey
+    FOREIGN KEY(as_user) REFERENCES users(username)
+    ON DELETE RESTRICT
+    ON UPDATE CASCADE
+    """
+  end
+end

--- a/test/cog/models/trigger_repo_test.exs
+++ b/test/cog/models/trigger_repo_test.exs
@@ -7,8 +7,7 @@ defmodule Cog.Models.TriggerRepoTest do
   alias Cog.Models.Trigger
 
   @valid_attrs %{name: "echo_message",
-                 pipeline: "echo $body.message > chat://#general",
-                 as_user: "marvin"}
+                 pipeline: "echo $body.message > chat://#general"}
 
   test "trigger names are unique" do
     assert %Trigger{} = Trigger.changeset(%Trigger{}, @valid_attrs) |> Repo.insert!

--- a/test/cog/repository/triggers_test.exs
+++ b/test/cog/repository/triggers_test.exs
@@ -22,13 +22,11 @@ defmodule Cog.Repository.TriggersTest do
 
   test "triggers can be created from a map of attributes" do
     attrs = %{name: "echo_message",
-              pipeline: "echo $body.message > chat://#general",
-              as_user: "marvin"}
+              pipeline: "echo $body.message > chat://#general"}
     {:ok, trigger} = Triggers.new(attrs)
     assert %Trigger{id: _,
                       name: "echo_message",
                       pipeline: "echo $body.message > chat://#general",
-                      as_user: "marvin",
                       timeout_sec: 30,
                       enabled: true,
                       description: nil} = trigger

--- a/test/commands/trigger/create_test.exs
+++ b/test/commands/trigger/create_test.exs
@@ -1,6 +1,8 @@
 defmodule Cog.Test.Commands.Trigger.CreateTest do
   use Cog.CommandCase, command_module: Cog.Commands.Trigger.Create
 
+  import Cog.Support.ModelUtilities, only: [user: 1]
+
   test "creating a trigger (simple)" do
     {:ok, payload} = new_req(args: ["foo", "echo stuff"])
     |> send_req()
@@ -16,6 +18,7 @@ defmodule Cog.Test.Commands.Trigger.CreateTest do
   end
 
   test "creating a trigger (complex)" do
+    user("bobby_tables")
     {:ok, payload} = new_req(args: ["foo", "echo stuff"],
                              options: %{"description" => "behold, a trigger",
                                         "enabled" => false,

--- a/test/controllers/v1/trigger_controller_test.exs
+++ b/test/controllers/v1/trigger_controller_test.exs
@@ -69,8 +69,8 @@ defmodule Cog.V1.TriggerControllerTest do
   test "trigger creation works", %{authed: user} do
     conn = api_request(user, :post, "/v1/triggers",
                        body: %{"trigger" => %{"name" => "my_trigger",
-                                           "pipeline" => "echo foo",
-                                           "as_user" => "me"}})
+                                              "pipeline" => "echo foo",
+                                              "as_user" => user.username}})
     api_trigger = json_response(conn, 201)["trigger"]
     assert %{"name" => "my_trigger"} = api_trigger
 
@@ -91,6 +91,16 @@ defmodule Cog.V1.TriggerControllerTest do
     updated = json_response(conn, 200)["trigger"]
     assert %{"id" => ^id,
              "name" => "foo"} = updated
+  end
+
+  test "trigger creation with non-existent user fails", %{authed: user} do
+    conn = api_request(user,
+                       :post, "/v1/triggers",
+                       body: %{"trigger" => %{name: "echo",
+                                              pipeline: "echo foo",
+                                              as_user: "who_is_this"}})
+
+    assert %{"as_user" => ["does not exist"]} == json_response(conn, 422)["errors"]
   end
 
   test "trigger editing fails with bad parameters", %{authed: user} do

--- a/test/controllers/v1/trigger_execution_controller_test.exs
+++ b/test/controllers/v1/trigger_execution_controller_test.exs
@@ -47,15 +47,6 @@ defmodule Cog.V1.TriggerExecutionControllerTest do
     assert "Bad ID format" = json_response(conn, 400)["errors"]
   end
 
-  test "executing a trigger as a non-existent user fails", %{conn: conn} do
-    trigger = trigger(%{name: "echo",
-                  pipeline: "echo foo",
-                  as_user: "nobody_i_know"})
-
-    conn = post(conn, "/v1/triggers/#{trigger.id}", %{})
-    assert "Configured trigger user does not exist" = json_response(conn, 422)["errors"]
-  end
-
   test "redirecting elsewhere results in 204 (OK, no content), as well as a message to the chat adapter", %{conn: conn} do
     {:ok, snoop} = Snoop.adapter_traffic
 

--- a/web/controllers/v1/user_controller.ex
+++ b/web/controllers/v1/user_controller.ex
@@ -101,6 +101,10 @@ defmodule Cog.V1.UserController do
        conn
        |> put_status(:not_found)
        |> json(%{errors: "User not found"})
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(Cog.ChangesetView, "error.json", changeset: changeset)
     end
   end
 end


### PR DESCRIPTION
If you attempt to delete a user that is currently associated with any
triggers (i.e., that user is the one the triggers run as), the request
will be blocked.

This will prevent triggers from breaking when users are deleted,
allowing operators to re-wire their triggers as appropriate.

Fixes #1246