### PR TITLE
Simplify audit log events

### DIFF
--- a/lib/cog/events/api_event.ex
+++ b/lib/cog/events/api_event.ex
@@ -1,11 +1,53 @@
 defmodule Cog.Events.ApiEvent do
   @moduledoc """
-  Provides functions for generating REST API request processing
-  events.
+  Encapsulates information about REST API request processing
+  events. Each event is a map; all events share a core set of fields,
+  while each event sub-type will have an additional set of fields
+  particular to that sub-type.
 
   The functions in this module generate API events from `Plug.Conn`
   instances, and depend on various metadata having been added to the
   `Conn` beforehand; see `Cog.Plug.Util` and `Cog.Plug.Event`
+
+  # Common Fields
+
+  * `request_id`: The unique identifier assigned to the request. All
+    events emitted in the processing of the request will share the
+    same ID.
+
+  * `event`: label indicating which API request lifecycle event is
+    being recorded.
+
+  * `timestamp`: When the event was created, in UTC, as an ISO-8601
+    extended-format string (e.g. `"2016-01-07T15:08:00.000000Z"`). For
+    pipelines that execute in sub-second time, also see
+    `elapsed_microseconds`.
+
+  * `elapsed_microseconds`: Number of microseconds elapsed since
+    beginning of request processing to the creation of this event.
+
+  * `http_method`: the HTTP method of the request being processed as
+    an uppercase string.
+
+  * `path`: the path portion of the request URL
+
+  # Event-specific Data
+
+  Depending on the type of event, the map will contain additional
+  different keys. These are detailed here for each event.
+
+  ## `api_request_started`
+
+  No extra fields
+
+  ## `api_request_authenticated`
+
+  * `user`: (String) the Cog username of the authenticated
+    requestor. Note that this is not a chat handle.
+
+  ## `api_request_finished`
+
+  * `status`: (Integer) the HTTP status code of the response.
   """
 
   alias Plug.Conn
@@ -18,68 +60,6 @@ defmodule Cog.Events.ApiEvent do
   @type event_label :: :api_request_started |
                        :api_request_authenticated |
                        :api_request_finished
-  @typedoc """
-  Encapsulates information about REST API request processing events.
-
-  # Fields
-
-  * `request_id`: The unique identifier assigned to the request. All
-    events emitted in the processing of the request will share the
-    same ID.
-
-  * `event`: label indicating which API request lifecycle event is
-    being recorded.
-
-  * `timestamp`: When the event was created, in UTC, as an ISO-8601
-    extended-format string (e.g. `"2016-01-07T15:08:00Z"`). For
-    pipelines that execute in sub-second time, also see
-    `elapsed_microseconds`.
-
-  * `elapsed_microseconds`: Number of microseconds elapsed since
-    beginning of request processing to the creation of this event. Can
-    be used to order events from a single request.
-
-  * `http_method`: the HTTP method of the request being processed as
-    an uppercase string.
-
-  * `path`: the path portion of the request URL
-
-  * `data`: Map of arbitrary event-specific data. See below for
-    details.
-
-  # Event-specific Data
-
-  Depending on the type of event, the `data` map will contain
-  different keys. These are detailed here for each event.
-
-  ## `api_request_started`
-
-  No extra data
-
-  ## `api_request_authenticated`
-
-  * `user`: (String) the Cog username of the authenticated
-    requestor. Note that this is not a chat handle.
-
-  ## `api_request_finished`
-
-  * `status`: (Integer) the HTTP status code of the response.
-
-  """
-  @type t :: %__MODULE__{request_id: Cog.Events.Util.correlation_id(),
-                         event: event_label(),
-                         timestamp: String.t,
-                         elapsed_microseconds: non_neg_integer(),
-                         http_method: String.t,
-                         path: String.t,
-                         data: map()}
-  defstruct [request_id: nil,
-             event: nil,
-             timestamp: nil,
-             elapsed_microseconds: 0,
-             http_method: nil,
-             path: nil,
-             data: %{}]
 
   @doc "Create an `api_request_started` event."
   def started(%Conn{}=conn),
@@ -96,7 +76,7 @@ defmodule Cog.Events.ApiEvent do
     do: new(conn, :api_request_finished, %{status: conn.status})
 
   # Centralize common event creation logic
-  defp new(conn, event, data \\ %{}) do
+  defp new(conn, event, extra_fields \\ %{}) do
     start = get_start_time(conn)
     {now, elapsed_us} = case event do
                           :api_request_started -> {start, 0}
@@ -105,13 +85,13 @@ defmodule Cog.Events.ApiEvent do
                             {now, elapsed(start, now)}
                         end
 
-    %__MODULE__{request_id: get_request_id(conn),
+    Map.merge(extra_fields,
+              %{request_id: get_request_id(conn),
                 http_method: conn.method,
                 path: conn.request_path,
                 event: event,
                 timestamp: Calendar.ISO.to_string(now),
-                elapsed_microseconds: elapsed_us,
-                data: data}
+                elapsed_microseconds: elapsed_us})
   end
 
 end


### PR DESCRIPTION
Removes the `data` map field from each event type. Now, all events are
simply flat maps, which should make ingesting them into aggregation
software (e.g. Logstash, Splunk) more straightforward.

Internally, we're just using maps instead of structs, though we still
maintain centralized control of how the maps are generated, so they
should be self-consistent.

Note that the order of the fields in the printed JSON in the log file
will not be deterministic (these are maps, not structs), so you'll need
to take that into account if you're rolling your own log analysis
tooling. Treat each line like a JSON map, though, and you'll be fine.

Fixes #1255