### PR TITLE
Improve list templates and fix failing tests due to bugfixes

### DIFF
--- a/lib/cog/commands/alias/info.ex
+++ b/lib/cog/commands/alias/info.ex
@@ -1,0 +1,76 @@
+defmodule Cog.Commands.Alias.Info do
+  use Cog.Command.GenCommand.Base,
+    bundle: Cog.Util.Misc.embedded_bundle,
+    name: "alias-info"
+
+  alias Cog.Models.User
+  alias Cog.Queries
+  alias Cog.Repo
+
+  require Cog.Commands.Helpers, as: Helpers
+
+  @description "Shows a specific alias"
+
+  @arguments "<alias-name>"
+
+  @examples """
+  Showing a specific alias:
+
+    alias info user:my-awesome-alias
+  """
+
+  @output_description "Returns a serialized alias"
+
+  @output_example """
+  [
+    {
+      "visibility": "user",
+      "pipeline": "echo \\\"My Awesome Alias\\\"",
+      "name": "my-awesome-alias"
+    }
+  ]
+  """
+
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:alias-info allow"
+
+  def handle_message(req = %{args: [name]}, state) when is_binary(name) do
+    user_id = req.user["id"]
+
+    result = case find_alias(name, %User{id: user_id}) do
+      {:ok, alias} ->
+        {:ok, "alias-info", Helpers.jsonify(alias)}
+      error ->
+        error
+    end
+
+    case result do
+      {:ok, template, data} ->
+        {:reply, req.reply_to, template, data, state}
+      {:error, err} ->
+        {:error, req.reply_to, Helpers.error(err), state}
+    end
+  end
+
+  def handle_message(req = %{args: []}, state),
+    do: {:error, req.reply_to, Helpers.error({:not_enough_args, 1}), state}
+  def handle_message(req, state),
+    do: {:error, req.reply_to, Helpers.error({:too_many_args, 1}), state}
+
+  def find_alias(full_name, user) do
+    query = case full_name do
+      "site:" <> name ->
+        Queries.Alias.site_alias_by_name(name)
+      "user:" <> name ->
+        Queries.Alias.user_alias_by_name(user, name)
+      name ->
+        Queries.Alias.user_alias_by_name(user, name)
+    end
+
+    case Repo.one(query) do
+      nil ->
+        {:error, :not_found}
+      alias ->
+        {:ok, alias}
+    end
+  end
+end

--- a/lib/cog/commands/rule/info.ex
+++ b/lib/cog/commands/rule/info.ex
@@ -18,7 +18,7 @@ defmodule Cog.Commands.Rule.Info do
     {
       "rule": "when command is operable:min allow",
       "id": "00000000-0000-0000-0000-000000000000",
-      "command_name": "operable:min"
+      "command": "operable:min"
     }
   ]
   """
@@ -40,7 +40,7 @@ defmodule Cog.Commands.Rule.Info do
     if Cog.UUID.is_uuid?(id) do
       case Rules.rule(id) do
         %Rule{}=rule ->
-          {:ok, Cog.V1.RuleView.render("show.json", %{rule: rule})[:rule]}
+          {:ok, rule}
         nil ->
           {:error, {:resource_not_found, "rule", id}}
       end

--- a/lib/cog/commands/rule/list.ex
+++ b/lib/cog/commands/rule/list.ex
@@ -6,7 +6,9 @@ defmodule Cog.Commands.Rule.List do
   alias Cog.Commands.Rule
   alias Cog.Repository.Rules
 
-  @description "List all rules or rules for the provided command."
+  @description "List all rules or rules for the provided command"
+
+  @arguments "[command]"
 
   @output_description "Returns the list of rules."
 
@@ -25,14 +27,12 @@ defmodule Cog.Commands.Rule.List do
   ]
   """
 
-  option "command", type: "string", short: "c", description: "List rules belonging to command"
-
   permission "manage_commands"
 
   rule "when command is #{Cog.Util.Misc.embedded_bundle}:rule-list must have #{Cog.Util.Misc.embedded_bundle}:manage_commands"
 
-  def handle_message(req, state) do
-    case list(req) do
+  def handle_message(req = %{args: args}, state) do
+    case list(args) do
       {:ok, rules} ->
         {:reply, req.reply_to, "rule-list", rules, state}
       {:error, error} ->
@@ -40,7 +40,7 @@ defmodule Cog.Commands.Rule.List do
     end
   end
 
-  defp list(%{options: %{"command" => command}}),
+  defp list([command]),
     do: Rules.rules_for_command(command)
   defp list(_req),
     do: {:ok, Rules.all_rules}

--- a/mix.lock
+++ b/mix.lock
@@ -27,7 +27,7 @@
   "getopt": {:git, "https://github.com/jcomellas/getopt.git", "68fe326f2c7585eb32a5b136dffc75428a53fc02", [branch: "master"]},
   "goldrush": {:hex, :goldrush, "0.1.8", "2024ba375ceea47e27ea70e14d2c483b2d8610101b4e852ef7f89163cdb6e649", [:rebar3], []},
   "gproc": {:hex, :gproc, "0.5.0", "2df2d886f8f8a7b81a4b04aa17972b5965bbc5bf0100ea6d8e8ac6a0e7389afe", [:rebar], []},
-  "greenbar": {:git, "https://github.com/operable/greenbar.git", "e56d7e6004765613feddd8bb45114de35aad1cb7", []},
+  "greenbar": {:git, "https://github.com/operable/greenbar.git", "b8cc204d05387354e2ecaaecde64bed9661b3f0c", []},
   "greenbar_markdown": {:git, "https://github.com/operable/greenbar_markdown.git", "ad6d027c92ef095a0461c08847d3eb999659c3a2", []},
   "hackney": {:hex, :hackney, "1.6.1", "ddd22d42db2b50e6a155439c8811b8f6df61a4395de10509714ad2751c6da817", [:rebar3], [{:certifi, "0.4.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.0", [hex: :ssl_verify_fun, optional: false]}]},
   "html_entities": {:hex, :html_entities, "0.3.0", "2f278ffc69c3f0cbd5996628fef37cf922fa715f3e04b9f38924c8adced3f25a", [:mix], []},

--- a/priv/templates/embedded/alias-info.greenbar
+++ b/priv/templates/embedded/alias-info.greenbar
@@ -1,0 +1,5 @@
+~each var=$results~
+**Name:** ~$item.name~
+**Visibility:** ~$item.visibility~
+**Pipeline:** `~$item.pipeline~`
+~end~

--- a/priv/templates/embedded/alias-info.greenbar
+++ b/priv/templates/embedded/alias-info.greenbar
@@ -1,5 +1,4 @@
 ~each var=$results~
-**Name:** ~$item.name~
-**Visibility:** ~$item.visibility~
+**Name:** ~$item.visibility~:~$item.name~
 **Pipeline:** `~$item.pipeline~`
 ~end~

--- a/priv/templates/embedded/alias-list.greenbar
+++ b/priv/templates/embedded/alias-list.greenbar
@@ -1,18 +1,14 @@
 ~each var=$results~
 
 ~if cond=$item.visibility == "user"~
-~attachment color="blue"~
-**Name:** ~$item.name~
-**Visibility:** ~$item.visibility~
-**Pipeline:** `~$item.pipeline~`
+~attachment color="green"~
+~$item.visibility~:~$item.name~
 ~end~
 ~end~
 
 ~if cond=$item.visibility == "site"~
-~attachment color="gray"~
-**Name:** ~$item.name~
-**Visibility:** ~$item.visibility~
-**Pipeline:** `~$item.pipeline~`
+~attachment color="blue"~
+~$item.visibility~:~$item.name~
 ~end~
 ~end~
 

--- a/priv/templates/embedded/bundle-info.greenbar
+++ b/priv/templates/embedded/bundle-info.greenbar
@@ -1,10 +1,8 @@
 ~each var=$results as=bundle~
 **ID:** ~$bundle.id~
 **Name:** ~$bundle.name~
-**Versions:** ~join var=$bundle.versions with=", "~~$item.version~~end~
-~if cond=$bundle.incompatible_versions not_empty?~
-**Incompatible Versions:** ~join var=$bundle.incompatible_versions with=", "~~$item.version~~end~
-~end~
-**Version Enabled:** ~if cond=$bundle.enabled_version bound?~~$bundle.enabled_version.version~~end~~if cond=$bundle.enabled_version not_bound?~Disabled~end~
 **Relay Groups:** ~if cond=$bundle.relay_groups empty?~Unassigned~end~~join var=$bundle.relay_groups with=", "~~$item.name~~end~
+**Versions:** ~join var=$bundle.versions with=", "~~$item.version~~end~
+**Version Enabled:** ~if cond=$bundle.enabled_version bound?~~$bundle.enabled_version.version~~end~~if cond=$bundle.enabled_version not_bound?~Disabled~end~
+~if cond=$bundle.incompatible_versions not_empty?~**Incompatible Versions:** ~join var=$bundle.incompatible_versions with=", "~~$item.version~~end~~end~
 ~end~

--- a/priv/templates/embedded/bundle-list.greenbar
+++ b/priv/templates/embedded/bundle-list.greenbar
@@ -2,15 +2,13 @@
 
 ~if cond=$item.enabled_version bound?~
 ~attachment color="green"~
-**Name:** ~$item.name~
-**Version Enabled:** ~$item.enabled_version.version~
+~$item.name~ (~$item.enabled_version.version~)
 ~end~
 ~end~
 
 ~if cond=$item.enabled_version not_bound?~
 ~attachment color="red"~
-**Name:** ~$item.name~
-**Version Enabled:** Disabled
+~$item.name~ (disabled)
 ~end~
 ~end~
 

--- a/priv/templates/embedded/bundle-versions.greenbar
+++ b/priv/templates/embedded/bundle-versions.greenbar
@@ -1,15 +1,24 @@
 ~each var=$results~
-~$item.compatible~
+
 ~if cond=$item.incompatible not_bound?~
-~attachment color="gray"~
-**Version:** ~$item.version~
-**Enabled:** ~$item.enabled~
+
+~if cond=$item.enabled == true~
+~attachment color="green"~
+~$item.version~ (enabled)
 ~end~
 ~end~
-~if cond=$item.incompatible bound?~
+
+~if cond=$item.enabled == false~
 ~attachment color="red"~
-**Version:** ~$item.version~
-**Incompatible**
+~$item.version~ (disabled)
+~end~
+~end~
+
+~end~
+
+~if cond=$item.incompatible bound?~
+~attachment color="yellow"~
+~$item.version~ (incompatible)
 ~end~
 ~end~
 

--- a/priv/templates/embedded/group-info.greenbar
+++ b/priv/templates/embedded/group-info.greenbar
@@ -2,6 +2,5 @@
 **Name:** ~$group.name~
 **ID:** ~$group.id~
 **Roles:** ~if cond=$group.roles empty?~Unassigned~end~~join var=$group.roles with=", "~~$item.name~~end~
-
 **Members:** ~if cond=$group.members empty?~No members~end~~join var=$group.members with=", "~~$item.username~~end~
 ~end~

--- a/priv/templates/embedded/group-list-verbose.greenbar
+++ b/priv/templates/embedded/group-list-verbose.greenbar
@@ -3,7 +3,6 @@
 **Name:** ~$group.name~
 **ID:** ~$group.id~
 **Roles:** ~if cond=$group.roles empty?~Unassigned~end~~join var=$group.roles with=", "~~$item.name~~end~
-
 **Members:** ~if cond=$group.members empty?~No members~end~~join var=$group.members with=", "~~$item.username~~end~
 ~end~
 ~end~

--- a/priv/templates/embedded/permission-info.greenbar
+++ b/priv/templates/embedded/permission-info.greenbar
@@ -1,12 +1,4 @@
-~if cond=length($results) == 1~
-**ID**: ~$results[0].id~
-**Bundle**: ~$results[0].bundle~
-**Name**: ~$results[0].name~
-~end~
-~if cond=length($results) > 1~
-| Bundle | Name | ID |
-|--------|------|----|
-~each var=$results~
-|~$item.bundle~|~$item.name~|~$item.id~|
-~end~
+~each var=$results as=permission~
+**Name:** ~$permission.bundle~:~$permission.name~
+**ID:** ~$permission.id~
 ~end~

--- a/priv/templates/embedded/permission-list.greenbar
+++ b/priv/templates/embedded/permission-list.greenbar
@@ -1,6 +1,5 @@
 ~each var=$results~
 ~attachment color="gray"~
-**Name:** ~$item.name~
-**Bundle:** ~$item.bundle~
+~$item.bundle~:~$item.name~
 ~end~
 ~end~

--- a/priv/templates/embedded/relay-group-info.greenbar
+++ b/priv/templates/embedded/relay-group-info.greenbar
@@ -2,7 +2,6 @@
 ~attachment color="gray"~
 **Name:** ~$relay_group.name~
 **Relays:** ~if cond=$relay_group.relays empty?~No relays~end~~join var=$relay_group.relays with=", "~~$item.name~~end~
-
 **Bundles:** ~if cond=$relay_group.bundles empty?~No bundles assigned~end~~join var=$relay_group.bundles with=", "~~$item.name~~end~
 ~end~
 ~end~

--- a/priv/templates/embedded/relay-group-list-verbose.greenbar
+++ b/priv/templates/embedded/relay-group-list-verbose.greenbar
@@ -2,7 +2,6 @@
 ~attachment color="gray"~
 **Name:** ~$relay_group.name~
 **Relays:** ~if cond=$relay_group.relays empty?~No relays~end~~join var=$relay_group.relays with=", "~~$item.name~~end~
-
 **Bundles:** ~if cond=$relay_group.bundles empty?~No bundles assigned~end~~join var=$relay_group.bundles with=", "~~$item.name~~end~
 ~end~
 ~end~

--- a/priv/templates/embedded/relay-list.greenbar
+++ b/priv/templates/embedded/relay-list.greenbar
@@ -2,15 +2,13 @@
 
 ~if cond=$relay.status == "enabled"~
 ~attachment color="green"~
-**Name:** ~$relay.name~
-**Status:** ~$relay.status~
+~$relay.name~ (enabled)
 ~end~
 ~end~
 
 ~if cond=$relay.status == "disabled"~
 ~attachment color="red"~
-**Name:** ~$relay.name~
-**Status:** ~$relay.status~
+~$relay.name~ (disabled)
 ~end~
 ~end~
 

--- a/priv/templates/embedded/role-info.greenbar
+++ b/priv/templates/embedded/role-info.greenbar
@@ -1,5 +1,4 @@
 ~each var=$results as=role~
-
 **Name:** ~$role.name~
 **ID:** ~$role.id~
 **Permissions:** ~if cond=$role.permissions empty?~No permissions~end~~join var=$role.permissions with=", "~~$item.bundle~:~$item.name~~end~

--- a/priv/templates/embedded/role-list.greenbar
+++ b/priv/templates/embedded/role-list.greenbar
@@ -1,3 +1,15 @@
 ~each var=$results as=role~
-~$role.name~
+
+~if cond=$role.permissions not_empty?~
+~attachment color="blue"~
+~$role.name~ (~count var=$role.permissions~ permissions)
+~end~
+~end~
+
+~if cond=$role.permissions empty?~
+~attachment color="gray"~
+~$role.name~ (0 permissions)
+~end~
+~end~
+
 ~end~

--- a/priv/templates/embedded/rule-info.greenbar
+++ b/priv/templates/embedded/rule-info.greenbar
@@ -1,10 +1,8 @@
 ~each var=$results as=rule~
 **ID:** ~$rule.id~
-**Command:** ~$rule.command_name~
 **Rule:**
 
 ```
 ~$rule.rule~
 ```
-
 ~end~

--- a/priv/templates/embedded/rule-info.greenbar
+++ b/priv/templates/embedded/rule-info.greenbar
@@ -1,11 +1,10 @@
-~if cond=length($results) == 1~
-**ID**: ~$results[0].id~
-**Command**: ~$results[0].command_name~
-**Rule**: ~$results[0].rule~
-~end~
-~if cond=length($results) > 1~
-| Command | Rule | ID |
-|---------|------|----|
-~each var=$results~|~$item.command_name~|~$item.rule~|~$item.id~|
-~end~
+~each var=$results as=rule~
+**ID:** ~$rule.id~
+**Command:** ~$rule.command_name~
+**Rule:**
+
+```
+~$rule.rule~
+```
+
 ~end~

--- a/priv/templates/embedded/rule-list.greenbar
+++ b/priv/templates/embedded/rule-list.greenbar
@@ -1,12 +1,8 @@
 ~each var=$results as=rule~
-~attachment color="gray"~
-**Command:** ~$rule.command~
 **ID:** ~$rule.id~
 **Rule:**
 
 ```
 ~$rule.rule~
 ```
-
-~end~
 ~end~

--- a/priv/templates/embedded/trigger-create.greenbar
+++ b/priv/templates/embedded/trigger-create.greenbar
@@ -1,3 +1,3 @@
 ~each var=$results~
-Created trigger '~$item.id~'
+Created trigger '~$item.name~'
 ~end~

--- a/priv/templates/embedded/trigger-info.greenbar
+++ b/priv/templates/embedded/trigger-info.greenbar
@@ -1,16 +1,10 @@
-~if cond=length($results) == 1~
-**ID**: ~$results[0].id~
-**Name**: ~$results[0].name~
-**Description**: ~$results[0].description~
-**Enabled?**: ~$results[0].enabled~
-**Pipeline**: `~$results[0].pipeline~`
-**As User**: ~$results[0].as_user~
-**Timeout (sec)**: ~$results[0].timeout_sec~
-**Invocation URL**: ~$results[0].invocation_url~
-~end~
-~if cond=length($results) > 1~
-| ID | Name | Description | Enabled? | Pipeline | As User | Timeout | Invocation URL |
-|----|------|-------------|----------|----------|---------|---------|----------------|
-~each var=$results~|~$item.id~|~$item.name~|~if cond=$item.description bound?~~$item.description~~end~|~$item.enabled~|`~$item.pipeline~`|~if cond=$item.as_user~~$item.as_user~~end~|~$item.timeout_sec~|~$item.invocation_url~|
-~end~
+~each var=$results as=trigger~
+**Name:** ~$trigger.name~
+**ID:** ~$trigger.id~
+**Description:** ~$trigger.description~
+**Status:** ~if cond=$trigger.enabled == true~Enabled~end~~if cond=$trigger.enabled == false~Disabled~end~
+**Pipeline:** `~$trigger.pipeline~`
+**As User:** ~$trigger.as_user~
+**Timeout:** ~$trigger.timeout_sec~ second~if cond=$trigger.timeout_sec > 1~s~end~
+**Invocation URL:** ~$trigger.invocation_url~
 ~end~

--- a/priv/templates/embedded/trigger-list.greenbar
+++ b/priv/templates/embedded/trigger-list.greenbar
@@ -1,11 +1,15 @@
 ~each var=$results as=trigger~
 
-~attachment color="gray"~
-**Name:** ~$trigger.name~
-**ID:** ~$trigger.id~
-**Enabled:** ~$trigger.enabled~
-**Invocation URL:** ~$trigger.invocation_url~
-**Pipeline:** `~$trigger.pipeline~`
+~if cond=$trigger.enabled == true~
+~attachment color="green"~
+~$trigger.name~ (enabled)
+~end~
+~end~
+
+~if cond=$trigger.enabled == false~
+~attachment color="red"~
+~$trigger.name~ (disabled)
+~end~
 ~end~
 
 ~end~

--- a/priv/templates/embedded/trigger-update.greenbar
+++ b/priv/templates/embedded/trigger-update.greenbar
@@ -1,20 +1,3 @@
-~if cond=length($results) == 1~
-**Trigger Updated**
-
-**ID**: ~$results[0].id~
-**Name**: ~$results[0].name~
-**Description**: ~$results[0].description~
-**Enabled?**: ~$results[0].enabled~
-**Pipeline**: `~$results[0].pipeline~`
-**As User**: ~$results[0].as_user~
-**Timeout (sec)**: ~$results[0].timeout_sec~
-**Invocation URL**: ~$results[0].invocation_url~
-~end~
-~if cond=length($results) > 1~
-**Triggers Updated**
-
-| ID | Name | Description | Enabled? | Pipeline | As User | Timeout | Invocation URL |
-|----|------|-------------|----------|----------|---------|---------|----------------|
-~each var=$results~|~$item.id~|~$item.name~|~if cond=$item.description bound?~~$item.description~~end~|~$item.enabled~|`~$item.pipeline~`|~if cond=$item.as_user~~$item.as_user~~end~|~$item.timeout_sec~|~$item.invocation_url~|
-~end~
+~each var=$results~
+Updated trigger '~$item.name~'
 ~end~

--- a/priv/templates/embedded/user-info.greenbar
+++ b/priv/templates/embedded/user-info.greenbar
@@ -1,16 +1,8 @@
-~if cond=length($results) == 1~
-**Username**: ~$results[0].username~
-**First Name**: ~$results[0].first_name~
-**Last Name**: ~$results[0].last_name~
-**Email**: ~$results[0].email_address~
-**Groups**: ~join var=$results[0].groups as=g~~$g.name~~end~
-
-**Handles**: ~join var=$results[0].chat_handles as=h~~$h.handle~ (~$h.chat_provider.name~)~end~
-~end~
-~if cond=length($results) > 1~
-| Username | First Name | Last Name | Email | Groups | Handles |
-|----------|------------|-----------|-------|--------|---------|
-~each var=$results~
-|~$item.username~|~$item.first_name~|~$item.last_name~|~$item.email_address~|~join var=$item.groups as=g~~$g.name~~end~|~join var=$item.chat_handles as=h~~$h.handle~ (~$h.chat_provider.name~)~end~|
-~end~
+~each var=$results as=user~
+**Username**: ~$user.username~
+**First Name**: ~$user.first_name~
+**Last Name**: ~$user.last_name~
+**Email**: ~$user.email_address~
+**Groups**: ~join var=$user.groups as=g~~$g.name~~end~
+**Handles**: ~join var=$user.chat_handles as=h~~$h.handle~ (~$h.chat_provider.name~)~end~
 ~end~

--- a/priv/templates/embedded/user-list-verbose.greenbar
+++ b/priv/templates/embedded/user-list-verbose.greenbar
@@ -1,8 +1,0 @@
-~each var=$results as=user~
-~attachment color="gray"~
-**Username:** ~$user.username~
-~if cond=$user.first_name bound?~**First Name:** ~$user.first_name~~end~
-~if cond=$user.last_name bound?~**Last Name:** ~$user.last_name~~end~
-**Email:** ~$user.email_address~
-~end~
-~end~

--- a/priv/templates/embedded/user-list-verbose.greenbar
+++ b/priv/templates/embedded/user-list-verbose.greenbar
@@ -1,0 +1,8 @@
+~each var=$results as=user~
+~attachment color="gray"~
+**Username:** ~$user.username~
+~if cond=$user.first_name bound?~**First Name:** ~$user.first_name~~end~
+~if cond=$user.last_name bound?~**Last Name:** ~$user.last_name~~end~
+**Email:** ~$user.email_address~
+~end~
+~end~

--- a/priv/templates/embedded/user-list.greenbar
+++ b/priv/templates/embedded/user-list.greenbar
@@ -1,8 +1,3 @@
 ~each var=$results as=user~
-~attachment color="gray"~
-**Username:** ~$user.username~
-~if cond=$user.first_name bound?~**First Name:** ~$user.first_name~~end~
-~if cond=$user.last_name bound?~**Last Name:** ~$user.last_name~~end~
-**Email:** ~$user.email_address~
-~end~
+~$user.username~
 ~end~

--- a/test/cog/chat/hipchat/templates/embedded/alias_info_test.exs
+++ b/test/cog/chat/hipchat/templates/embedded/alias_info_test.exs
@@ -1,0 +1,15 @@
+defmodule Cog.Chat.HipChat.Templates.Embedded.AliasInfoTest do
+  use Cog.TemplateCase
+
+  test "alias-info template" do
+    data = %{"results" => [%{"visibility" => "user",
+                             "name" => "awesome_alias",
+                             "pipeline" => "echo 'awesome!'"}]}
+    expected = """
+    <strong>Name:</strong> user:awesome_alias<br/>
+    <strong>Pipeline:</strong> <code>echo 'awesome!'</code>
+    """ |> String.replace("\n", "")
+
+    assert_rendered_template(:hipchat, :embedded, "alias-info", data, expected)
+  end
+end

--- a/test/cog/chat/hipchat/templates/embedded/alias_list_test.exs
+++ b/test/cog/chat/hipchat/templates/embedded/alias_list_test.exs
@@ -12,17 +12,9 @@ defmodule Cog.Chat.HipChat.Templates.Embedded.AliasListTest do
                              "name" => "wow_neat",
                              "pipeline" => "echo 'wow, neat!'"}]}
     expected = """
-    <strong>Name:</strong> awesome_alias<br/>
-    <strong>Visibility:</strong> user<br/>
-    <strong>Pipeline:</strong> <code>echo 'awesome!'</code><br/>
-    <br/>
-    <strong>Name:</strong> another_awesome_alias<br/>
-    <strong>Visibility:</strong> user<br/>
-    <strong>Pipeline:</strong> <code>echo 'more awesome!'</code><br/>
-    <br/>
-    <strong>Name:</strong> wow_neat<br/>
-    <strong>Visibility:</strong> site<br/>
-    <strong>Pipeline:</strong> <code>echo 'wow, neat!'</code>
+    user:awesome_alias<br/>
+    user:another_awesome_alias<br/>
+    site:wow_neat
     """ |> String.replace("\n", "")
 
     assert_rendered_template(:hipchat, :embedded, "alias-list", data, expected)

--- a/test/cog/chat/hipchat/templates/embedded/bundle_info_test.exs
+++ b/test/cog/chat/hipchat/templates/embedded/bundle_info_test.exs
@@ -14,9 +14,9 @@ defmodule Cog.Chat.HipChat.Templates.Embedded.BundleInfoTest do
     expected = """
     <strong>ID:</strong> aaaa-bbbb-cccc-dddd-eeee-ffff<br/>
     <strong>Name:</strong> my_bundle<br/>
+    <strong>Relay Groups:</strong> preprod, prod<br/>
     <strong>Versions:</strong> 0.0.1, 0.0.2, 0.0.3<br/>
-    <strong>Version Enabled:</strong> 0.0.3<br/>
-    <strong>Relay Groups:</strong> preprod, prod
+    <strong>Version Enabled:</strong> 0.0.3
     """ |> String.replace("\n", "")
 
     assert_rendered_template(:hipchat, :embedded, "bundle-info", data, expected)
@@ -36,10 +36,10 @@ defmodule Cog.Chat.HipChat.Templates.Embedded.BundleInfoTest do
     expected = """
     <strong>ID:</strong> aaaa-bbbb-cccc-dddd-eeee-ffff<br/>
     <strong>Name:</strong> my_bundle<br/>
+    <strong>Relay Groups:</strong> preprod, prod<br/>
     <strong>Versions:</strong> 0.0.2, 0.0.3, 0.0.4<br/>
-    <strong>Incompatible Versions:</strong> 0.0.1<br/>
     <strong>Version Enabled:</strong> 0.0.3<br/>
-    <strong>Relay Groups:</strong> preprod, prod
+    <strong>Incompatible Versions:</strong> 0.0.1
     """ |> String.replace("\n", "")
 
     assert_rendered_template(:hipchat, :embedded, "bundle-info", data, expected)

--- a/test/cog/chat/hipchat/templates/embedded/bundle_list_test.exs
+++ b/test/cog/chat/hipchat/templates/embedded/bundle_list_test.exs
@@ -13,17 +13,10 @@ defmodule Cog.Chat.HipChat.Templates.Embedded.BundleListTest do
 
 
     expected = """
-    <strong>Name:</strong> test_bundle1<br/>
-    <strong>Version Enabled:</strong> 1.0.0<br/>
-    <br/>
-    <strong>Name:</strong> test_bundle2<br/>
-    <strong>Version Enabled:</strong> 2.0.0<br/>
-    <br/>
-    <strong>Name:</strong> test_bundle3<br/>
-    <strong>Version Enabled:</strong> 3.0.0<br/>
-    <br/>
-    <strong>Name:</strong> test_bundle4<br/>
-    <strong>Version Enabled:</strong> 4.0.0
+    test_bundle1 (1.0.0)<br/>
+    test_bundle2 (2.0.0)<br/>
+    test_bundle3 (3.0.0)<br/>
+    test_bundle4 (4.0.0)
     """ |> String.replace("\n", "")
 
     assert_rendered_template(:hipchat, :embedded, "bundle-list", data, expected)
@@ -36,11 +29,8 @@ defmodule Cog.Chat.HipChat.Templates.Embedded.BundleListTest do
 
 
     expected = """
-    <strong>Name:</strong> test_bundle1<br/>
-    <strong>Version Enabled:</strong> Disabled<br/>
-    <br/>
-    <strong>Name:</strong> test_bundle2<br/>
-    <strong>Version Enabled:</strong> 2.0.0
+    test_bundle1 (disabled)<br/>
+    test_bundle2 (2.0.0)
     """ |> String.replace("\n", "")
 
     assert_rendered_template(:hipchat, :embedded, "bundle-list", data, expected)

--- a/test/cog/chat/hipchat/templates/embedded/bundle_versions_test.exs
+++ b/test/cog/chat/hipchat/templates/embedded/bundle_versions_test.exs
@@ -15,17 +15,10 @@ defmodule Cog.Chat.HipChat.Templates.Embedded.BundleVersionsTest do
                              "version" => "0.0.7",
                              "enabled" => false}]}
     expected = """
-    <strong>Version:</strong> 1.0.0<br/>
-    <strong>Enabled:</strong> true<br/>
-    <br/>
-    <strong>Version:</strong> 0.0.9<br/>
-    <strong>Enabled:</strong> false<br/>
-    <br/>
-    <strong>Version:</strong> 0.0.8<br/>
-    <strong>Enabled:</strong> false<br/>
-    <br/>
-    <strong>Version:</strong> 0.0.7<br/>
-    <strong>Enabled:</strong> false
+    1.0.0 (enabled)<br/>
+    0.0.9 (disabled)<br/>
+    0.0.8 (disabled)<br/>
+    0.0.7 (disabled)
     """ |> String.replace("\n", "")
 
     assert_rendered_template(:hipchat, :embedded, "bundle-versions", data, expected)

--- a/test/cog/chat/hipchat/templates/embedded/permission_info_test.exs
+++ b/test/cog/chat/hipchat/templates/embedded/permission_info_test.exs
@@ -4,31 +4,11 @@ defmodule Cog.Chat.HipChat.Templates.Embedded.PermissionInfoTest do
   test "permission-info template" do
     data = %{"results" => [%{"id" => "123", "bundle" => "site", "name" => "foo"}]}
 
-    expected = "<strong>ID</strong>: 123<br/>" <>
-      "<strong>Bundle</strong>: site<br/>" <>
-      "<strong>Name</strong>: foo"
-
-    assert_rendered_template(:hipchat, :embedded, "permission-info", data, expected)
-  end
-
-  test "permission-info template with multiple inputs" do
-    data = %{"results" => [%{"id" => "123", "bundle" => "foo_bundle", "name" => "foo"},
-                           %{"id" => "456", "bundle" => "bar_bundle", "name" => "bar"},
-                           %{"id" => "789", "bundle" => "baz_bundle", "name" => "baz"}]}
-
     expected = """
-    <pre>+------------+------+-----+
-    | Bundle     | Name | ID  |
-    +------------+------+-----+
-    | foo_bundle | foo  | 123 |
-    | bar_bundle | bar  | 456 |
-    | baz_bundle | baz  | 789 |
-    +------------+------+-----+
-    </pre>\
-    """
+    <strong>Name:</strong> site:foo<br/>
+    <strong>ID:</strong> 123
+    """ |> String.replace("\n", "")
 
     assert_rendered_template(:hipchat, :embedded, "permission-info", data, expected)
   end
-
-
 end

--- a/test/cog/chat/hipchat/templates/embedded/permission_list_test.exs
+++ b/test/cog/chat/hipchat/templates/embedded/permission_list_test.exs
@@ -7,14 +7,9 @@ defmodule Cog.Chat.HipChat.Templates.Embedded.PermissionListTest do
                            %{"bundle" => "site", "name" => "baz"}]}
 
     expected = """
-    <strong>Name:</strong> foo<br/>
-    <strong>Bundle:</strong> site<br/>
-    <br/>
-    <strong>Name:</strong> bar<br/>
-    <strong>Bundle:</strong> site<br/>
-    <br/>
-    <strong>Name:</strong> baz<br/>
-    <strong>Bundle:</strong> site
+    site:foo<br/>
+    site:bar<br/>
+    site:baz
     """ |> String.replace("\n", "")
 
     assert_rendered_template(:hipchat, :embedded, "permission-list", data, expected)

--- a/test/cog/chat/hipchat/templates/embedded/relay_list_test.exs
+++ b/test/cog/chat/hipchat/templates/embedded/relay_list_test.exs
@@ -10,14 +10,9 @@ defmodule Cog.Chat.HipChat.Templates.Embedded.RelayListTest do
                              "status" => "enabled"}]}
 
     expected = """
-    <strong>Name:</strong> relay_one<br/>
-    <strong>Status:</strong> enabled<br/>
-    <br/>
-    <strong>Name:</strong> relay_two<br/>
-    <strong>Status:</strong> disabled<br/>
-    <br/>
-    <strong>Name:</strong> relay_three<br/>
-    <strong>Status:</strong> enabled
+    relay_one (enabled)<br/>
+    relay_two (disabled)<br/>
+    relay_three (enabled)
     """ |> String.replace("\n", "")
 
     assert_rendered_template(:hipchat, :embedded, "relay-list", data, expected)

--- a/test/cog/chat/hipchat/templates/embedded/role_list_test.exs
+++ b/test/cog/chat/hipchat/templates/embedded/role_list_test.exs
@@ -4,12 +4,15 @@ defmodule Cog.Chat.HipChat.Templates.Embedded.RoleListTest do
   test "role-list template" do
     data = %{"results" => [%{"name" => "foo"},
                            %{"name" => "bar"},
-                           %{"name" => "baz"}]}
+                           %{"name" => "baz",
+                             "permissions" => [%{"name": "manage_users",
+                                                 "id": "a598628c-c2d8-4ace-9abc-29467e35f5e0",
+                                                 "bundle": "operable"}]}]}
 
     expected = """
-    foo<br/>
-    bar<br/>
-    baz
+    foo (0 permissions)<br/>
+    bar (0 permissions)<br/>
+    baz (1 permissions)
     """ |> String.replace("\n", "")
 
     assert_rendered_template(:hipchat, :embedded, "role-list", data, expected)

--- a/test/cog/chat/hipchat/templates/embedded/rule_info_test.exs
+++ b/test/cog/chat/hipchat/templates/embedded/rule_info_test.exs
@@ -5,36 +5,14 @@ defmodule Cog.Chat.HipChat.Templates.Embedded.RuleInfoTest do
     data = %{"results" => [%{"command_name" => "foo:foo",
                              "rule" => "when command is foo:foo allow",
                              "id" => "123"}]}
-    expected = "<strong>ID</strong>: 123<br/>" <>
-      "<strong>Command</strong>: foo:foo<br/>" <>
-      "<strong>Rule</strong>: when command is foo:foo allow"
 
-    assert_rendered_template(:hipchat, :embedded, "rule-info", data, expected)
-  end
-
-  test "rule-info template with multiple rules" do
-    data = %{"results" => [%{"command_name" => "foo:foo",
-                             "rule" => "when command is foo:foo allow",
-                             "id" => "123"},
-                           %{"command_name" => "foo:bar",
-                             "rule" => "when command is foo:bar allow",
-                             "id" => "456"},
-                           %{"command_name" => "foo:baz",
-                             "rule" => "when command is foo:baz allow",
-                             "id" => "789"}]}
     expected = """
-    <pre>+---------+-------------------------------+-----+
-    | Command | Rule                          | ID  |
-    +---------+-------------------------------+-----+
-    | foo:foo | when command is foo:foo allow | 123 |
-    | foo:bar | when command is foo:bar allow | 456 |
-    | foo:baz | when command is foo:baz allow | 789 |
-    +---------+-------------------------------+-----+
-    </pre>\
-    """
+    <strong>ID:</strong> 123<br/>
+    <strong>Command:</strong> foo:foo<br/>
+    <strong>Rule:</strong><br/>
+    <pre>when command is foo:foo allow</pre>
+    """ |> String.replace("\n", "")
 
     assert_rendered_template(:hipchat, :embedded, "rule-info", data, expected)
   end
-
-
 end

--- a/test/cog/chat/hipchat/templates/embedded/rule_info_test.exs
+++ b/test/cog/chat/hipchat/templates/embedded/rule_info_test.exs
@@ -8,7 +8,6 @@ defmodule Cog.Chat.HipChat.Templates.Embedded.RuleInfoTest do
 
     expected = """
     <strong>ID:</strong> 123<br/>
-    <strong>Command:</strong> foo:foo<br/>
     <strong>Rule:</strong><br/>
     <pre>when command is foo:foo allow</pre>
     """ |> String.replace("\n", "")

--- a/test/cog/chat/hipchat/templates/embedded/rule_list_test.exs
+++ b/test/cog/chat/hipchat/templates/embedded/rule_list_test.exs
@@ -12,17 +12,15 @@ defmodule Cog.Chat.HipChat.Templates.Embedded.RuleListTest do
                              "rule" => "when command is foo:baz allow",
                              "id" => "789"}]}
     expected = """
-    <strong>Command:</strong> foo:foo<br/>
     <strong>ID:</strong> 123<br/>
-    <strong>Rule:</strong><pre>when command is foo:foo allow</pre><br/>
-    <br/>
-    <strong>Command:</strong> foo:bar<br/>
+    <strong>Rule:</strong><br/>
+    <pre>when command is foo:foo allow</pre><br/>
     <strong>ID:</strong> 456<br/>
-    <strong>Rule:</strong><pre>when command is foo:bar allow</pre><br/>
-    <br/>
-    <strong>Command:</strong> foo:baz<br/>
+    <strong>Rule:</strong><br/>
+    <pre>when command is foo:bar allow</pre><br/>
     <strong>ID:</strong> 789<br/>
-    <strong>Rule:</strong><pre>when command is foo:baz allow</pre>
+    <strong>Rule:</strong><br/>
+    <pre>when command is foo:baz allow</pre>
     """ |> String.replace("\n", "")
 
     assert_rendered_template(:hipchat, :embedded, "rule-list", data, expected)

--- a/test/cog/chat/hipchat/templates/embedded/trigger_create_test.exs
+++ b/test/cog/chat/hipchat/templates/embedded/trigger_create_test.exs
@@ -2,18 +2,18 @@ defmodule Cog.Chat.HipChat.Templates.Embedded.TriggerCreateTest do
   use Cog.TemplateCase
 
   test "trigger-create template" do
-    data = %{"results" => [%{"id" => "12345"}]}
-    expected = "Created trigger '12345'"
+    data = %{"results" => [%{"name" => "echo-test"}]}
+    expected = "Created trigger 'echo-test'"
     assert_rendered_template(:hipchat, :embedded, "trigger-create", data, expected)
   end
 
   test "trigger-create template with multiple inputs" do
-    data = %{"results" => [%{"id" => "12345"},
-                           %{"id" => "67890"},
-                           %{"id" => "11111"}]}
-    expected = "Created trigger '12345'<br/>" <>
-      "Created trigger '67890'<br/>" <>
-      "Created trigger '11111'"
+    data = %{"results" => [%{"name" => "echo-1"},
+                           %{"name" => "echo-2"},
+                           %{"name" => "echo-3"}]}
+    expected = "Created trigger 'echo-1'<br/>" <>
+      "Created trigger 'echo-2'<br/>" <>
+      "Created trigger 'echo-3'"
 
     assert_rendered_template(:hipchat, :embedded, "trigger-create", data, expected)
   end

--- a/test/cog/chat/hipchat/templates/embedded/trigger_info_test.exs
+++ b/test/cog/chat/hipchat/templates/embedded/trigger_info_test.exs
@@ -10,14 +10,14 @@ defmodule Cog.Chat.HipChat.Templates.Embedded.TriggerInfoTest do
                              "as_user" => "bobby_tables",
                              "timeout_sec" => 30,
                              "invocation_url" => "https://cog.mycompany.com/invoke_stuff"}]}
-    expected = "<strong>ID</strong>: abc123<br/>" <>
-      "<strong>Name</strong>: test_trigger<br/>" <>
-      "<strong>Description</strong>: Tests things!<br/>" <>
-      "<strong>Enabled?</strong>: true<br/>" <>
-      "<strong>Pipeline</strong>: <code>echo 'Something just happened'</code><br/>" <>
-      "<strong>As User</strong>: bobby_tables<br/>" <>
-      "<strong>Timeout (sec)</strong>: 30<br/>" <>
-      "<strong>Invocation URL</strong>: https://cog.mycompany.com/invoke_stuff"
+    expected = "<strong>Name:</strong> test_trigger<br/>" <>
+      "<strong>ID:</strong> abc123<br/>" <>
+      "<strong>Description:</strong> Tests things!<br/>" <>
+      "<strong>Status:</strong> Enabled<br/>" <>
+      "<strong>Pipeline:</strong> <code>echo 'Something just happened'</code><br/>" <>
+      "<strong>As User:</strong> bobby_tables<br/>" <>
+      "<strong>Timeout:</strong> 30 seconds<br/>" <>
+      "<strong>Invocation URL:</strong> https://cog.mycompany.com/invoke_stuff"
 
 
     assert_rendered_template(:hipchat, :embedded, "trigger-info", data, expected)
@@ -30,42 +30,14 @@ defmodule Cog.Chat.HipChat.Templates.Embedded.TriggerInfoTest do
                              "pipeline" => "echo 'Something just happened'",
                              "timeout_sec" => 30,
                              "invocation_url" => "https://cog.mycompany.com/invoke_stuff"}]}
-    expected = "<strong>ID</strong>: abc123<br/>" <>
-      "<strong>Name</strong>: test_trigger<br/>" <>
-      "<strong>Description</strong>: <br/>" <>
-      "<strong>Enabled?</strong>: true<br/>" <>
-      "<strong>Pipeline</strong>: <code>echo 'Something just happened'</code><br/>" <>
-      "<strong>As User</strong>: <br/>" <>
-      "<strong>Timeout (sec)</strong>: 30<br/>" <>
-      "<strong>Invocation URL</strong>: https://cog.mycompany.com/invoke_stuff"
-
-    assert_rendered_template(:hipchat, :embedded, "trigger-info", data, expected)
-  end
-
-  test "multiple inputs" do
-    data = %{"results" => [%{"id" => "abc123",
-                             "name" => "test_trigger",
-                             "description" => "Tests things!",
-                             "enabled" => true,
-                             "pipeline" => "echo 'Something just happened'",
-                             "timeout_sec" => 30,
-                             "invocation_url" => "https://cog.mycompany.com/invoke_stuff"},
-                          %{"id" => "abc456",
-                            "name" => "test_trigger_2",
-                            "enabled" => false,
-                            "pipeline" => "echo 'Something else just happened'",
-                            "as_user" => "bobby_tables",
-                            "timeout_sec" => 30,
-                            "invocation_url" => "https://cog.mycompany.com/invoke_other_stuff"}]}
-    expected = """
-    <pre>+--------+----------------+---------------+----------+-------------------------------------+--------------+---------+----------------------------------------------+
-    | ID     | Name           | Description   | Enabled? | Pipeline                            | As User      | Timeout | Invocation URL                               |
-    +--------+----------------+---------------+----------+-------------------------------------+--------------+---------+----------------------------------------------+
-    | abc123 | test_trigger   | Tests things! | true     | echo 'Something just happened'      |              | 30      | https://cog.mycompany.com/invoke_stuff       |
-    | abc456 | test_trigger_2 |               | false    | echo 'Something else just happened' | bobby_tables | 30      | https://cog.mycompany.com/invoke_other_stuff |
-    +--------+----------------+---------------+----------+-------------------------------------+--------------+---------+----------------------------------------------+
-    </pre>\
-    """
+    expected = "<strong>Name:</strong> test_trigger<br/>" <>
+      "<strong>ID:</strong> abc123<br/>" <>
+      "<strong>Description:</strong> <br/>" <>
+      "<strong>Status:</strong> Enabled<br/>" <>
+      "<strong>Pipeline:</strong> <code>echo 'Something just happened'</code><br/>" <>
+      "<strong>As User:</strong> <br/>" <>
+      "<strong>Timeout:</strong> 30 seconds<br/>" <>
+      "<strong>Invocation URL:</strong> https://cog.mycompany.com/invoke_stuff"
 
     assert_rendered_template(:hipchat, :embedded, "trigger-info", data, expected)
   end

--- a/test/cog/chat/hipchat/templates/embedded/trigger_list_test.exs
+++ b/test/cog/chat/hipchat/templates/embedded/trigger_list_test.exs
@@ -17,17 +17,8 @@ defmodule Cog.Chat.HipChat.Templates.Embedded.TriggerListTest do
                             "timeout_sec" => 30,
                             "invocation_url" => "https://cog.mycompany.com/invoke_other_stuff"}]}
     expected = """
-    <strong>Name:</strong> test_trigger<br/>
-    <strong>ID:</strong> abc123<br/>
-    <strong>Enabled:</strong> true<br/>
-    <strong>Invocation URL:</strong> https://cog.mycompany.com/invoke_stuff<br/>
-    <strong>Pipeline:</strong> <code>echo 'Something just happened'</code><br/>
-    <br/>
-    <strong>Name:</strong> test_trigger_2<br/>
-    <strong>ID:</strong> abc456<br/>
-    <strong>Enabled:</strong> false<br/>
-    <strong>Invocation URL:</strong> https://cog.mycompany.com/invoke_other_stuff<br/>
-    <strong>Pipeline:</strong> <code>echo 'Something else just happened'</code>
+    test_trigger (enabled)<br/>
+    test_trigger_2 (disabled)
     """ |> String.replace("\n", "")
 
     assert_rendered_template(:hipchat, :embedded, "trigger-list", data, expected)

--- a/test/cog/chat/hipchat/templates/embedded/trigger_update_test.exs
+++ b/test/cog/chat/hipchat/templates/embedded/trigger_update_test.exs
@@ -10,16 +10,8 @@ defmodule Cog.Chat.HipChat.Templates.Embedded.TriggerUpdateTest do
                              "as_user" => "bobby_tables",
                              "timeout_sec" => 30,
                              "invocation_url" => "https://cog.mycompany.com/invoke_stuff"}]}
-    expected = "<strong>Trigger Updated</strong><br/><br/>" <>
-      "<strong>ID</strong>: abc123<br/>" <>
-      "<strong>Name</strong>: test_trigger<br/>" <>
-      "<strong>Description</strong>: Tests things!<br/>" <>
-      "<strong>Enabled?</strong>: true<br/>" <>
-      "<strong>Pipeline</strong>: <code>echo 'Something just happened'</code><br/>" <>
-      "<strong>As User</strong>: bobby_tables<br/>" <>
-      "<strong>Timeout (sec)</strong>: 30<br/>" <>
-      "<strong>Invocation URL</strong>: https://cog.mycompany.com/invoke_stuff"
 
+    expected = "Updated trigger 'test_trigger'"
 
     assert_rendered_template(:hipchat, :embedded, "trigger-update", data, expected)
   end
@@ -31,15 +23,8 @@ defmodule Cog.Chat.HipChat.Templates.Embedded.TriggerUpdateTest do
                              "pipeline" => "echo 'Something just happened'",
                              "timeout_sec" => 30,
                              "invocation_url" => "https://cog.mycompany.com/invoke_stuff"}]}
-    expected = "<strong>Trigger Updated</strong><br/><br/>" <>
-      "<strong>ID</strong>: abc123<br/>" <>
-      "<strong>Name</strong>: test_trigger<br/>" <>
-      "<strong>Description</strong>: <br/>" <>
-      "<strong>Enabled?</strong>: true<br/>" <>
-      "<strong>Pipeline</strong>: <code>echo 'Something just happened'</code><br/>" <>
-      "<strong>As User</strong>: <br/>" <>
-      "<strong>Timeout (sec)</strong>: 30<br/>" <>
-      "<strong>Invocation URL</strong>: https://cog.mycompany.com/invoke_stuff"
+
+    expected = "Updated trigger 'test_trigger'"
 
     assert_rendered_template(:hipchat, :embedded, "trigger-update", data, expected)
   end
@@ -59,16 +44,11 @@ defmodule Cog.Chat.HipChat.Templates.Embedded.TriggerUpdateTest do
                             "as_user" => "bobby_tables",
                             "timeout_sec" => 30,
                             "invocation_url" => "https://cog.mycompany.com/invoke_other_stuff"}]}
+
     expected = """
-    <strong>Triggers Updated</strong><br/>\
-    <pre>+--------+----------------+---------------+----------+-------------------------------------+--------------+---------+----------------------------------------------+
-    | ID     | Name           | Description   | Enabled? | Pipeline                            | As User      | Timeout | Invocation URL                               |
-    +--------+----------------+---------------+----------+-------------------------------------+--------------+---------+----------------------------------------------+
-    | abc123 | test_trigger   | Tests things! | true     | echo 'Something just happened'      |              | 30      | https://cog.mycompany.com/invoke_stuff       |
-    | abc456 | test_trigger_2 |               | false    | echo 'Something else just happened' | bobby_tables | 30      | https://cog.mycompany.com/invoke_other_stuff |
-    +--------+----------------+---------------+----------+-------------------------------------+--------------+---------+----------------------------------------------+
-    </pre>\
-    """
+    Updated trigger 'test_trigger'<br/>
+    Updated trigger 'test_trigger_2'
+    """ |> String.replace("\n", "")
 
     assert_rendered_template(:hipchat, :embedded, "trigger-update", data, expected)
   end

--- a/test/cog/chat/hipchat/templates/embedded/user_info_test.exs
+++ b/test/cog/chat/hipchat/templates/embedded/user_info_test.exs
@@ -20,39 +20,4 @@ defmodule Cog.Chat.HipChat.Templates.Embedded.UserInfoTest do
 
     assert_rendered_template(:hipchat, :embedded, "user-info", data, expected)
   end
-
-  @tag :wip
-  test "user-info template with multiple inputs" do
-    data = %{"results" => [%{"username" => "cog",
-                             "first_name" => "Cog",
-                             "last_name" => "McCog",
-                             "email_address" => "cog@example.com",
-                             "groups" => [%{"name" => "dev"},
-                                          %{"name" => "ops"}],
-                             "chat_handles" => [%{"chat_provider" => %{"name" => "HipChat"},
-                                                  "handle" => "the_cog"}]},
-
-                           %{"username" => "sprocket",
-                             "first_name" => "Sprocket",
-                             "last_name" => "McSprocket",
-                             "email_address" => "sprocket@example.com",
-                             "groups" => [%{"name" => "sec"},
-                                          %{"name" => "test"}],
-                             "chat_handles" => [%{"chat_provider" => %{"name" => "HipChat"},
-                                                  "handle" => "sprocket"},
-                                                %{"chat_provider" => %{"name" => "HipChat"},
-                                                  "handle" => "SprocketMcSprocket"}]}
-                          ]}
-    expected = """
-    <pre>+----------+------------+------------+----------------------+-----------+--------------------------------------------------+
-    | Username | First Name | Last Name  | Email                | Groups    | Handles                                          |
-    +----------+------------+------------+----------------------+-----------+--------------------------------------------------+
-    | cog      | Cog        | McCog      | cog@example.com      | dev, ops  | the_cog (HipChat)                                |
-    | sprocket | Sprocket   | McSprocket | sprocket@example.com | sec, test | sprocket (HipChat), SprocketMcSprocket (HipChat) |
-    +----------+------------+------------+----------------------+-----------+--------------------------------------------------+
-    </pre>\
-    """
-
-    assert_rendered_template(:hipchat, :embedded, "user-info", data, expected)
-  end
 end

--- a/test/cog/chat/hipchat/templates/embedded/user_list_test.exs
+++ b/test/cog/chat/hipchat/templates/embedded/user_list_test.exs
@@ -15,48 +15,9 @@ defmodule Cog.Chat.HipChat.Templates.Embedded.UserListTest do
                              "last_name" => "Ops",
                              "email_address" => "chetops@example.com"}]}
     expected = """
-    <strong>Username:</strong> cog<br/>
-    <strong>First Name:</strong> Cog<br/>
-    <strong>Last Name:</strong> McCog<br/>
-    <strong>Email:</strong> cog@example.com<br/>
-    <br/>
-    <strong>Username:</strong> sprocket<br/>
-    <strong>First Name:</strong> Sprocket<br/>
-    <strong>Last Name:</strong> McCog<br/>
-    <strong>Email:</strong> sprocket@example.com<br/>
-    <br/>
-    <strong>Username:</strong> chetops<br/>
-    <strong>First Name:</strong> Chet<br/>
-    <strong>Last Name:</strong> Ops<br/>
-    <strong>Email:</strong> chetops@example.com
-    """ |> String.replace("\n", "")
-
-    assert_rendered_template(:hipchat, :embedded, "user-list", data, expected)
-  end
-
-  test "handle when names aren't specified" do
-    data = %{"results" => [%{"username" => "cog",
-                             "first_name" => "Cog",
-                             "email_address" => "cog@example.com"},
-                           %{"username" => "sprocket",
-                             "last_name" => "McCog",
-                             "email_address" => "sprocket@example.com"},
-                           %{"username" => "chetops",
-                             "email_address" => "chetops@example.com"}]}
-    expected = """
-    <strong>Username:</strong> cog<br/>
-    <strong>First Name:</strong> Cog<br/>
-    <br/>
-    <strong>Email:</strong> cog@example.com<br/>
-    <br/>
-    <strong>Username:</strong> sprocket<br/>
-    <br/>
-    <strong>Last Name:</strong> McCog<br/>
-    <strong>Email:</strong> sprocket@example.com<br/>
-    <br/>
-    <strong>Username:</strong> chetops<br/>
-    <br/>
-    <strong>Email:</strong> chetops@example.com
+    cog<br/>
+    sprocket<br/>
+    chetops
     """ |> String.replace("\n", "")
 
     assert_rendered_template(:hipchat, :embedded, "user-list", data, expected)

--- a/test/cog/chat/slack/templates/embedded/alias_info_test.exs
+++ b/test/cog/chat/slack/templates/embedded/alias_info_test.exs
@@ -1,0 +1,15 @@
+defmodule Cog.Chat.Slack.Templates.Embedded.AliasInfoTest do
+  use Cog.TemplateCase
+
+  test "alias-info template" do
+    data = %{"results" => [%{"visibility" => "user",
+                             "name" => "awesome_alias",
+                             "pipeline" => "echo 'awesome!'"}]}
+    expected = """
+    *Name:* user:awesome_alias
+    *Pipeline:* `echo 'awesome!'`
+    """ |> String.strip
+
+    assert_rendered_template(:slack, :embedded, "alias-info", data, expected)
+  end
+end

--- a/test/cog/chat/slack/templates/embedded/alias_list_test.exs
+++ b/test/cog/chat/slack/templates/embedded/alias_list_test.exs
@@ -11,23 +11,8 @@ defmodule Cog.Chat.Slack.Templates.Embedded.AliasListTest do
                            %{"visibility" => "site",
                              "name" => "wow_neat",
                              "pipeline" => "echo 'wow, neat!'"}]}
-    attachments = [
-      """
-      *Name:* awesome_alias
-      *Visibility:* user
-      *Pipeline:* `echo 'awesome!'`
-      """,
-      """
-      *Name:* another_awesome_alias
-      *Visibility:* user
-      *Pipeline:* `echo 'more awesome!'`
-      """,
-      """
-      *Name:* wow_neat
-      *Visibility:* site
-      *Pipeline:* `echo 'wow, neat!'`
-      """
-    ] |> Enum.map(&String.strip/1)
+
+    attachments = ["user:awesome_alias", "user:another_awesome_alias", "site:wow_neat"]
 
     assert_rendered_template(:slack, :embedded, "alias-list", data, {"", attachments})
   end

--- a/test/cog/chat/slack/templates/embedded/bundle_info_test.exs
+++ b/test/cog/chat/slack/templates/embedded/bundle_info_test.exs
@@ -13,9 +13,9 @@ defmodule Cog.Chat.Slack.Templates.Embedded.BundleInfoTest do
     expected = """
     *ID:* aaaa-bbbb-cccc-dddd-eeee-ffff
     *Name:* my_bundle
+    *Relay Groups:* preprod, prod
     *Versions:* 0.0.1, 0.0.2, 0.0.3
     *Version Enabled:* 0.0.3
-    *Relay Groups:* preprod, prod
     """ |> String.strip
 
     assert_rendered_template(:slack, :embedded, "bundle-info", data, expected)
@@ -34,10 +34,10 @@ defmodule Cog.Chat.Slack.Templates.Embedded.BundleInfoTest do
     expected = """
     *ID:* aaaa-bbbb-cccc-dddd-eeee-ffff
     *Name:* my_bundle
-    *Versions:* 0.0.2, 0.0.3, 0.0.4
-    *Incompatible Versions:* 0.0.1
-    *Version Enabled:* 0.0.3
     *Relay Groups:* preprod, prod
+    *Versions:* 0.0.2, 0.0.3, 0.0.4
+    *Version Enabled:* 0.0.3
+    *Incompatible Versions:* 0.0.1
     """ |> String.strip
 
     assert_rendered_template(:slack, :embedded, "bundle-info", data, expected)

--- a/test/cog/chat/slack/templates/embedded/bundle_list_test.exs
+++ b/test/cog/chat/slack/templates/embedded/bundle_list_test.exs
@@ -11,24 +11,10 @@ defmodule Cog.Chat.Slack.Templates.Embedded.BundleListTest do
                            %{"name" => "test_bundle4",
                              "enabled_version" => %{"version" => "4.0.0"}}]}
 
-    attachments = [
-      """
-      *Name:* test_bundle1
-      *Version Enabled:* 1.0.0
-      """,
-      """
-      *Name:* test_bundle2
-      *Version Enabled:* 2.0.0
-      """,
-      """
-      *Name:* test_bundle3
-      *Version Enabled:* 3.0.0
-      """,
-      """
-      *Name:* test_bundle4
-      *Version Enabled:* 4.0.0
-      """
-    ] |> Enum.map(&String.strip/1)
+    attachments = ["test_bundle1 (1.0.0)",
+                   "test_bundle2 (2.0.0)",
+                   "test_bundle3 (3.0.0)",
+                   "test_bundle4 (4.0.0)"]
 
     assert_rendered_template(:slack, :embedded, "bundle-list", data, {"", attachments})
   end
@@ -39,16 +25,9 @@ defmodule Cog.Chat.Slack.Templates.Embedded.BundleListTest do
                              "enabled_version" => %{"version" => "2.0.0"}}]}
 
 
-    attachments = [
-      """
-      *Name:* test_bundle1
-      *Version Enabled:* Disabled
-      """,
-      """
-      *Name:* test_bundle2
-      *Version Enabled:* 2.0.0
-      """,
-    ] |> Enum.map(&String.strip/1)
+
+    attachments = ["test_bundle1 (disabled)",
+                   "test_bundle2 (2.0.0)"]
 
     assert_rendered_template(:slack, :embedded, "bundle-list", data, {"", attachments})
   end

--- a/test/cog/chat/slack/templates/embedded/bundle_versions_test.exs
+++ b/test/cog/chat/slack/templates/embedded/bundle_versions_test.exs
@@ -15,24 +15,10 @@ defmodule Cog.Chat.Slack.Templates.Embedded.BundleVersionsTest do
                              "version" => "0.0.7",
                              "enabled" => false}]}
 
-    attachments = [
-      """
-      *Version:* 1.0.0
-      *Enabled:* true
-      """,
-      """
-      *Version:* 0.0.9
-      *Enabled:* false
-      """,
-      """
-      *Version:* 0.0.8
-      *Enabled:* false
-      """,
-      """
-      *Version:* 0.0.7
-      *Enabled:* false
-      """
-    ] |> Enum.map(&String.strip/1)
+    attachments = ["1.0.0 (enabled)",
+                   "0.0.9 (disabled)",
+                   "0.0.8 (disabled)",
+                   "0.0.7 (disabled)"]
 
     assert_rendered_template(:slack, :embedded, "bundle-versions", data, {"", attachments})
   end

--- a/test/cog/chat/slack/templates/embedded/permission_info_test.exs
+++ b/test/cog/chat/slack/templates/embedded/permission_info_test.exs
@@ -5,32 +5,10 @@ defmodule Cog.Chat.Slack.Templates.Embedded.PermissionInfoTest do
     data = %{"results" => [%{"id" => "123", "bundle" => "site", "name" => "foo"}]}
 
     expected = """
-    *ID*: 123
-    *Bundle*: site
-    *Name*: foo
+    *Name:* site:foo
+    *ID:* 123
     """ |> String.strip
 
     assert_rendered_template(:slack, :embedded, "permission-info", data, expected)
   end
-
-  test "permission-info template with multiple inputs" do
-    data = %{"results" => [%{"id" => "123", "bundle" => "foo_bundle", "name" => "foo"},
-                           %{"id" => "456", "bundle" => "bar_bundle", "name" => "bar"},
-                           %{"id" => "789", "bundle" => "baz_bundle", "name" => "baz"}]}
-
-    expected = """
-    ```+------------+------+-----+
-    | Bundle     | Name | ID  |
-    +------------+------+-----+
-    | foo_bundle | foo  | 123 |
-    | bar_bundle | bar  | 456 |
-    | baz_bundle | baz  | 789 |
-    +------------+------+-----+
-    ```
-    """ |> String.strip
-
-    assert_rendered_template(:slack, :embedded, "permission-info", data, expected)
-  end
-
-
 end

--- a/test/cog/chat/slack/templates/embedded/permission_list_test.exs
+++ b/test/cog/chat/slack/templates/embedded/permission_list_test.exs
@@ -7,19 +7,10 @@ defmodule Cog.Chat.Slack.Templates.Embedded.PermissionListTest do
                            %{"bundle" => "site", "name" => "baz"}]}
 
     attachments = [
-      """
-      *Name:* foo
-      *Bundle:* site
-      """,
-      """
-      *Name:* bar
-      *Bundle:* site
-      """,
-      """
-      *Name:* baz
-      *Bundle:* site
-      """
-    ] |> Enum.map(&String.strip/1)
+      "site:foo",
+      "site:bar",
+      "site:baz"
+    ]
 
     assert_rendered_template(:slack, :embedded, "permission-list", data, {"", attachments})
   end

--- a/test/cog/chat/slack/templates/embedded/relay_list_test.exs
+++ b/test/cog/chat/slack/templates/embedded/relay_list_test.exs
@@ -10,19 +10,10 @@ defmodule Cog.Chat.Slack.Templates.Embedded.RelayListTest do
                              "status" => "enabled"}]}
 
     attachments = [
-      """
-      *Name:* relay_one
-      *Status:* enabled
-      """,
-      """
-      *Name:* relay_two
-      *Status:* disabled
-      """,
-      """
-      *Name:* relay_three
-      *Status:* enabled
-      """,
-    ] |> Enum.map(&String.strip/1)
+      "relay_one (enabled)",
+      "relay_two (disabled)",
+      "relay_three (enabled)"
+    ]
 
     assert_rendered_template(:slack, :embedded, "relay-list", data, {"", attachments})
   end

--- a/test/cog/chat/slack/templates/embedded/role_list_test.exs
+++ b/test/cog/chat/slack/templates/embedded/role_list_test.exs
@@ -4,15 +4,18 @@ defmodule Cog.Chat.Slack.Templates.Embedded.RoleListTest do
   test "role-list template" do
     data = %{"results" => [%{"name" => "foo"},
                            %{"name" => "bar"},
-                           %{"name" => "baz"}]}
+                           %{"name" => "baz",
+                             "permissions" => [%{"name": "manage_users",
+                                                 "id": "a598628c-c2d8-4ace-9abc-29467e35f5e0",
+                                                 "bundle": "operable"}]}]}
 
-    expected = """
-    foo
-    bar
-    baz
-    """ |> String.strip
+    attachments = [
+      "foo (0 permissions)",
+      "bar (0 permissions)",
+      "baz (1 permissions)"
+    ]
 
-    assert_rendered_template(:slack, :embedded, "role-list", data, expected)
+    assert_rendered_template(:slack, :embedded, "role-list", data, {"", attachments})
   end
 
 end

--- a/test/cog/chat/slack/templates/embedded/rule_info_test.exs
+++ b/test/cog/chat/slack/templates/embedded/rule_info_test.exs
@@ -2,12 +2,11 @@ defmodule Cog.Chat.Slack.Templates.Embedded.RuleInfoTest do
   use Cog.TemplateCase
 
   test "rule-info template" do
-    data = %{"results" => [%{"command_name" => "foo:foo",
+    data = %{"results" => [%{"command" => "foo:foo",
                              "rule" => "when command is foo:foo allow",
                              "id" => "123"}]}
     expected = """
     *ID:* 123
-    *Command:* foo:foo
     *Rule:*
 
     ```when command is foo:foo allow```

--- a/test/cog/chat/slack/templates/embedded/rule_info_test.exs
+++ b/test/cog/chat/slack/templates/embedded/rule_info_test.exs
@@ -6,37 +6,13 @@ defmodule Cog.Chat.Slack.Templates.Embedded.RuleInfoTest do
                              "rule" => "when command is foo:foo allow",
                              "id" => "123"}]}
     expected = """
-    *ID*: 123
-    *Command*: foo:foo
-    *Rule*: when command is foo:foo allow
+    *ID:* 123
+    *Command:* foo:foo
+    *Rule:*
+
+    ```when command is foo:foo allow```
     """ |> String.strip
 
     assert_rendered_template(:slack, :embedded, "rule-info", data, {expected, []})
   end
-
-  test "rule-info template with multiple rules" do
-    data = %{"results" => [%{"command_name" => "foo:foo",
-                             "rule" => "when command is foo:foo allow",
-                             "id" => "123"},
-                           %{"command_name" => "foo:bar",
-                             "rule" => "when command is foo:bar allow",
-                             "id" => "456"},
-                           %{"command_name" => "foo:baz",
-                             "rule" => "when command is foo:baz allow",
-                             "id" => "789"}]}
-    expected = """
-    ```+---------+-------------------------------+-----+
-    | Command | Rule                          | ID  |
-    +---------+-------------------------------+-----+
-    | foo:foo | when command is foo:foo allow | 123 |
-    | foo:bar | when command is foo:bar allow | 456 |
-    | foo:baz | when command is foo:baz allow | 789 |
-    +---------+-------------------------------+-----+
-    ```
-    """ |> String.strip
-
-    assert_rendered_template(:slack, :embedded, "rule-info", data, expected)
-  end
-
-
 end

--- a/test/cog/chat/slack/templates/embedded/rule_list_test.exs
+++ b/test/cog/chat/slack/templates/embedded/rule_list_test.exs
@@ -11,31 +11,25 @@ defmodule Cog.Chat.Slack.Templates.Embedded.RuleListTest do
                            %{"command" => "foo:baz",
                              "rule" => "when command is foo:baz allow",
                              "id" => "789"}]}
-    attachments = [
-      """
-      *Command:* foo:foo
-      *ID:* 123
-      *Rule:*
 
-      ```when command is foo:foo allow```
-      """,
-      """
-      *Command:* foo:bar
-      *ID:* 456
-      *Rule:*
+    expected = """
+    *ID:* 123
+    *Rule:*
 
-      ```when command is foo:bar allow```
-      """, 
-      """
-      *Command:* foo:baz
-      *ID:* 789
-      *Rule:*
+    ```when command is foo:foo allow```
 
-      ```when command is foo:baz allow```
-      """
-    ] |> Enum.map(&String.strip/1)
+    *ID:* 456
+    *Rule:*
 
-    assert_rendered_template(:slack, :embedded, "rule-list", data, {"", attachments})
+    ```when command is foo:bar allow```
+
+    *ID:* 789
+    *Rule:*
+
+    ```when command is foo:baz allow```
+    """ |> String.strip
+
+    assert_rendered_template(:slack, :embedded, "rule-list", data, expected)
   end
 
 end

--- a/test/cog/chat/slack/templates/embedded/trigger_create_test.exs
+++ b/test/cog/chat/slack/templates/embedded/trigger_create_test.exs
@@ -2,19 +2,20 @@ defmodule Cog.Chat.Slack.Templates.Embedded.TriggerCreateTest do
   use Cog.TemplateCase
 
   test "trigger-create template" do
-    data = %{"results" => [%{"id" => "12345"}]}
-    expected = "Created trigger '12345'"
+    data = %{"results" => [%{"name" => "echo-test"}]}
+    expected = "Created trigger 'echo-test'"
     assert_rendered_template(:slack, :embedded, "trigger-create", data, expected)
   end
 
   test "trigger-create template with multiple inputs" do
-    data = %{"results" => [%{"id" => "12345"},
-                           %{"id" => "67890"},
-                           %{"id" => "11111"}]}
+    data = %{"results" => [%{"name" => "echo-1"},
+                           %{"name" => "echo-2"},
+                           %{"name" => "echo-3"}]}
+
     expected = """
-    Created trigger '12345'
-    Created trigger '67890'
-    Created trigger '11111'
+    Created trigger 'echo-1'
+    Created trigger 'echo-2'
+    Created trigger 'echo-3'
     """ |> String.strip
 
     assert_rendered_template(:slack, :embedded, "trigger-create", data, expected)

--- a/test/cog/chat/slack/templates/embedded/trigger_info_test.exs
+++ b/test/cog/chat/slack/templates/embedded/trigger_info_test.exs
@@ -11,14 +11,14 @@ defmodule Cog.Chat.Slack.Templates.Embedded.TriggerInfoTest do
                              "timeout_sec" => 30,
                              "invocation_url" => "https://cog.mycompany.com/invoke_stuff"}]}
     expected = """
-    *ID*: abc123
-    *Name*: test_trigger
-    *Description*: Tests things!
-    *Enabled?*: true
-    *Pipeline*: `echo 'Something just happened'`
-    *As User*: bobby_tables
-    *Timeout (sec)*: 30
-    *Invocation URL*: https://cog.mycompany.com/invoke_stuff
+    *Name:* test_trigger
+    *ID:* abc123
+    *Description:* Tests things!
+    *Status:* Enabled
+    *Pipeline:* `echo 'Something just happened'`
+    *As User:* bobby_tables
+    *Timeout:* 30 seconds
+    *Invocation URL:* https://cog.mycompany.com/invoke_stuff
     """ |> String.strip
 
     assert_rendered_template(:slack, :embedded, "trigger-info", data, {expected, []})
@@ -32,43 +32,17 @@ defmodule Cog.Chat.Slack.Templates.Embedded.TriggerInfoTest do
                              "timeout_sec" => 30,
                              "invocation_url" => "https://cog.mycompany.com/invoke_stuff"}]}
     expected = """
-    *ID*: abc123
-    *Name*: test_trigger
-    *Description*: \n*Enabled?*: true
-    *Pipeline*: `echo 'Something just happened'`
-    *As User*: \n*Timeout (sec)*: 30
-    *Invocation URL*: https://cog.mycompany.com/invoke_stuff
+    *Name:* test_trigger
+    *ID:* abc123
+    *Description:* 
+    *Status:* Enabled
+    *Pipeline:* `echo 'Something just happened'`
+    *As User:* 
+    *Timeout:* 30 seconds
+    *Invocation URL:* https://cog.mycompany.com/invoke_stuff
     """ |> String.strip
 
     assert_rendered_template(:slack, :embedded, "trigger-info", data, {expected, []})
-  end
-
-  test "multiple inputs" do
-    data = %{"results" => [%{"id" => "abc123",
-                             "name" => "test_trigger",
-                             "description" => "Tests things!",
-                             "enabled" => true,
-                             "pipeline" => "echo 'Something just happened'",
-                             "timeout_sec" => 30,
-                             "invocation_url" => "https://cog.mycompany.com/invoke_stuff"},
-                          %{"id" => "abc456",
-                            "name" => "test_trigger_2",
-                            "enabled" => false,
-                            "pipeline" => "echo 'Something else just happened'",
-                            "as_user" => "bobby_tables",
-                            "timeout_sec" => 30,
-                            "invocation_url" => "https://cog.mycompany.com/invoke_other_stuff"}]}
-    expected = """
-    ```+--------+----------------+---------------+----------+-------------------------------------+--------------+---------+----------------------------------------------+
-    | ID     | Name           | Description   | Enabled? | Pipeline                            | As User      | Timeout | Invocation URL                               |
-    +--------+----------------+---------------+----------+-------------------------------------+--------------+---------+----------------------------------------------+
-    | abc123 | test_trigger   | Tests things! | true     | echo 'Something just happened'      |              | 30      | https://cog.mycompany.com/invoke_stuff       |
-    | abc456 | test_trigger_2 |               | false    | echo 'Something else just happened' | bobby_tables | 30      | https://cog.mycompany.com/invoke_other_stuff |
-    +--------+----------------+---------------+----------+-------------------------------------+--------------+---------+----------------------------------------------+
-    ```
-    """ |> String.strip
-
-    assert_rendered_template(:slack, :embedded, "trigger-info", data, expected)
   end
 
 end

--- a/test/cog/chat/slack/templates/embedded/trigger_list_test.exs
+++ b/test/cog/chat/slack/templates/embedded/trigger_list_test.exs
@@ -19,21 +19,9 @@ defmodule Cog.Chat.Slack.Templates.Embedded.TriggerListTest do
                             "timeout_sec" => 30,
                             "invocation_url" => "https://cog.mycompany.com/invoke_other_stuff"}]}
     attachments = [
-      """
-      *Name:* test_trigger
-      *ID:* abc123
-      *Enabled:* true
-      *Invocation URL:* https://cog.mycompany.com/invoke_stuff
-      *Pipeline:* `echo 'Something just happened'`
-      """,
-      """
-      *Name:* test_trigger_2
-      *ID:* abc456
-      *Enabled:* false
-      *Invocation URL:* https://cog.mycompany.com/invoke_other_stuff
-      *Pipeline:* `echo 'Something else just happened'`
-      """
-    ] |> Enum.map(&String.strip/1)
+      "test_trigger (enabled)",
+      "test_trigger_2 (disabled)"
+    ]
 
     assert_rendered_template(:slack, :embedded, "trigger-list", data, {"", attachments})
   end

--- a/test/cog/chat/slack/templates/embedded/trigger_update_test.exs
+++ b/test/cog/chat/slack/templates/embedded/trigger_update_test.exs
@@ -11,16 +11,7 @@ defmodule Cog.Chat.Slack.Templates.Embedded.TriggerUpdateTest do
                              "timeout_sec" => 30,
                              "invocation_url" => "https://cog.mycompany.com/invoke_stuff"}]}
     expected = """
-    *Trigger Updated*
-
-    *ID*: abc123
-    *Name*: test_trigger
-    *Description*: Tests things!
-    *Enabled?*: true
-    *Pipeline*: `echo 'Something just happened'`
-    *As User*: bobby_tables
-    *Timeout (sec)*: 30
-    *Invocation URL*: https://cog.mycompany.com/invoke_stuff
+    Updated trigger 'test_trigger'
     """ |> String.strip
 
     assert_rendered_template(:slack, :embedded, "trigger-update", data, {expected, []})
@@ -34,14 +25,7 @@ defmodule Cog.Chat.Slack.Templates.Embedded.TriggerUpdateTest do
                              "timeout_sec" => 30,
                              "invocation_url" => "https://cog.mycompany.com/invoke_stuff"}]}
     expected = """
-    *Trigger Updated*
-
-    *ID*: abc123
-    *Name*: test_trigger
-    *Description*: \n*Enabled?*: true
-    *Pipeline*: `echo 'Something just happened'`
-    *As User*: \n*Timeout (sec)*: 30
-    *Invocation URL*: https://cog.mycompany.com/invoke_stuff
+    Updated trigger 'test_trigger'
     """ |> String.strip
 
     assert_rendered_template(:slack, :embedded, "trigger-update", data, {expected, []})
@@ -63,15 +47,8 @@ defmodule Cog.Chat.Slack.Templates.Embedded.TriggerUpdateTest do
                             "timeout_sec" => 30,
                             "invocation_url" => "https://cog.mycompany.com/invoke_other_stuff"}]}
     expected = """
-    *Triggers Updated*
-
-    ```+--------+----------------+---------------+----------+-------------------------------------+--------------+---------+----------------------------------------------+
-    | ID     | Name           | Description   | Enabled? | Pipeline                            | As User      | Timeout | Invocation URL                               |
-    +--------+----------------+---------------+----------+-------------------------------------+--------------+---------+----------------------------------------------+
-    | abc123 | test_trigger   | Tests things! | true     | echo 'Something just happened'      |              | 30      | https://cog.mycompany.com/invoke_stuff       |
-    | abc456 | test_trigger_2 |               | false    | echo 'Something else just happened' | bobby_tables | 30      | https://cog.mycompany.com/invoke_other_stuff |
-    +--------+----------------+---------------+----------+-------------------------------------+--------------+---------+----------------------------------------------+
-    ```
+    Updated trigger 'test_trigger'
+    Updated trigger 'test_trigger_2'
     """ |> String.strip
 
     assert_rendered_template(:slack, :embedded, "trigger-update", data, expected)

--- a/test/cog/chat/slack/templates/embedded/user_info_test.exs
+++ b/test/cog/chat/slack/templates/embedded/user_info_test.exs
@@ -22,38 +22,4 @@ defmodule Cog.Chat.Slack.Templates.Embedded.UserInfoTest do
 
     assert_rendered_template(:slack, :embedded, "user-info", data, expected)
   end
-
-  test "user-info template with multiple inputs" do
-    data = %{"results" => [%{"username" => "cog",
-                             "first_name" => "Cog",
-                             "last_name" => "McCog",
-                             "email_address" => "cog@example.com",
-                             "groups" => [%{"name" => "dev"},
-                                          %{"name" => "ops"}],
-                             "chat_handles" => [%{"chat_provider" => %{"name" => "Slack"},
-                                                  "handle" => "the_cog"}]},
-
-                           %{"username" => "sprocket",
-                             "first_name" => "Sprocket",
-                             "last_name" => "McSprocket",
-                             "email_address" => "sprocket@example.com",
-                             "groups" => [%{"name" => "sec"},
-                                          %{"name" => "test"}],
-                             "chat_handles" => [%{"chat_provider" => %{"name" => "Slack"},
-                                                  "handle" => "sprocket"},
-                                                %{"chat_provider" => %{"name" => "HipChat"},
-                                                  "handle" => "SprocketMcSprocket"}]}
-                          ]}
-    expected = """
-    ```+----------+------------+------------+----------------------+-----------+------------------------------------------------+
-    | Username | First Name | Last Name  | Email                | Groups    | Handles                                        |
-    +----------+------------+------------+----------------------+-----------+------------------------------------------------+
-    | cog      | Cog        | McCog      | cog@example.com      | dev, ops  | the_cog (Slack)                                |
-    | sprocket | Sprocket   | McSprocket | sprocket@example.com | sec, test | sprocket (Slack), SprocketMcSprocket (HipChat) |
-    +----------+------------+------------+----------------------+-----------+------------------------------------------------+
-    ```
-    """ |> String.strip
-
-    assert_rendered_template(:slack, :embedded, "user-info", data, expected)
-  end
 end

--- a/test/cog/chat/slack/templates/embedded/user_list_test.exs
+++ b/test/cog/chat/slack/templates/embedded/user_list_test.exs
@@ -15,60 +15,12 @@ defmodule Cog.Chat.Slack.Templates.Embedded.UserListTest do
                              "last_name" => "Ops",
                              "email_address" => "chetops@example.com"}]}
 
-    attachments = [
-      """
-      *Username:* cog
-      *First Name:* Cog
-      *Last Name:* McCog
-      *Email:* cog@example.com
-      """,
-      """
-      *Username:* sprocket
-      *First Name:* Sprocket
-      *Last Name:* McCog
-      *Email:* sprocket@example.com
-      """,
-      """
-      *Username:* chetops
-      *First Name:* Chet
-      *Last Name:* Ops
-      *Email:* chetops@example.com
-      """
-    ] |> Enum.map(&String.strip/1)
+    expected = """
+    cog
+    sprocket
+    chetops
+    """ |> String.strip
 
-    assert_rendered_template(:slack, :embedded, "user-list", data, {"", attachments})
-  end
-
-  test "handle when names aren't specified" do
-    data = %{"results" => [%{"username" => "cog",
-                             "first_name" => "Cog",
-                             "email_address" => "cog@example.com"},
-                           %{"username" => "sprocket",
-                             "last_name" => "McCog",
-                             "email_address" => "sprocket@example.com"},
-                           %{"username" => "chetops",
-                             "email_address" => "chetops@example.com"}]}
-    # TODO: Fix newlines here
-    attachments = [
-      """
-      *Username:* cog
-      *First Name:* Cog
-
-      *Email:* cog@example.com
-      """,
-      """
-      *Username:* sprocket
-
-      *Last Name:* McCog
-      *Email:* sprocket@example.com
-      """,
-      """
-      *Username:* chetops
-
-      *Email:* chetops@example.com
-      """
-    ] |> Enum.map(&String.strip/1)
-
-    assert_rendered_template(:slack, :embedded, "user-list", data, {"", attachments})
+    assert_rendered_template(:slack, :embedded, "user-list", data, expected)
   end
 end

--- a/test/commands/alias/info_test.exs
+++ b/test/commands/alias/info_test.exs
@@ -1,0 +1,32 @@
+defmodule Cog.Test.Commands.Alias.InfoTest do
+  use Cog.CommandCase, command_module: Cog.Commands.Alias.Info
+
+  import Cog.Support.ModelUtilities,
+    only: [site_alias: 2, with_alias: 3, user: 1]
+
+  setup do
+    {:ok, %{user: user("alias_test_user")}}
+  end
+
+  test "showing a user alias", %{user: user} do
+    with_alias(user, "my-awesome-alias", "echo 'awesome!'")
+
+    {:ok, response} = new_req(user: %{"id" => user.id}, args: ["user:my-awesome-alias"])
+    |> send_req()
+
+    assert(%{visibility: "user",
+             pipeline: "echo 'awesome!'",
+             name: "my-awesome-alias"} == response)
+  end
+
+  test "showing a site alias" do
+    site_alias("my-site-alias", "echo 'site!'")
+
+    {:ok, response} = new_req(args: ["site:my-site-alias"])
+    |> send_req()
+
+    assert(%{visibility: "site",
+             pipeline: "echo 'site!'",
+             name: "my-site-alias"} == response)
+  end
+end

--- a/test/commands/rule/info_test.exs
+++ b/test/commands/rule/info_test.exs
@@ -15,7 +15,7 @@ defmodule Cog.Test.Commands.Rule.InfoTest do
               |> unwrap()
 
     assert %{id: id,
-             command_name: "operable:rule-info",
+             command: "operable:rule-info",
              rule: "when command is operable:rule-info allow"} == payload
   end
 

--- a/test/commands/rule/list_test.exs
+++ b/test/commands/rule/list_test.exs
@@ -6,7 +6,7 @@ defmodule Cog.Test.Commands.Rule.ListTest do
   setup :with_bundle
 
   test "listing rules" do
-    response = new_req(options: %{"command" => "test-bundle:st-echo"})
+    response = new_req(%{args: ["test-bundle:st-echo"]})
                |> send_req()
                |> unwrap()
 
@@ -15,7 +15,7 @@ defmodule Cog.Test.Commands.Rule.ListTest do
   end
 
   test "error when listing rules for an unrecognized command" do
-    error = new_req(options: %{"command" => "not_really:a_command"})
+    error = new_req(%{args: ["not_really:a_command"]})
             |> send_req()
             |> unwrap_error()
 
@@ -24,7 +24,7 @@ defmodule Cog.Test.Commands.Rule.ListTest do
 
   @tag :with_disabled_bundle
   test "listing rules for a disabled command fails" do
-    error = new_req(options: %{"command" => "test-bundle:st-echo"})
+    error = new_req(%{args: ["test-bundle:st-echo"]})
             |> send_req()
             |> unwrap_error()
 

--- a/test/commands/rule/list_test.exs
+++ b/test/commands/rule/list_test.exs
@@ -6,7 +6,7 @@ defmodule Cog.Test.Commands.Rule.ListTest do
   setup :with_bundle
 
   test "listing rules" do
-    response = new_req(%{args: ["test-bundle:st-echo"]})
+    response = new_req(args: ["test-bundle:st-echo"])
                |> send_req()
                |> unwrap()
 
@@ -15,7 +15,7 @@ defmodule Cog.Test.Commands.Rule.ListTest do
   end
 
   test "error when listing rules for an unrecognized command" do
-    error = new_req(%{args: ["not_really:a_command"]})
+    error = new_req(args: ["not_really:a_command"])
             |> send_req()
             |> unwrap_error()
 
@@ -24,7 +24,7 @@ defmodule Cog.Test.Commands.Rule.ListTest do
 
   @tag :with_disabled_bundle
   test "listing rules for a disabled command fails" do
-    error = new_req(%{args: ["test-bundle:st-echo"]})
+    error = new_req(args: ["test-bundle:st-echo"])
             |> send_req()
             |> unwrap_error()
 


### PR DESCRIPTION
Most of the changes here revolve around making list commands print scannable output. The only exception is `rule list` as other commands require an id, but we need to show the entire rule since that's really the only identifiable information available.

Tests were also fixed to remove newlines and join tags and extra break tags in hipchat output which were each related to recent greenbar bugfixes.