### PR TITLE
Disable and disallow enabling of incompatible bundle versions

### DIFF
--- a/lib/cog.ex
+++ b/lib/cog.ex
@@ -50,6 +50,18 @@ defmodule Cog do
         Logger.info("Ensuring common templates are up-to-date")
         Cog.Repository.Templates.refresh_common_templates!
 
+        # Disable bundles that have an unsupported config version
+        # If Cog is upgraded incompatible bundles that were installed
+        # previously will be disabled and a warning message displayed
+        # to the user. Nothing will happen if there are no enabled
+        # incompatible bundle versions.
+        Cog.Repository.Bundles.disable_incompatible_bundles()
+        |> Enum.map(&Logger.warn("""
+        Detected unsupported bundle config version '#{&1.config_file["cog_bundle_version"]}'. \
+        Disabling incompatible bundle '#{&1.bundle.name}', version '#{&1.version}'. \
+        Update your bundle config to the newest version, '#{Spanner.Config.current_config_version}' and reinstall.\
+        """))
+
         # Send a start event to the Operable telemetry service
         Cog.Telemetry.send_event(:start)
 

--- a/lib/cog/commands/bundle/info.ex
+++ b/lib/cog/commands/bundle/info.ex
@@ -22,6 +22,13 @@ defmodule Cog.Commands.Bundle.Info do
           "description": "Core chat commands for Cog"
         }
       ],
+      "incompatible_versions": [
+        {
+          "version": "0.16.0",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "description": "Core chat commands for Cog"
+        }
+      ],
       "updated_at": "2016-12-07T22:19:04",
       "relay_groups": [],
       "name": "operable",

--- a/lib/cog/commands/help.ex
+++ b/lib/cog/commands/help.ex
@@ -61,7 +61,8 @@ defmodule Cog.Commands.Help do
   # When help is called with no arguments we return the list of installed bundles
   def handle_message(%{args: []} = req, state) do
     bundles = %{enabled: Repo.preload(Bundles.enabled, :bundle),
-                disabled: Repo.preload(Bundles.highest_disabled_versions, :bundle)}
+                disabled: Repo.preload(Bundles.highest_disabled_versions, :bundle),
+                incompatible: Repo.preload(Bundles.highest_incompatible_versions, :bundle)}
     {:reply, req.reply_to, "help-bundles", bundles, state}
   end
   # When called with arguments the user could be requesting help for either a bundle or

--- a/mix.lock
+++ b/mix.lock
@@ -60,7 +60,7 @@
   "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []},
   "romeo": {:git, "https://github.com/operable/romeo.git", "65106b94f134a12791ec63fa284b0ce5e9358538", [branch: "iq-bodies"]},
   "slack": {:git, "https://github.com/operable/Elixir-Slack.git", "4d6a3c4036ec4129e8d77e55cd1d3e62093cc001", []},
-  "spanner": {:git, "https://github.com/operable/spanner.git", "86635b34f4feadcd88105e6cfa04017f6b0a5a76", []},
+  "spanner": {:git, "https://github.com/operable/spanner.git", "57df53144d9c9bf589bbaf60014840be2aa57a6d", []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
   "table_rex": {:hex, :table_rex, "0.8.3", "1c68dfc6886d6f118f5047b0449d6402ae0ac5709064789e578c2f4659f4064b", [:mix], []},
   "uuid": {:hex, :uuid, "1.1.5", "96cb36d86ee82f912efea4d50464a5df606bf3f1163d6bdbb302d98474969369", [], []},

--- a/priv/templates/embedded/bundle-info.greenbar
+++ b/priv/templates/embedded/bundle-info.greenbar
@@ -2,7 +2,9 @@
 **ID:** ~$bundle.id~
 **Name:** ~$bundle.name~
 **Versions:** ~join var=$bundle.versions with=", "~~$item.version~~end~
-
+~if cond=$bundle.incompatible_versions not_empty?~
+**Incompatible Versions:** ~join var=$bundle.incompatible_versions with=", "~~$item.version~~end~
+~end~
 **Version Enabled:** ~if cond=$bundle.enabled_version bound?~~$bundle.enabled_version.version~~end~~if cond=$bundle.enabled_version not_bound?~Disabled~end~
 **Relay Groups:** ~if cond=$bundle.relay_groups empty?~Unassigned~end~~join var=$bundle.relay_groups with=", "~~$item.name~~end~
 ~end~

--- a/priv/templates/embedded/bundle-versions.greenbar
+++ b/priv/templates/embedded/bundle-versions.greenbar
@@ -1,8 +1,16 @@
 ~each var=$results~
-
+~$item.compatible~
+~if cond=$item.incompatible not_bound?~
 ~attachment color="gray"~
 **Version:** ~$item.version~
 **Enabled:** ~$item.enabled~
+~end~
+~end~
+~if cond=$item.incompatible bound?~
+~attachment color="red"~
+**Version:** ~$item.version~
+**Incompatible**
+~end~
 ~end~
 
 ~end~

--- a/priv/templates/embedded/help-bundles.greenbar
+++ b/priv/templates/embedded/help-bundles.greenbar
@@ -21,6 +21,17 @@ __Disabled Bundles__
 ~end~
 ~end~
 
+~if cond=$bundles.incompatible not_empty?~
+~br~
+__Incompatible Bundles__
+
+~br~
+
+~each var=$bundles.incompatible as=bundle~
+* ~$bundle.name~~if cond=$bundle.description~ - ~$bundle.description~~end~
+~end~
+~end~
+
 ~br~
 
 To learn more about a specific bundle and the commands available within it, you can use "operable:help <bundle>".

--- a/test/cog/chat/hipchat/templates/embedded/bundle_info_test.exs
+++ b/test/cog/chat/hipchat/templates/embedded/bundle_info_test.exs
@@ -22,4 +22,27 @@ defmodule Cog.Chat.HipChat.Templates.Embedded.BundleInfoTest do
     assert_rendered_template(:hipchat, :embedded, "bundle-info", data, expected)
   end
 
+  test "bundle-info with incompatible versions template" do
+    data = %{"results" => [%{"id" => "aaaa-bbbb-cccc-dddd-eeee-ffff",
+                             "name" => "my_bundle",
+                             "versions" => [%{"version" => "0.0.2"},
+                                            %{"version" => "0.0.3"},
+                                            %{"version" => "0.0.4"}],
+                             "incompatible_versions" => [%{"version" => "0.0.1"}],
+                             "enabled_version" => %{"version" => "0.0.3"},
+                             "relay_groups" => [%{"name" => "preprod"},
+                                                %{"name" => "prod"}]}]}
+
+    expected = """
+    <strong>ID:</strong> aaaa-bbbb-cccc-dddd-eeee-ffff<br/>
+    <strong>Name:</strong> my_bundle<br/>
+    <strong>Versions:</strong> 0.0.2, 0.0.3, 0.0.4<br/>
+    <strong>Incompatible Versions:</strong> 0.0.1<br/>
+    <strong>Version Enabled:</strong> 0.0.3<br/>
+    <strong>Relay Groups:</strong> preprod, prod
+    """ |> String.replace("\n", "")
+
+    assert_rendered_template(:hipchat, :embedded, "bundle-info", data, expected)
+  end
+
 end

--- a/test/cog/chat/slack/templates/embedded/bundle_info_test.exs
+++ b/test/cog/chat/slack/templates/embedded/bundle_info_test.exs
@@ -21,4 +21,26 @@ defmodule Cog.Chat.Slack.Templates.Embedded.BundleInfoTest do
     assert_rendered_template(:slack, :embedded, "bundle-info", data, expected)
   end
 
+  test "bundle-info with incompatible versions template" do
+    data = %{"results" => [%{"id" => "aaaa-bbbb-cccc-dddd-eeee-ffff",
+                             "name" => "my_bundle",
+                             "versions" => [%{"version" => "0.0.2"},
+                                            %{"version" => "0.0.3"},
+                                            %{"version" => "0.0.4"}],
+                             "incompatible_versions" => [%{"version" => "0.0.1"}],
+                             "enabled_version" => %{"version" => "0.0.3"},
+                             "relay_groups" => [%{"name" => "preprod"},
+                                                %{"name" => "prod"}]}]}
+    expected = """
+    *ID:* aaaa-bbbb-cccc-dddd-eeee-ffff
+    *Name:* my_bundle
+    *Versions:* 0.0.2, 0.0.3, 0.0.4
+    *Incompatible Versions:* 0.0.1
+    *Version Enabled:* 0.0.3
+    *Relay Groups:* preprod, prod
+    """ |> String.strip
+
+    assert_rendered_template(:slack, :embedded, "bundle-info", data, expected)
+  end
+
 end

--- a/test/cog/chat/slack/templates/embedded/help_bundles_test.exs
+++ b/test/cog/chat/slack/templates/embedded/help_bundles_test.exs
@@ -25,4 +25,37 @@ defmodule Cog.Chat.Slack.Templates.Embedded.HelpBundlesTest do
 
     assert_rendered_template(:slack, :embedded, "help-bundles", data, expected)
   end
+
+  test "help-bundles template with incompatible bundles" do
+    data = %{"results" => [%{"enabled" => [%{"name" => "operable"}],
+                             "disabled" => [%{"name" => "test-bundle"}],
+                             "incompatible" => [%{"name" => "incompatible-bundle"}]}]}
+
+    expected = """
+    *Enabled Bundles*
+
+
+       • operable
+
+
+
+    *Disabled Bundles*
+
+
+       • test-bundle
+
+
+
+    *Incompatible Bundles*
+
+
+       • incompatible-bundle
+
+
+
+    To learn more about a specific bundle and the commands available within it, you can use \"operable:help <bundle>\".
+    """ |> String.rstrip
+
+    assert_rendered_template(:slack, :embedded, "help-bundles", data, expected)
+  end
 end

--- a/test/controllers/v1/bundle_version_controller_test.exs
+++ b/test/controllers/v1/bundle_version_controller_test.exs
@@ -43,6 +43,7 @@ defmodule Cog.V1.BundleVersionControllerTest do
     {:ok, version} = Bundles.install(%{"name" => "test-bundle",
                                        "version" => "1.0.0",
                                        "config_file" => %{
+                                         "cog_bundle_version" => Spanner.Config.current_config_version(),
                                          "name" => "test-bundle",
                                          "version" => "1.0.0",
                                          "commands" => %{"foo" => %{"documentation" => "docs for foo"},

--- a/test/controllers/v1/bundles_controller_test.exs
+++ b/test/controllers/v1/bundles_controller_test.exs
@@ -6,6 +6,8 @@ defmodule Cog.V1.BundlesControllerTest do
 
   @bad_uuid "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 
+  @empty_config_file %{"cog_bundle_version" => Spanner.Config.current_config_version()}
+
   setup do
     # Requests handled by the role controller require this permission
     required_permission = permission("#{Cog.Util.Misc.embedded_bundle}:manage_commands")
@@ -169,9 +171,9 @@ defmodule Cog.V1.BundlesControllerTest do
   end
 
   test "shows disabled bundle", %{authed: requestor} do
-    {:ok, _version3} = Bundles.install(%{"name" => "foo", "version" => "3.0.0", "config_file" => %{}})
-    {:ok, _version2} = Bundles.install(%{"name" => "foo", "version" => "2.0.0", "config_file" => %{}})
-    {:ok, version1} = Bundles.install(%{"name" => "foo", "version" => "1.0.0", "config_file" => %{}})
+    {:ok, _version3} = Bundles.install(%{"name" => "foo", "version" => "3.0.0", "config_file" => @empty_config_file})
+    {:ok, _version2} = Bundles.install(%{"name" => "foo", "version" => "2.0.0", "config_file" => @empty_config_file})
+    {:ok, version1} = Bundles.install(%{"name" => "foo", "version" => "1.0.0", "config_file" => @empty_config_file})
 
     bundle = version1.bundle
 
@@ -191,11 +193,12 @@ defmodule Cog.V1.BundlesControllerTest do
   end
 
   test "shows enabled bundle", %{authed: requestor} do
-    {:ok, _version3} = Bundles.install(%{"name" => "foo", "version" => "3.0.0", "config_file" => %{}})
+    {:ok, _version3} = Bundles.install(%{"name" => "foo", "version" => "3.0.0", "config_file" => @empty_config_file})
     {:ok, version2}  = Bundles.install(%{"name" => "foo", "version" => "2.0.0", "config_file" => %{
+                                         "cog_bundle_version" => Spanner.Config.current_config_version(),
                                           "permissions" => ["foo:bar"],
                                           "commands" => %{"blah" => %{}}}})
-    {:ok, version1}  = Bundles.install(%{"name" => "foo", "version" => "1.0.0", "config_file" => %{}})
+    {:ok, version1}  = Bundles.install(%{"name" => "foo", "version" => "1.0.0", "config_file" => @empty_config_file})
 
     :ok = Bundles.set_bundle_version_status(version2, :enabled)
     bundle = version1.bundle
@@ -309,11 +312,12 @@ defmodule Cog.V1.BundlesControllerTest do
   end
 
   test "shows bundle versions", %{authed: requestor} do
-    {:ok, version1}  = Bundles.install(%{"name" => "foo", "version" => "1.0.0", "config_file" => %{}})
+    {:ok, version1}  = Bundles.install(%{"name" => "foo", "version" => "1.0.0", "config_file" => @empty_config_file})
     {:ok, _version2}  = Bundles.install(%{"name" => "foo", "version" => "2.0.0", "config_file" => %{
+                                          "cog_bundle_version" => Spanner.Config.current_config_version(),
                                           "permissions" => ["foo:bar"],
                                           "commands" => %{"blah" => %{}}}})
-    {:ok, _version3} = Bundles.install(%{"name" => "foo", "version" => "3.0.0", "config_file" => %{}})
+    {:ok, _version3} = Bundles.install(%{"name" => "foo", "version" => "3.0.0", "config_file" => @empty_config_file})
 
     conn = api_request(requestor, :get, "/v1/bundles/#{version1.bundle.id}/versions")
 

--- a/test/support/command_case.ex
+++ b/test/support/command_case.ex
@@ -9,6 +9,7 @@ defmodule Cog.CommandCase do
   using opts do
     quote location: :keep, bind_quoted: [opts: opts] do
       import Cog.CommandCase
+      import Cog.Test.Util
 
       # command_module and command_tag provide some niceties and shortcuts
       # for working with command tests. Both are optional.
@@ -130,22 +131,4 @@ defmodule Cog.CommandCase do
 
   def services_root,
     do: Cog.ServiceEndpoint.url()
-
-
-  #### Utility Functions ####
-
-  # unwraps :ok tuples, returning just their value
-  # If a tuple without an :ok atom is passed, raises an error.
-  def unwrap({:ok, value}),
-    do: value
-  def unwrap(value),
-    do: raise "Expected {:ok, value}, but received #{inspect(value)} instead."
-
-  # unwraps :error tuples, returning just the error
-  # If a tuple without an :error atom is passed, raises an error.
-  def unwrap_error({:error, error}),
-    do: error
-  def unwrap_error(value),
-    do: raise "Expected {:error, error}, but received #{inspect(value)} instead."
-
 end

--- a/test/support/model_case.ex
+++ b/test/support/model_case.ex
@@ -20,6 +20,7 @@ defmodule Cog.ModelCase do
       import Ecto.Model
       import Ecto.Query, only: [from: 2]
       import Cog.ModelCase
+      import Cog.Test.Util
 
       # These are ours
       import DatabaseTestSetup

--- a/test/support/util.ex
+++ b/test/support/util.ex
@@ -1,0 +1,21 @@
+defmodule Cog.Test.Util do
+  @moduldoc """
+  Collection of utility functions for use in tests
+  """
+
+  @doc """
+  unwraps 2-tuples starting with the provided value
+  """
+  def unwrap(tuple, any \\ :ok)
+  def unwrap({any, value}, any), do: value
+  def unwrap(any, value),
+    do: raise "Expected 2-tuple starting with #{inspect any} but received #{inspect value} instead."
+
+  @doc """
+  unwraps :error tuples, returning just the error
+  If a tuple without an :error atom is passed, raises an error.
+  """
+  def unwrap_error(value),
+    do: unwrap(value, :error)
+
+end

--- a/web/controllers/v1/bundle_status_controller.ex
+++ b/web/controllers/v1/bundle_status_controller.ex
@@ -30,6 +30,16 @@ defmodule Cog.V1.BundleStatusController do
             conn
             |> put_status(:forbidden)
             |> json(%{error: "Cannot modify the status of the #{name} bundle"})
+          {:error, {:incompatible_config_version, bundle_version}} ->
+            message = """
+            Cannot modify the status of '#{bundle_version.bundle.name}' version '#{bundle_version.version}'. \
+            Config version '#{bundle_version.config_file["cog_bundle_version"]}' is no longer supported. \
+            Please install an updated version of the bundle.\
+            """
+
+            conn
+            |> put_status(:bad_request)
+            |> json(%{error: message})
         end
       nil ->
         conn

--- a/web/views/bundle_version_view.ex
+++ b/web/views/bundle_version_view.ex
@@ -3,7 +3,7 @@ defmodule Cog.V1.BundleVersionView do
   alias Cog.Repository.Bundles
 
   def render("bundle_version.json", %{bundle_version: bundle_version}) do
-    %{id: bundle_version.id,
+    version = %{id: bundle_version.id,
       bundle_id: bundle_version.bundle.id,
       name: bundle_version.bundle.name,
       description: bundle_version.description,
@@ -17,6 +17,12 @@ defmodule Cog.V1.BundleVersionView do
       config_file: bundle_version.config_file,
       inserted_at: bundle_version.inserted_at,
       updated_at: bundle_version.updated_at}
+
+    if Bundles.incompatible?(bundle_version) do
+      Map.put(version, :incompatible, true)
+    else
+      version
+    end
   end
   def render("index.json", %{bundle_versions: bundle_versions}),
     do: %{bundle_versions: render_many(bundle_versions, __MODULE__, "bundle_version.json", as: :bundle_version)}

--- a/web/views/bundles_view.ex
+++ b/web/views/bundles_view.ex
@@ -20,7 +20,8 @@ defmodule Cog.V1.BundlesView do
 
     %{id: bundle.id,
       name: bundle.name,
-      versions: ordered_versions(bundle.versions),
+      versions: ordered_compatible_versions(bundle.versions),
+      incompatible_versions: ordered_incompatible_versions(bundle.versions),
       inserted_at: bundle.inserted_at,
       updated_at: bundle.updated_at}
     |> Map.merge(enabled_version)
@@ -34,6 +35,23 @@ defmodule Cog.V1.BundlesView do
   end
 
   ########################################################################
+
+  # TODO: Move these functions to the bundles repository. We should probably
+  # be getting the versions from the db ordered and grouped by compatible
+  # and incompatible. But that should require some rework around how we get
+  # bundles. Aside from the ordering these functions just extract the needed
+  # fields for display, so I'll leave them here for now.
+  defp ordered_compatible_versions(versions) do
+    # Reject incompatible versions, then order the rest
+    Enum.reject(versions, &Cog.Repository.Bundles.incompatible?/1)
+    |> ordered_versions()
+  end
+
+  defp ordered_incompatible_versions(versions) do
+    # Drop compatible versions, then order the rest
+    Enum.filter(versions, &Cog.Repository.Bundles.incompatible?/1)
+    |> ordered_versions()
+  end
 
   defp ordered_versions(versions) do
     versions


### PR DESCRIPTION
This moves a lot of the post startup bits to a separate module and adds additional logic to disable old incompatible bundles. It also prevents incompatible bundles from being re-enabled.

part of #1262 
depends on https://github.com/operable/spanner/pull/88