### PR TITLE
Share MQTT connections between processes

### DIFF
--- a/lib/carrier/messaging/connection.ex
+++ b/lib/carrier/messaging/connection.ex
@@ -20,6 +20,7 @@ defmodule Carrier.Messaging.Connection do
 
   @internal_mq_username Cog.Util.Misc.internal_mq_username
   @default_connect_timeout 5000 # 5 seconds
+  @default_call_timeout 5000 # 5 seconds
   @default_log_level :error
 
   defstruct [:conn, :tracker, :owner]
@@ -101,7 +102,7 @@ defmodule Carrier.Messaging.Connection do
   @spec call(conn::connection(), topic::String.t, endpoint::String.t, message::Map.t, opts::call_opts()) :: Map.t | {:error, atom()}
   def call(conn, topic, endpoint, message, opts \\ []) do
     subscriber = Keyword.get(opts, :subscriber, self())
-    timeout = Keyword.get(opts, :timeout, 5000)
+    timeout = Keyword.get(opts, :timeout, @default_call_timeout)
     GenServer.call(conn, {:call, topic, endpoint, message, subscriber, timeout}, :infinity)
   end
 

--- a/lib/carrier/messaging/connection.ex
+++ b/lib/carrier/messaging/connection.ex
@@ -2,6 +2,9 @@ defmodule Carrier.Messaging.Connection do
 
   require Logger
 
+  use Cog.Util.Debug
+
+  alias Carrier.Messaging.Tracker
   alias Carrier.Messaging.Messages.MqttCall
   alias Carrier.Messaging.Messages.MqttCast
   alias Carrier.Messaging.Messages.MqttReply
@@ -9,30 +12,30 @@ defmodule Carrier.Messaging.Connection do
   require Record
   Record.defrecord :hostent, Record.extract(:hostent, from_lib: "kernel/include/inet.hrl")
 
+  use GenServer
+
   @moduledoc """
-  Interface for the message bus on which commands communicate.
+  General interface to Cog's message bus
   """
 
   @internal_mq_username Cog.Util.Misc.internal_mq_username
   @default_connect_timeout 5000 # 5 seconds
   @default_log_level :error
 
-  defstruct [:id, :conn, :call_reply]
+  defstruct [:conn, :tracker, :owner]
 
   # Note: This type is what we get from emqttc; if we change
   # underlying message buses, we can just change this
   # definition. Client code can just depend on this opaque type and
   # not need to know that we're using emqttc at all.
   @typedoc "The connection to the message bus."
-  @opaque connection :: %__MODULE__{}
+  @opaque connection :: pid()
 
-  @doc """
-  Starts up a message bus client process using only preconfigured parameters.
-  """
-  @spec connect() :: {:ok, connection()} | :ignore | {:error, term()}
-  def connect() do
-    connect([])
-  end
+  @type call_opts :: [] | [call_opt()]
+  @type call_opt :: {:timeout, integer()} | {:subscriber, pid()}
+
+  @type publish_opts :: [] | [publish_opt()]
+  @type publish_opt :: {:routed_by, String.t} | {:threshold, integer()}
 
   @doc """
   Starts up a message bus client process.
@@ -47,14 +50,85 @@ defmodule Carrier.Messaging.Connection do
 
   """
   # Again, this spec is what comes from emqttc
-  @spec connect(Keyword.t()) :: {:ok, connection()} | :ignore | {:error, term()}
-  def connect(opts) do
-    connect_timeout = Keyword.get(opts, :connect_timeout, @default_connect_timeout)
-
+  @spec start_link(pid(), Keyword.t()) :: {:ok, connection()} | :ignore | {:error, term()}
+  def start_link(owner, opts \\ []) do
     opts = opts
     |> add_connect_config
     |> add_internal_credentials
 
+    GenServer.start_link(__MODULE__, [owner, opts])
+  end
+
+  @doc """
+  Creates a GenMqtt-style reply endpoint and subscribes `subscriber` to the topic
+
+  `subscriber` defaults to the caller's pid
+  """
+  @spec create_reply_endpoint(conn::connection(), subscriber::pid()) :: {:ok, String.t} | {:error, atom()}
+  def create_reply_endpoint(conn, subscriber \\ self()) do
+    GenServer.call(conn, {:create_reply_endpoint, subscriber}, :infinity)
+  end
+
+  @doc """
+  Creates a subscription to a given topic for `subscriber`
+
+  `subscriber` defaults to caller's pid
+  """
+  @spec subscribe(conn::connection(), topic::String.t, subscriber::pid()) :: {:ok, String.t} | {:error, atom()}
+  def subscribe(conn, topic, subscriber \\ self()) do
+    GenServer.call(conn, {:subscribe, topic, subscriber}, :infinity)
+  end
+
+  @doc """
+  Removes the named subscription for `subscriber`.
+  Returns true if unsubscribe was successful, false otherwise.
+  """
+  @spec unsubscribe(conn::connection(), topic::String.t, subscriber::pid()) :: boolean()
+  def unsubscribe(conn, topic, subscriber \\ self()) do
+    GenServer.call(conn, {:unsubscribe, topic, subscriber}, :infinity)
+  end
+
+  @doc """
+  Publishes a message to a MQTT topic
+
+  ## Keyword Arguments
+
+    * `:routed_by` - the topic on which to publish `message`. Required.
+  """
+  @spec publish(conn::connection(), message::Map.t, opts::publish_opts()) :: :ok | {:error, atom()}
+  def publish(conn, message, opts) do
+    GenServer.call(conn, {:publish, message, opts}, :infinity)
+  end
+
+  @doc """
+  Sends a GenMqtt call message and waits for reply
+  """
+  @spec call(conn::connection(), topic::String.t, endpoint::String.t, message::Map.t, opts::call_opts()) :: Map.t | {:error, atom()}
+  def call(conn, topic, endpoint, message, opts \\ []) do
+    subscriber = Keyword.get(opts, :subscriber, self())
+    timeout = Keyword.get(opts, :timeout, 5000)
+    GenServer.call(conn, {:call, topic, endpoint, message, subscriber, timeout}, :infinity)
+  end
+
+  @doc """
+  Sends a GenMqtt cast message
+  """
+  @spec cast(conn::connection(), topic::String.t, endpoint::String.t, message::Map.t) :: :ok | {:error, atom()}
+  def cast(conn, topic, endpoint, message) do
+    GenServer.call(conn, {:cast, topic, endpoint, message}, :infinity)
+  end
+
+  @doc """
+  Terminates an active connection
+  """
+  @spec disconnect(conn::connection) :: :ok
+  def disconnect(conn) do
+    GenServer.call(conn, :disconnect)
+  end
+
+
+  def init([owner, opts]) do
+    connect_timeout = Keyword.get(opts, :connect_timeout, @default_connect_timeout)
     {:ok, conn} = :emqttc.start_link(opts)
 
     # `emqttc:start_link/1` returns a message bus client process, but it
@@ -70,101 +144,105 @@ defmodule Carrier.Messaging.Connection do
     # If we don't connect after a specified timeout, we just fail.
     receive do
       {:mqttc, ^conn, :connected} ->
-        id = UUID.uuid4(:hex)
-        call_reply = "carrier/call/reply/#{id}"
-        :emqttc.sync_subscribe(conn, call_reply)
-        {:ok, %__MODULE__{conn: conn, id: id, call_reply: call_reply}}
+        Process.link(owner)
+        {:ok, %__MODULE__{conn: conn,
+                          owner: owner,
+                          tracker: %Tracker{}}}
     after connect_timeout ->
         Logger.info("Connection not established")
-        {:error, :econnrefused}
+        {:stop, :econnrefused}
     end
   end
 
-  @spec disconnect(%__MODULE__{}) :: :ok | atom
-  def disconnect(%__MODULE__{conn: conn}) do
-    :emqttc.disconnect(conn)
+  def handle_call({:create_reply_endpoint, subscriber}, _from, %__MODULE__{tracker: tracker}=state) do
+    {tracker, topic} = Tracker.add_reply_endpoint(tracker, subscriber)
+    unless Enum.member?(:emqttc.topics(state.conn), {topic, :qos1}) do
+      :emqttc.sync_subscribe(state.conn, topic, :qos1)
+    end
+    {:reply, {:ok, topic}, %{state | tracker: tracker}}
   end
-
-  def subscribe(%__MODULE__{conn: conn}, topic) do
-    # `:qos1` is an MQTT quality-of-service level indicating "at least
-    # once delivery" of messages. Additionally, the sender blocks
-    # until receiving a message acknowledging receipt of the
-    # message. This provides back-pressure for the system, and
-    # generally makes things easier to reason about.
-    #
-    # See
-    # http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718101
-    # for more.
-    :emqttc.sync_subscribe(conn, topic, :qos1)
+  def handle_call({:subscribe, topic, subscriber}, _from, %__MODULE__{tracker: tracker}=state) do
+    tracker = Tracker.add_subscription(tracker, topic, subscriber)
+    unless Enum.member?(:emqttc.topics(state.conn), {topic, :qos1}) do
+      :emqttc.sync_subscribe(state.conn, topic, :qos1)
+    end
+    {:reply, {:ok, topic}, %{state | tracker: tracker}}
   end
-
-  def unsubscribe(%__MODULE__{conn: conn}, topic) do
-    :emqttc.unsubscribe(conn, topic)
+  def handle_call({:unsubscribe, topic, subscriber}, _from, %__MODULE__{tracker: tracker}=state) do
+    {tracker, deleted} = Tracker.del_subscription(tracker, topic, subscriber)
+    state = if deleted do
+      drop_unused_topics(%{state | tracker: tracker})
+    else
+      state
+    end
+    {:reply, deleted, state}
   end
-
-  @spec call(conn :: connection, call_topic :: String.t, endpoint :: String.t, payload :: map, timeout :: integer) ::
-    map |
-    {:error, :call_timeout} |
-    {:error, reason :: any}
-  def call(%__MODULE__{call_reply: reply}=conn, call_topic, endpoint, payload, timeout) when is_map(payload) do
-    flush_pending(reply)
-
-    message = %MqttCall{sender: reply, endpoint: endpoint, payload: payload}
-
-    # Publish message (make blocking call)
-    case publish(conn, message, routed_by: call_topic) do
-      {:ok, _} ->
-        # Wait for response
-        receive do
-          {:publish, ^reply, message} ->
-            MqttReply.decode!(message)
-        after timeout ->
-            {:error, :call_timeout}
+  def handle_call({:publish, message, opts}, _from, state) do
+    case Keyword.get(opts, :routed_by) do
+      nil ->
+        {:reply, {:error, :no_topic}, state}
+      topic ->
+        case message.__struct__.encode(message) do
+          {:ok, encoded} ->
+            case :emqttc.sync_publish(state.conn, topic, encoded, :qos1) do
+              {:ok, _} ->
+                {:reply, :ok, state}
+              error ->
+                {:reply, error, state}
+            end
+          error ->
+            {:reply, error, state}
         end
     end
   end
-
-  @spec cast(conn :: connection, cast_topic :: String.t, endpoint :: String.t, payload :: map) :: :ok | {:error, reason :: any}
-  def cast(%__MODULE__{}=conn, cast_topic, endpoint, payload) when is_map(payload) do
+  def handle_call({:call, topic, endpoint, payload, subscriber, timeout}, from, state) do
+    case Tracker.get_reply_endpoint(state.tracker, subscriber) do
+      nil ->
+        {:reply, {:error, :no_reply_endpoint}, state}
+      reply_endpoint ->
+        flush_pending(reply_endpoint)
+        message = %MqttCall{sender: reply_endpoint, endpoint: endpoint, payload: payload}
+        case handle_call({:publish, message, routed_by: topic}, from, state) do
+          {:reply, :ok, state} ->
+            # Wait for response
+            receive do
+              {:publish, ^reply_endpoint, message} ->
+                {:reply, MqttReply.decode(message), state}
+            after timeout ->
+                {:reply, {:error, :call_timeout}, state}
+            end
+          error ->
+            error
+        end
+    end
+  end
+  def handle_call({:cast, topic, endpoint, payload}, from, state) do
     message = %MqttCast{endpoint: endpoint, payload: payload}
-    case publish(conn, message, routed_by: cast_topic) do
-      {:ok, _} ->
-        :ok
-      error ->
-        error
+    handle_call({:publish, message, routed_by: topic}, from, state)
+  end
+  def handle_call(:disconnect, _from, state) do
+    unless state.owner == nil do
+      Process.unlink(state.owner)
     end
+    :emqttc.disconnect(state.conn)
+    {:stop, :shutdown, :ok, state}
   end
 
-  @doc """
-  Publish a JSON object to the message bus. The object will be
-  signed with the system key.
-
-  ## Keyword Arguments
-
-    * `:routed_by` - the topic on which to publish `message`. Required.
-
-  """
-
-  # Here, we assume we're being passed a Conduit-enabled struct
-  # (aside: any way to verify that statically?) We'll do the encoding
-  # to JSON internally
-  def publish(%__MODULE__{conn: conn}, %{__struct__: _}=message, kw_args) do
-    topic = Keyword.fetch!(kw_args, :routed_by)
-
-    encoded = message.__struct__.encode!(message)
-    case Keyword.fetch(kw_args, :threshold) do
-      {:ok, threshold} ->
-        size = byte_size(encoded)
-        if size > threshold do
-          Logger.warn("Message potentially too long (#{size} bytes)")
-        else
-          :ok
-        end
-      :error ->
-        :ok
+  def handle_info({:DOWN, _mref, :process, subscriber, _}, %__MODULE__{tracker: tracker}=state) do
+    tracker = Tracker.del_subscriber(tracker, subscriber)
+    {:noreply, drop_unused_topics(%{state | tracker: tracker})}
+  end
+  def handle_info({:publish, topic, _}=message, state) do
+    case Tracker.find_subscribers(state.tracker, topic) do
+      [] ->
+        {:noreply, state}
+      subscribed ->
+        Enum.each(subscribed, &(Process.send(&1, message, [])))
+        {:noreply, state}
     end
-
-    :emqttc.sync_publish(conn, topic, encoded, :qos1)
+  end
+  def handle_info(_msg, state) do
+    {:noreply, state}
   end
 
   ########################################################################
@@ -232,6 +310,12 @@ defmodule Carrier.Messaging.Connection do
     after 0 ->
         :ok
     end
+  end
+
+  defp drop_unused_topics(%__MODULE__{tracker: tracker, conn: conn}=state) do
+    {tracker, unused_topics} = Tracker.get_and_reset_unused_topics(tracker)
+    Enum.each(unused_topics, &(:emqttc.unsubscribe(conn, &1)))
+    %{state | tracker: tracker}
   end
 
 end

--- a/lib/carrier/messaging/connection.ex
+++ b/lib/carrier/messaging/connection.ex
@@ -24,10 +24,6 @@ defmodule Carrier.Messaging.Connection do
 
   defstruct [:conn, :tracker, :owner]
 
-  # Note: This type is what we get from emqttc; if we change
-  # underlying message buses, we can just change this
-  # definition. Client code can just depend on this opaque type and
-  # not need to know that we're using emqttc at all.
   @typedoc "The connection to the message bus."
   @opaque connection :: pid()
 
@@ -49,7 +45,6 @@ defmodule Carrier.Messaging.Connection do
   `:connect_timeout` option in `opts`.
 
   """
-  # Again, this spec is what comes from emqttc
   @spec start_link(pid(), Keyword.t()) :: {:ok, connection()} | :ignore | {:error, term()}
   def start_link(owner, opts \\ []) do
     opts = opts

--- a/lib/carrier/messaging/connection.ex
+++ b/lib/carrier/messaging/connection.ex
@@ -2,8 +2,6 @@ defmodule Carrier.Messaging.Connection do
 
   require Logger
 
-  use Cog.Util.Debug
-
   alias Carrier.Messaging.Tracker
   alias Carrier.Messaging.Messages.MqttCall
   alias Carrier.Messaging.Messages.MqttCast

--- a/lib/carrier/messaging/connection_sup.ex
+++ b/lib/carrier/messaging/connection_sup.ex
@@ -1,0 +1,16 @@
+defmodule Carrier.Messaging.ConnectionSup do
+  use Supervisor
+
+  def start_link,
+    do: Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+
+  def init(_) do
+    children = [worker(Carrier.Messaging.Connection, [], restart: :temporary)]
+    supervise(children, strategy: :simple_one_for_one, max_restarts: 0, max_seconds: 1)
+  end
+
+  def connect(opts \\ []) do
+    Supervisor.start_child(__MODULE__, [self(), opts])
+  end
+
+end

--- a/lib/carrier/messaging/tracker.ex
+++ b/lib/carrier/messaging/tracker.ex
@@ -130,9 +130,9 @@ defmodule Carrier.Messaging.Tracker do
   end
 
   def unmonitor_subscriber(%__MODULE__{monitors: monitors}=tracker, subscriber) do
-    mref = Map.fetch!(monitors, subscriber)
+    {mref, monitors} = Map.pop(monitors, subscriber)
     :erlang.demonitor(mref, [:flush])
-    %{tracker | monitors: Map.delete(monitors, subscriber)}
+    %{tracker | monitors: monitors}
   end
 
   defp has_subscriptions?(tracker, subscriber) do

--- a/lib/carrier/messaging/tracker.ex
+++ b/lib/carrier/messaging/tracker.ex
@@ -91,10 +91,14 @@ defmodule Carrier.Messaging.Tracker do
     end
   end
 
+  # Tracker users regexes to find subscribers for a given MQTT topic because
+  # the MQTT standard describes two types of wildcard subscriptions:
+  #   * "foo/+" means "subscribe to foo and all topics one level down"
+  #   * "foo/*" means "subscribe to foo and all subtopics regardless of depth"
   defp subscription_matcher(sub_topic) do
     regex = case String.slice(sub_topic, -2, 2) do
               "/+" ->
-                "^#{String.slice(sub_topic, 0, String.length(sub_topic) - 1)}[a-zA-Z0-9_]+$"
+                "^#{String.slice(sub_topic, 0, String.length(sub_topic) - 1)}[a-zA-Z0-9_\-]+$"
               "/*" ->
                 "^#{String.slice(sub_topic, 0, String.length(sub_topic) - 1)}.*"
               _ ->

--- a/lib/carrier/messaging/tracker.ex
+++ b/lib/carrier/messaging/tracker.ex
@@ -1,0 +1,179 @@
+defmodule Carrier.Messaging.Tracker do
+
+  defstruct [reply_endpoints: %{}, subscriptions: %{}, monitors: %{}, unused_topics: []]
+
+  @spec add_reply_endpoint(Tracker.t, pid()) :: {Tracker.t, String.t}
+  def add_reply_endpoint(%__MODULE__{reply_endpoints: reps}=tracker, subscriber) do
+    case Map.get(reps, subscriber) do
+      nil ->
+        topic = make_reply_endpoint_topic()
+        reps = reps
+        |> Map.put(subscriber, topic)
+        |> Map.put(topic, subscriber)
+        {maybe_monitor_subscriber(%{tracker | reply_endpoints: reps}, subscriber), topic}
+      topic ->
+        {tracker, topic}
+    end
+  end
+
+  @spec get_reply_endpoint(Tracker.t, pid()) :: String.t | nil
+  def get_reply_endpoint(%__MODULE__{reply_endpoints: reps}, subscriber) do
+    Map.get(reps, subscriber)
+  end
+
+  @spec add_subscription(Tracker.t, String.t, pid()) :: Tracker.t
+  def add_subscription(%__MODULE__{subscriptions: subs}=tracker, topic, subscriber) do
+    subs = case Map.get(subs, topic) do
+             nil ->
+               Map.put(subs, topic, {subscription_matcher(topic), [subscriber]})
+             {matcher, subscribed} ->
+               Map.put(subs, topic, {matcher, Enum.uniq([subscriber|subscribed])})
+           end
+    maybe_monitor_subscriber(%{tracker | subscriptions: subs}, subscriber)
+  end
+
+  @spec del_subscription(Tracker.t, String.t, pid()) :: {Tracker.t, boolean()}
+  def del_subscription(%__MODULE__{subscriptions: subs, unused_topics: ut}=tracker, topic, subscriber) do
+    case Map.get(subs, topic) do
+      {_matcher, [^subscriber]} ->
+        subs = Map.delete(subs, topic)
+        {maybe_unmonitor_subscriber(%{tracker | subscriptions: subs, unused_topics: Enum.uniq([topic|ut])}, subscriber), true}
+      {matcher, subscribed} ->
+        case List.delete(subscribed, subscriber) do
+          ^subscribed ->
+            {tracker, false}
+          updated ->
+            {maybe_unmonitor_subscriber(%{tracker | subscriptions: Map.put(subs, topic, {matcher, updated})}, subscriber), true}
+        end
+      nil ->
+        {tracker, false}
+    end
+  end
+
+  @spec find_reply_subscriber(Tracker.t, String.t) :: pid() | nil
+  def find_reply_subscriber(%__MODULE__{reply_endpoints: reps}, topic) do
+    Map.get(reps, topic)
+  end
+
+  @spec find_subscribers(Tracker.t, String.t) :: [] | [pid()]
+  def find_subscribers(%__MODULE__{subscriptions: subs}, topic) do
+    Enum.reduce(subs, [], &(find_matching_subscriptions(&1, topic, &2)))
+  end
+
+  @spec del_subscriber(Tracker.t, pid()) :: Tracker.t
+  def del_subscriber(tracker, subscriber) do
+    tracker
+    |> del_reply_endpoint(subscriber)
+    |> del_all_subscriptions(subscriber)
+    |> unmonitor_subscriber(subscriber)
+  end
+
+  @spec unused?(Tracker.t) :: boolean()
+  def unused?(%__MODULE__{reply_endpoints: reps, subscriptions: subs, monitors: monitors}) do
+    Enum.empty?(reps) and Enum.empty?(subs) and Enum.empty?(monitors)
+  end
+
+  @spec get_and_reset_unused_topics(Tracker.t) :: {Tracker.t, [String.t]}
+  def get_and_reset_unused_topics(tracker) do
+    {%{tracker | unused_topics: []}, tracker.unused_topics}
+  end
+
+  defp make_reply_endpoint_topic() do
+    id = UUID.uuid4(:hex)
+    "carrier/call/reply/#{id}"
+  end
+
+  defp find_matching_subscriptions({_, {matcher, subscribed}}, topic, accum) do
+    if Regex.match?(matcher, topic) do
+      accum ++ subscribed
+    else
+      accum
+    end
+  end
+
+  defp subscription_matcher(sub_topic) do
+    regex = case String.slice(sub_topic, -2, 2) do
+              "/+" ->
+                "^#{String.slice(sub_topic, 0, String.length(sub_topic) - 1)}[a-zA-Z0-9_]+$"
+              "/*" ->
+                "^#{String.slice(sub_topic, 0, String.length(sub_topic) - 1)}.*"
+              _ ->
+                "^#{sub_topic}$"
+            end
+    Regex.compile!(regex)
+  end
+
+  def maybe_monitor_subscriber(%__MODULE__{monitors: monitors}=tracker, subscriber) do
+    case Map.get(monitors, subscriber) do
+      nil ->
+        mref = :erlang.monitor(:process, subscriber)
+        %{tracker | monitors: Map.put(monitors, subscriber, mref)}
+      _ ->
+        tracker
+    end
+  end
+
+  def maybe_unmonitor_subscriber(%__MODULE__{monitors: monitors}=tracker, subscriber) do
+    if has_subscriptions?(tracker, subscriber) do
+      tracker
+    else
+      if Map.has_key?(monitors, subscriber) do
+        unmonitor_subscriber(tracker, subscriber)
+      else
+        tracker
+      end
+    end
+  end
+
+  def unmonitor_subscriber(%__MODULE__{monitors: monitors}=tracker, subscriber) do
+    mref = Map.fetch!(monitors, subscriber)
+    :erlang.demonitor(mref, [:flush])
+    %{tracker | monitors: Map.delete(monitors, subscriber)}
+  end
+
+  defp has_subscriptions?(tracker, subscriber) do
+    if Enum.reduce_while(tracker.reply_endpoints, false, &(has_endpoint(&1, subscriber, &2))) do
+      true
+    else
+      Enum.reduce_while(tracker.subscriptions, false, &(has_any_subscription(&1, subscriber, &2)))
+    end
+  end
+
+  defp has_endpoint({_topic, subscriber}, subscriber, _), do: {:halt, true}
+  defp has_endpoint({_, _}, _, _), do: {:cont, false}
+
+  defp has_any_subscription({_, {_, subscribed}}, subscriber, _) do
+    if Enum.member?(subscribed, subscriber) do
+        {:halt, true}
+    else
+      {:cont, false}
+    end
+  end
+
+  defp del_reply_endpoint(%__MODULE__{reply_endpoints: reps, unused_topics: ut}=tracker, subscriber) do
+    case Map.get(reps, subscriber) do
+      nil ->
+        tracker
+      rep ->
+        reps = reps
+        |> Map.delete(rep)
+        |> Map.delete(subscriber)
+        %{tracker | reply_endpoints: reps, unused_topics: Enum.uniq([rep|ut])}
+    end
+  end
+
+  defp del_all_subscriptions(%__MODULE__{subscriptions: subs}=tracker, subscriber) do
+    subs = Enum.reduce(Map.keys(subs), subs, &(delete_subscription(&1, subscriber, &2)))
+    %{tracker | subscriptions: subs}
+  end
+
+  defp delete_subscription(topic, subscriber, subs) do
+    case Map.get(subs, topic) do
+      {_, []} ->
+        subs
+      {matcher, subscribed} ->
+        Map.put(subs, topic, {matcher, List.delete(subscribed, subscriber)})
+    end
+  end
+
+end

--- a/lib/carrier/messaging/tracker.ex
+++ b/lib/carrier/messaging/tracker.ex
@@ -136,22 +136,12 @@ defmodule Carrier.Messaging.Tracker do
   end
 
   defp has_subscriptions?(tracker, subscriber) do
-    if Enum.reduce_while(tracker.reply_endpoints, false, &(has_endpoint(&1, subscriber, &2))) do
-      true
-    else
-      Enum.reduce_while(tracker.subscriptions, false, &(has_any_subscription(&1, subscriber, &2)))
-    end
+    Map.has_key?(tracker.reply_endpoints, subscriber) or
+      Enum.any?(tracker.subscriptions, &(has_subscription?(&1, subscriber)))
   end
 
-  defp has_endpoint({_topic, subscriber}, subscriber, _), do: {:halt, true}
-  defp has_endpoint({_, _}, _, _), do: {:cont, false}
-
-  defp has_any_subscription({_, {_, subscribed}}, subscriber, _) do
-    if Enum.member?(subscribed, subscriber) do
-        {:halt, true}
-    else
-      {:cont, false}
-    end
+  defp has_subscription?({_, {_, subscribed}}, subscriber) do
+    Enum.member?(subscribed, subscriber)
   end
 
   defp del_reply_endpoint(%__MODULE__{reply_endpoints: reps, unused_topics: ut}=tracker, subscriber) do

--- a/lib/cog.ex
+++ b/lib/cog.ex
@@ -17,6 +17,7 @@ defmodule Cog do
 
     maybe_display_unenforcing_warning()
     children = [worker(Cog.BusDriver, [], shutdown: 1000),
+                supervisor(Carrier.Messaging.ConnectionSup, []),
                 worker(Cog.Repo, []),
                 supervisor(Cog.CoreSup, [])]
 

--- a/lib/cog/chat/hipchat/provider.ex
+++ b/lib/cog/chat/hipchat/provider.ex
@@ -5,7 +5,7 @@ defmodule Cog.Chat.HipChat.Provider do
   use GenServer
   use Cog.Chat.Provider
 
-  alias Carrier.Messaging.Connection
+  alias Carrier.Messaging.ConnectionSup
   alias Carrier.Messaging.GenMqtt
   alias Cog.Chat.HipChat
 
@@ -64,7 +64,7 @@ defmodule Cog.Chat.HipChat.Provider do
     incoming = Keyword.fetch!(config, :incoming_topic)
     case HipChat.Connector.start_link(config) do
       {:ok, xmpp_conn} ->
-        {:ok, mbus} = Connection.connect()
+        {:ok, mbus} = ConnectionSup.connect()
         {:ok, %__MODULE__{incoming: incoming, mbus: mbus, xmpp: xmpp_conn}}
       error ->
         error

--- a/lib/cog/chat/http/provider.ex
+++ b/lib/cog/chat/http/provider.ex
@@ -2,7 +2,7 @@ defmodule Cog.Chat.Http.Provider do
   use GenServer
   use Cog.Chat.Provider
 
-  alias Carrier.Messaging.Connection
+  alias Carrier.Messaging.ConnectionSup
   alias Carrier.Messaging.GenMqtt
   alias Cog.Chat.Http.Connector
   alias Cog.Chat.Message
@@ -38,7 +38,7 @@ defmodule Cog.Chat.Http.Provider do
 
   def init(config) do
     incoming = Keyword.fetch!(config, :incoming_topic)
-    {:ok, mbus} = Connection.connect()
+    {:ok, mbus} = ConnectionSup.connect()
     {:ok, %__MODULE__{incoming: incoming, mbus: mbus}}
   end
 

--- a/lib/cog/chat/slack/provider.ex
+++ b/lib/cog/chat/slack/provider.ex
@@ -5,7 +5,7 @@ defmodule Cog.Chat.Slack.Provider do
   use GenServer
   use Cog.Chat.Provider
 
-  alias Carrier.Messaging.Connection
+  alias Carrier.Messaging.ConnectionSup
   alias Carrier.Messaging.GenMqtt
   alias Cog.Chat.Slack.Connector
   alias Greenbar.Renderers.SlackRenderer
@@ -71,7 +71,7 @@ defmodule Cog.Chat.Slack.Provider do
     else
       incoming = Keyword.fetch!(config, :incoming_topic)
 
-      {:ok, mbus} = Connection.connect()
+      {:ok, mbus} = ConnectionSup.connect()
       {:ok, pid} = Connector.start_link(token)
       {:ok, %__MODULE__{token: token, incoming: incoming, connector: pid, mbus: mbus}}
     end

--- a/lib/cog/command/gen_command.ex
+++ b/lib/cog/command/gen_command.ex
@@ -124,7 +124,7 @@ defmodule Cog.Command.GenCommand do
 
     # Establish a connection to the message bus and subscribe to
     # the appropriate topics
-    case Carrier.Messaging.Connection.connect do
+    case Carrier.Messaging.ConnectionSup.connect do
       {:ok, conn} ->
         relay_id = Cog.Config.embedded_relay()
         [topic, _reply_topic] = topics = [command_topic(bundle, command, relay_id),

--- a/lib/cog/command/pipeline/executor.ex
+++ b/lib/cog/command/pipeline/executor.ex
@@ -103,8 +103,7 @@ defmodule Cog.Command.Pipeline.Executor do
   require Logger
 
   def start_link(request) do
-    result = :gen_fsm.start_link(__MODULE__, [request], [])
-    result
+    :gen_fsm.start_link(__MODULE__, [request], [])
   end
 
   def init([%Cog.Messages.AdapterRequest{}=request]) do
@@ -628,8 +627,7 @@ defmodule Cog.Command.Pipeline.Executor do
 
   defp fetch_user_from_request(%Cog.Messages.AdapterRequest{}=request) do
     # TODO: This should happen when we validate the request
-    result = ChatAdapter.is_chat_provider?(request.adapter)
-    if result do
+    if ChatAdapter.is_chat_provider?(request.adapter) do
       adapter   = request.adapter
       sender_id = request.sender.id
       user = Queries.User.for_chat_provider_user_id(sender_id, adapter)

--- a/lib/cog/command/pipeline/initializer.ex
+++ b/lib/cog/command/pipeline/initializer.ex
@@ -10,6 +10,7 @@ defmodule Cog.Command.Pipeline.Initializer do
 
   require Logger
 
+  alias Carrier.Messaging.ConnectionSup
   alias Carrier.Messaging.Connection
   alias Cog.Command.ReplyHelper
   alias Cog.Command.Pipeline.ExecutorSup
@@ -26,7 +27,7 @@ defmodule Cog.Command.Pipeline.Initializer do
 
   def init(_) do
     previous_command_token = Application.get_env(:cog, :previous_command_token)
-    {:ok, conn} = Connection.connect()
+    {:ok, conn} = ConnectionSup.connect()
     Connection.subscribe(conn, "/bot/commands")
     Logger.info("Ready.")
     {:ok, %__MODULE__{mq_conn: conn, previous_command_token: previous_command_token}}

--- a/lib/cog/relay/info.ex
+++ b/lib/cog/relay/info.ex
@@ -17,7 +17,8 @@ defmodule Cog.Relay.Info do
   require Logger
   use GenServer
 
-  alias Carrier.Messaging
+  alias Carrier.Messaging.ConnectionSup
+  alias Carrier.Messaging.Connection
   alias Cog.Repo
   alias Cog.Models.Relay
   alias Cog.Repository.Bundles
@@ -28,10 +29,10 @@ defmodule Cog.Relay.Info do
   end
 
   def init(_) do
-    case Messaging.Connection.connect() do
+    case ConnectionSup.connect() do
       {:ok, conn} ->
         Logger.info("Starting relay information service")
-        Messaging.Connection.subscribe(conn, @relay_info_topic)
+        Connection.subscribe(conn, @relay_info_topic)
         {:ok, %__MODULE__{mq_conn: conn}}
       error ->
         Logger.error("Error starting relay info: #{inspect error}")
@@ -113,7 +114,7 @@ defmodule Cog.Relay.Info do
   end
 
   defp respond(payload, reply_to, state) do
-    Messaging.Connection.publish(state.mq_conn, payload, routed_by: reply_to)
+    Connection.publish(state.mq_conn, payload, routed_by: reply_to)
   end
 
   defp calculate_signature(configs) do

--- a/lib/cog/relay/relays.ex
+++ b/lib/cog/relay/relays.ex
@@ -8,7 +8,8 @@ defmodule Cog.Relay.Relays do
   require Logger
   use GenServer
 
-  alias Carrier.Messaging
+  alias Carrier.Messaging.ConnectionSup
+  alias Carrier.Messaging.Connection
   alias Cog.Models.Relay
   alias Cog.Repo
   alias Cog.Relay.Util
@@ -65,10 +66,10 @@ defmodule Cog.Relay.Relays do
     do: GenServer.call(__MODULE__, {:relays_running, bundle_name, version}, :infinity)
 
   def init(_) do
-    case Messaging.Connection.connect() do
+    case ConnectionSup.connect() do
       {:ok, conn} ->
         Logger.info("Starting")
-        Messaging.Connection.subscribe(conn, @relays_discovery_topic)
+        Connection.subscribe(conn, @relays_discovery_topic)
         # Seed RNG so picking relays at random works
         :rand.seed(:exsplus, :os.timestamp())
         {:ok, %__MODULE__{tracker: Tracker.new(), mq_conn: conn}}
@@ -155,7 +156,7 @@ defmodule Cog.Relay.Relays do
     announcement_id = announcement.announcement_id
     receipt = receipt(announcement_id, failed_bundles)
     Logger.debug("Sending receipt to #{reply_to}: #{inspect receipt}")
-    Messaging.Connection.publish(state.mq_conn, receipt, routed_by: reply_to)
+    Connection.publish(state.mq_conn, receipt, routed_by: reply_to)
 
     %{state | tracker: tracker}
   end

--- a/lib/cog/util/debug.ex
+++ b/lib/cog/util/debug.ex
@@ -6,7 +6,7 @@ defmodule Cog.Util.Debug do
 
   defmacro __using__(_) do
     quote do
-      import unquote(__MODULE__), only: [debug: 1]
+      import unquote(__MODULE__), only: [debug: 1, dump: 1]
     end
   end
 
@@ -19,6 +19,12 @@ defmodule Cog.Util.Debug do
     end
   end
 
+  defmacro dump(thing) do
+    quote do
+      debug(unquote(thing))
+      unquote(thing)
+    end
+  end
 
   defp format_file_name(name) do
     parts = String.split(name, "/")

--- a/test/carrier/messaging/tracker_test.exs
+++ b/test/carrier/messaging/tracker_test.exs
@@ -1,0 +1,91 @@
+defmodule Carrier.Messaging.TrackerTest do
+
+  use ExUnit.Case, async: true
+
+  alias Carrier.Messaging.Tracker
+
+  defp placeholder() do
+    spawn(fn() ->
+      receive do
+        _ ->
+          :ok
+      end end)
+  end
+
+  test "adding reply endpoint" do
+    p1 = placeholder()
+    tracker = %Tracker{}
+    {tracker, reply_topic} = Tracker.add_reply_endpoint(tracker, p1)
+    assert reply_topic != nil
+    assert reply_topic != ""
+    assert Tracker.find_reply_subscriber(tracker, reply_topic) == p1
+  end
+
+  test "adding subscription" do
+    p1 = placeholder()
+    tracker = %Tracker{}
+    tracker = Tracker.add_subscription(tracker, "foo/bar", p1)
+    assert Tracker.find_subscribers(tracker, "foo/bar") == [p1]
+  end
+
+  test "adding/removing subscriptions" do
+    p1 = placeholder()
+    tracker = %Tracker{}
+    tracker = Tracker.add_subscription(tracker, "foo/bar", p1)
+    {tracker, true} = Tracker.del_subscription(tracker, "foo/bar", p1)
+    assert Tracker.find_subscribers(tracker, "foo/bar") == []
+  end
+
+  test "multiple subscribers" do
+    p1 = placeholder()
+    p2 = placeholder()
+    tracker = %Tracker{}
+    tracker = Tracker.add_subscription(tracker, "foo/bar", p1)
+    tracker = Tracker.add_subscription(tracker, "foo/bar", p2)
+    subs = Tracker.find_subscribers(tracker, "foo/bar")
+    assert Enum.member?(subs, p1)
+    assert Enum.member?(subs, p2)
+    tracker = Tracker.del_subscriber(tracker, p1)
+    assert Tracker.find_subscribers(tracker, "foo/bar") == [p2]
+  end
+
+  test "single level wildcard subscriptions" do
+    p1 = placeholder()
+    tracker = %Tracker{}
+    tracker = Tracker.add_subscription(tracker, "foo/bar/+", p1)
+    assert Tracker.find_subscribers(tracker, "foo/bar/baz") == [p1]
+    assert Tracker.find_subscribers(tracker, "foo/bar/baz/quux") == []
+  end
+
+  test "multi level wildcard subscriptions" do
+    p1 = placeholder()
+    p2 = placeholder()
+    tracker = %Tracker{}
+    tracker = tracker
+              |> Tracker.add_subscription("foo/bar/+", p1)
+              |> Tracker.add_subscription("foo/bar/*", p2)
+    subs = Tracker.find_subscribers(tracker, "foo/bar/baz")
+    assert Enum.member?(subs, p1)
+    assert Enum.member?(subs, p2)
+    assert Tracker.find_subscribers(tracker, "foo/bar/baz/quux") == [p2]
+    assert Tracker.find_subscribers(tracker, "foo/ba/baz") == []
+  end
+
+  test "unused? predicate functions" do
+    p1 = placeholder()
+    {tracker, reply_endpoint} = %Tracker{}
+                   |> Tracker.add_subscription("foo/bar", p1)
+                   |> Tracker.add_reply_endpoint(p1)
+    refute Tracker.unused?(tracker)
+    {tracker1, _} = Tracker.del_subscription(tracker, "foo/bar", p1)
+    assert tracker != tracker1
+    refute Tracker.unused?(tracker1)
+    tracker2 = Tracker.del_subscriber(tracker1, p1)
+    assert tracker2 != tracker1
+    assert Tracker.unused?(tracker2)
+    {tracker3, unused_topics} = Tracker.get_and_reset_unused_topics(tracker2)
+    assert tracker3 != tracker2
+    assert Enum.sort(unused_topics) == [reply_endpoint, "foo/bar"]
+  end
+
+end

--- a/test/controllers/v1/bundle_version_controller_test.exs
+++ b/test/controllers/v1/bundle_version_controller_test.exs
@@ -58,28 +58,21 @@ defmodule Cog.V1.BundleVersionControllerTest do
 
     bundle_id = version.bundle.id
     version_id = version.id
-    assert %{"bundle_version" =>
-              %{"id" => ^version_id,
-                "bundle_id" => ^bundle_id,
-                "name" => "test-bundle",
-                "version" => "1.0.0",
-                "enabled" => true,
-                "inserted_at" => _,
-                "updated_at" => _,
-                "commands" => [
-                  %{"id" => _,
-                    "bundle" => "test-bundle",
-                    "name" => "bar",
-                    "description" => nil,
-                    "documentation" => "docs for bar"},
-                  %{"id" => _,
-                    "bundle" => "test-bundle",
-                    "name" => "foo",
-                    "description" => nil,
-                    "documentation" => "docs for foo"}],
-                "permissions" => [%{"id" => _,
-                                    "bundle" => "test-bundle",
-                                    "name" => "permission"}]}} = json_response(conn, 200)
+    %{"bundle_version" =>
+      %{"id" => ^version_id,
+        "bundle_id" => ^bundle_id,
+        "name" => "test-bundle",
+        "version" => "1.0.0",
+        "enabled" => true,
+        "inserted_at" => _,
+        "updated_at" => _,
+        "commands" => commands,
+        "permissions" => [%{"id" => _,
+                            "bundle" => "test-bundle",
+                            "name" => "permission"}]}} = json_response(conn, 200)
+    assert Enum.count(commands) == 2
+    command_names = [Map.get(Enum.at(commands, 0), "name"), Map.get(Enum.at(commands, 1), "name")]
+    assert command_names == ["bar", "foo"] or command_names == ["foo", "bar"]
   end
 
   test "cannot delete an enabled bundle version", %{authed: requestor} do

--- a/test/controllers/v1/bundle_version_controller_test.exs
+++ b/test/controllers/v1/bundle_version_controller_test.exs
@@ -70,9 +70,7 @@ defmodule Cog.V1.BundleVersionControllerTest do
         "permissions" => [%{"id" => _,
                             "bundle" => "test-bundle",
                             "name" => "permission"}]}} = json_response(conn, 200)
-    assert Enum.count(commands) == 2
-    command_names = [Map.get(Enum.at(commands, 0), "name"), Map.get(Enum.at(commands, 1), "name")]
-    assert command_names == ["bar", "foo"] or command_names == ["foo", "bar"]
+    assert ([Map.get(Enum.at(commands, 0), "name"), Map.get(Enum.at(commands, 1), "name")] |> Enum.sort) == ["bar", "foo"]
   end
 
   test "cannot delete an enabled bundle version", %{authed: requestor} do

--- a/test/support/fake_relay.ex
+++ b/test/support/fake_relay.ex
@@ -18,7 +18,7 @@ defmodule Cog.FakeRelay do
   containing the connections and the relay model.
   """
   def new(%Relay{}=relay) do
-    {:ok, conn} = Messaging.Connection.connect()
+    {:ok, conn} = Messaging.ConnectionSup.connect()
     %__MODULE__{conn: conn, relay: relay}
   end
 

--- a/test/support/snoop.ex
+++ b/test/support/snoop.ex
@@ -108,7 +108,7 @@ defmodule Cog.Snoop do
   # GenServer implementation details
 
   def init(topic) do
-    {:ok, mq_conn} = Connection.connect
+    {:ok, mq_conn} = Carrier.Messaging.ConnectionSup.connect()
     Connection.subscribe(mq_conn, topic)
     {:ok, %__MODULE__{mq_conn: mq_conn,
                       topic: topic,

--- a/test/support/test_provider.ex
+++ b/test/support/test_provider.ex
@@ -12,7 +12,7 @@ defmodule Cog.Chat.Test.Provider do
     do: GenServer.start_link(__MODULE__, args, name: __MODULE__)
 
   def init(config) do
-    {:ok, conn} = Carrier.Messaging.Connection.connect
+    {:ok, conn} = Carrier.Messaging.ConnectionSup.connect()
     incoming = Keyword.fetch!(config, :incoming_topic)
     {:ok, %__MODULE__{conn: conn, incoming: incoming}}
   end


### PR DESCRIPTION
Refactored `Carrier.Messaging.Connection` so multiple Erlang/Elixir processes can share
a single connection. The connection keeps track of subscribers and GenMqtt-style reply endpoints and ensures correct delivery of messages including support for `+` and `*` topic wildcards. `Connection` places monitors on all subscribing processes allowing it to clean up subscriptions after subscribers crash.

These changes are in preparation for the new executor design based on GenStage. Attempting to share a single connection between stages for the same pipeline didn't integrate well with GenMqtt causing Cog to use transient MQTT connections and incurring a small, but noticeable,
performance penalty.

Centralizing connection sharing logic in the connection itself resolves all previous problems and results in a more testable design compared to my earlier attempts at layering multiplexing on top of `Connection`.