### PR TITLE
cog info command

### DIFF
--- a/lib/cog/commands/info.ex
+++ b/lib/cog/commands/info.ex
@@ -1,0 +1,19 @@
+defmodule Cog.Commands.Info do
+  use Cog.Command.GenCommand.Base,
+    bundle: Cog.Util.Misc.embedded_bundle
+
+  @description "Display information about the current running instance of Cog"
+
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:info allow"
+
+  def handle_message(req, state) do
+    info = %{
+      cog_version: Keyword.get(Mix.Project.config(), :version),
+      elixir_version: System.build_info().version,
+      embedded_bundle_version: Application.fetch_env!(:cog, :embedded_bundle_version),
+      bundle_config_version: Spanner.Config.current_config_version()
+    }
+
+    {:reply, req.reply_to, "info", info, state}
+  end
+end

--- a/lib/cog/commands/info.ex
+++ b/lib/cog/commands/info.ex
@@ -2,7 +2,18 @@ defmodule Cog.Commands.Info do
   use Cog.Command.GenCommand.Base,
     bundle: Cog.Util.Misc.embedded_bundle
 
-  @description "Display information about the current running instance of Cog"
+  @description "Display information about the current running instance of Cog."
+
+  @output_example """
+  [
+    {
+      "embedded_bundle_version": "0.18.0",
+      "elixir_version": "1.3.4",
+      "cog_version": "0.18.0",
+      "bundle_config_version": 5
+    }
+  ]
+  """
 
   rule "when command is #{Cog.Util.Misc.embedded_bundle}:info allow"
 

--- a/priv/templates/embedded/info.greenbar
+++ b/priv/templates/embedded/info.greenbar
@@ -1,0 +1,9 @@
+~each var=$results as=info~
+**Cog System Information**
+~attachment color="blue"~
+**Cog Version:** ~$info.cog_version~
+**Embedded Bundle Version:** ~$info.embedded_bundle_version~
+**Bundle Config Version:** ~$info.bundle_config_version~
+**Elixir Version:** ~$info.elixir_version~
+~end~
+~end~

--- a/test/cog/chat/hipchat/templates/embedded/info_test.exs
+++ b/test/cog/chat/hipchat/templates/embedded/info_test.exs
@@ -1,0 +1,21 @@
+defmodule Cog.Chat.HipChat.Templates.Embedded.InfoTest do
+  use Cog.TemplateCase
+
+  test "info template" do
+    data = %{"results" => [%{"embedded_bundle_version" => "0.18.0",
+                             "elixir_version" => "1.3.4",
+                             "cog_version" => "0.18.0",
+                             "bundle_config_version" => 5}]}
+
+    expected = """
+    <strong>Cog System Information</strong><br/>\
+    <br/>\
+    <strong>Cog Version:</strong> 0.18.0<br/>\
+    <strong>Embedded Bundle Version:</strong> 0.18.0<br/>\
+    <strong>Bundle Config Version:</strong> 5<br/>\
+    <strong>Elixir Version:</strong> 1.3.4
+    """ |> String.strip
+
+    assert_rendered_template(:hipchat, :embedded, "info", data, expected)
+  end
+end

--- a/test/cog/chat/slack/templates/embedded/info_test.exs
+++ b/test/cog/chat/slack/templates/embedded/info_test.exs
@@ -1,0 +1,23 @@
+defmodule Cog.Chat.Slack.Templates.Embedded.InfoTest do
+  use Cog.TemplateCase
+
+  test "info template" do
+    data = %{"results" => [%{"embedded_bundle_version" => "0.18.0",
+                             "elixir_version" => "1.3.4",
+                             "cog_version" => "0.18.0",
+                             "bundle_config_version" => 5}]}
+
+    expected = """
+    *Cog System Information*
+    """ |> String.strip
+
+    attachment = ["""
+    *Cog Version:* 0.18.0
+    *Embedded Bundle Version:* 0.18.0
+    *Bundle Config Version:* 5
+    *Elixir Version:* 1.3.4
+    """] |> Enum.map(&String.strip/1)
+
+    assert_rendered_template(:slack, :embedded, "info", data, {expected, attachment})
+  end
+end


### PR DESCRIPTION
Adds a simple info command for cog

<img width="454" alt="screen shot 2017-01-05 at 5 14 05 pm" src="https://cloud.githubusercontent.com/assets/47858/21699571/69d8dec2-d36a-11e6-8c69-901be32f624d.png">

resolves #1284 