### PR TITLE
Remove subcommands from codebase

### DIFF
--- a/lib/cog/bundle/config.ex
+++ b/lib/cog/bundle/config.ex
@@ -97,7 +97,6 @@ defmodule Cog.Bundle.Config do
         "examples" => GenCommand.Base.examples(module),
         "notes" => GenCommand.Base.notes(module),
         "arguments" => GenCommand.Base.arguments(module),
-        "subcommands" => GenCommand.Base.subcommands(module),
         "output" => GenCommand.Base.output(module),
         "documentation" => case Code.get_docs(module, :moduledoc) do
                              {_line, doc} ->

--- a/lib/cog/command/gen_command/base.ex
+++ b/lib/cog/command/gen_command/base.ex
@@ -134,7 +134,6 @@ defmodule Cog.Command.GenCommand.Base do
       Module.register_attribute(__MODULE__, :examples, accumulate: false, persist: true)
       Module.register_attribute(__MODULE__, :notes, accumulate: false, persist: true)
       Module.register_attribute(__MODULE__, :arguments, accumulate: false, persist: true)
-      Module.register_attribute(__MODULE__, :subcommands, accumulate: false, persist: true)
       Module.register_attribute(__MODULE__, :options, accumulate: true, persist: true)
       Module.register_attribute(__MODULE__, :permissions, accumulate: true, persist: true)
       Module.register_attribute(__MODULE__, :raw_rules, accumulate: true, persist: false)
@@ -180,7 +179,7 @@ defmodule Cog.Command.GenCommand.Base do
     attr_value(module, :command_name)
   end
 
-  for attr <- [:description, :long_description, :examples, :notes, :arguments, :subcommands, :output_description, :output_example] do
+  for attr <- [:description, :long_description, :examples, :notes, :arguments, :output_description, :output_example] do
     def unquote(attr)(module),
       do: attr_value(module, unquote(attr))
   end

--- a/lib/cog/commands/help.ex
+++ b/lib/cog/commands/help.ex
@@ -38,7 +38,6 @@ defmodule Cog.Commands.Help do
   @output_example """
   {
     "synopsis": "operable:raw",
-    "subcommands": [],
     "required_options": [],
     "output": {},
     "options": [],

--- a/lib/cog/commands/helpers.ex
+++ b/lib/cog/commands/helpers.ex
@@ -41,15 +41,6 @@ defmodule Cog.Commands.Helpers do
   end
 
   @doc """
-  Returns a tuple containing the subcommand and remaining args
-  """
-  @spec get_subcommand(List.t) :: {String.t, List.t}
-  def get_subcommand([]),
-    do: {nil, []}
-  def get_subcommand([subcommand | args]),
-    do: {subcommand, args}
-
-  @doc """
   If flag exists and is true will return true, otherwise returns false. Flags
   are defined as boolean options. Options that are not.
   """
@@ -123,10 +114,6 @@ defmodule Cog.Commands.Helpers do
     do: "Invalid alias name. Only emoji, letters, numbers, and the following special characters are allowed: *, -, _"
   def error(:too_many_wildcards),
     do: "Too many wildcards. You can only include one wildcard in a query"
-  def error(:no_subcommand),
-    do: "I don't what to do, please specify a subcommand"
-  def error({:unknown_subcommand, subcommand}),
-    do: "Unknown subcommand '#{subcommand}'"
   def error({:resource_not_found, "rule", id}),
     do: "Could not find 'rule' with the id '#{id}'"
   def error({:resource_not_found, resource_type, resource_name}),

--- a/lib/cog/models/command_version.ex
+++ b/lib/cog/models/command_version.ex
@@ -14,7 +14,6 @@ defmodule Cog.Models.CommandVersion do
     field :examples, :string
     field :notes, :string
     field :arguments, :string
-    field :subcommands, :map
     field :documentation, :string
     field :output, :map
     field :status, :string, virtual: true
@@ -28,7 +27,7 @@ defmodule Cog.Models.CommandVersion do
   end
 
   @required_fields ~w(command_id bundle_version_id)
-  @optional_fields ~w(description documentation long_description examples notes arguments subcommands output)
+  @optional_fields ~w(description documentation long_description examples notes arguments output)
 
   summary_fields [:documentation]
   detail_fields [:documentation]

--- a/mix.lock
+++ b/mix.lock
@@ -60,7 +60,7 @@
   "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []},
   "romeo": {:git, "https://github.com/operable/romeo.git", "65106b94f134a12791ec63fa284b0ce5e9358538", [branch: "iq-bodies"]},
   "slack": {:git, "https://github.com/operable/Elixir-Slack.git", "4d6a3c4036ec4129e8d77e55cd1d3e62093cc001", []},
-  "spanner": {:git, "https://github.com/operable/spanner.git", "57df53144d9c9bf589bbaf60014840be2aa57a6d", []},
+  "spanner": {:git, "https://github.com/operable/spanner.git", "fca6da5bfe738de87f1027e93677ba971c787110", []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
   "table_rex": {:hex, :table_rex, "0.8.3", "1c68dfc6886d6f118f5047b0449d6402ae0ac5709064789e578c2f4659f4064b", [:mix], []},
   "uuid": {:hex, :uuid, "1.1.5", "96cb36d86ee82f912efea4d50464a5df606bf3f1163d6bdbb302d98474969369", [], []},

--- a/priv/repo/migrations/20170106205545_remove_subcommands_from_command_versions.exs
+++ b/priv/repo/migrations/20170106205545_remove_subcommands_from_command_versions.exs
@@ -1,0 +1,9 @@
+defmodule Cog.Repo.Migrations.RemoveSubcommandsFromCommandVersions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:command_versions) do
+      remove :subcommands
+    end
+  end
+end

--- a/priv/templates/embedded/help-command.greenbar
+++ b/priv/templates/embedded/help-command.greenbar
@@ -46,16 +46,6 @@ __Options__
 ~br~
 ~end~
 
-~if cond=$command.subcommands not_empty?~
-__Subcommands__
-~br~
-~each var=$command.subcommands as=subcommand~
-* ~$subcommand.command~ - ~$subcommand.description~
-
-~end~
-~br~
-~end~
-
 ~if cond=$command.examples~
 __Examples__
 ~br~

--- a/web/views/command_version_help_view.ex
+++ b/web/views/command_version_help_view.ex
@@ -10,7 +10,6 @@ defmodule Cog.CommandVersionHelpView do
       synopsis: render_synopsis(command_version),
       required_options: render_required_options(command_version),
       options: render_options(command_version),
-      subcommands: render_subcommands(command_version),
       examples: command_version.examples,
       notes: command_version.notes,
       output: render_output(command_version),
@@ -94,15 +93,6 @@ defmodule Cog.CommandVersionHelpView do
     do: "--#{long_flag}"
   defp render_long_flag(%CommandOption{long_flag: long_flag, name: name}),
     do: "--#{long_flag} <#{name}>"
-
-  def render_subcommands(%CommandVersion{subcommands: nil}),
-    do: []
-  def render_subcommands(%CommandVersion{subcommands: subcommands}) do
-    Enum.map(subcommands, fn {command, description} ->
-      %{command: command,
-        description: description}
-    end)
-  end
 
   def render_output(%CommandVersion{output: output}) do
     %{description: output["description"],


### PR DESCRIPTION
Subcommands are still present in the v4 bundle configs (which can still be installed) but they will no longer be shown in the help documentation or otherwise supported. They have been completely removed from v5 bundle configs.

https://github.com/operable/cog/issues/1204