### PR TITLE
Handle exited connection owners

### DIFF
--- a/lib/carrier/messaging/connection.ex
+++ b/lib/carrier/messaging/connection.ex
@@ -144,7 +144,7 @@ defmodule Carrier.Messaging.Connection do
         try do
           Process.link(owner)
         rescue
-          e ->
+          e in ErlangError ->
             Logger.error("Linking to owner process failed: #{Exception.message(e)}")
             {:stop, :failed_owner_link}
         end

--- a/lib/carrier/messaging/connection.ex
+++ b/lib/carrier/messaging/connection.ex
@@ -138,7 +138,16 @@ defmodule Carrier.Messaging.Connection do
     # If we don't connect after a specified timeout, we just fail.
     receive do
       {:mqttc, ^conn, :connected} ->
-        Process.link(owner)
+        # Detect when the connection owner has exited before the connection
+        # is fully setup and exit. Prevents long stack traces from polluting
+        # log output.
+        try do
+          Process.link(owner)
+        rescue
+          e ->
+            Logger.error("Linking to owner process failed: #{Exception.message(e)}")
+            {:stop, :failed_owner_link}
+        end
         {:ok, %__MODULE__{conn: conn,
                           owner: owner,
                           tracker: %Tracker{}}}


### PR DESCRIPTION
Wraps logic creating link between `Connection` and its owning process with a `try/rescue` block. Detects when the owner process has exited before the connection is fully set up.

Prevents long stacktraces from polluting Cog's log output. I noticed this happening over the weekend when Slack integration tests run.