### PR TITLE
Compress all mqtt traffic with snappy

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -75,6 +75,7 @@ defmodule Cog.Mixfile do
       # Used by cowboy, emqttd, esockd... they don't seem to lock to a
       # particular version, though.
       {:gproc, "~> 0.5.0", override: true},
+      {:snappy, github: "fdmanana/snappy-erlang-nif"},
 
       # Logging
       ########################################################################

--- a/mix.lock
+++ b/mix.lock
@@ -60,6 +60,7 @@
   "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []},
   "romeo": {:git, "https://github.com/operable/romeo.git", "65106b94f134a12791ec63fa284b0ce5e9358538", [branch: "iq-bodies"]},
   "slack": {:git, "https://github.com/operable/Elixir-Slack.git", "4d6a3c4036ec4129e8d77e55cd1d3e62093cc001", []},
+  "snappy": {:git, "https://github.com/fdmanana/snappy-erlang-nif.git", "0951a1bf8e58141b3c439bebe1f2992688298631", []},
   "spanner": {:git, "https://github.com/operable/spanner.git", "fca6da5bfe738de87f1027e93677ba971c787110", []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
   "table_rex": {:hex, :table_rex, "0.8.3", "1c68dfc6886d6f118f5047b0449d6402ae0ac5709064789e578c2f4659f4064b", [:mix], []},


### PR DESCRIPTION
Companion PR: https://github.com/operable/go-relay/pull/68

Fixes https://github.com/operable/cog/issues/874