### PR TITLE
Protect the last user in the cog-admin group

### DIFF
--- a/lib/cog/models/user.ex
+++ b/lib/cog/models/user.ex
@@ -136,8 +136,8 @@ defimpl Groupable, for: Cog.Models.User do
         case error do
           # Handle exception from protected_admin_group_memberships trigger
           %Postgrex.Error{postgres: %{code: :raise_exception,
-                                      message: "cannot remove admin user from cog-admin group"}} ->
-            {:error, :cannot_remove_admin_user}
+                                      message: "cannot remove last user from cog-admin group"}} ->
+            {:error, :cannot_remove_last_admin_user}
         end
     end
   end

--- a/priv/repo/migrations/20170118183141_protect_last_admin_group_membership.exs
+++ b/priv/repo/migrations/20170118183141_protect_last_admin_group_membership.exs
@@ -1,0 +1,89 @@
+defmodule Cog.Repo.Migrations.ProtectLastAdminGroupMembership do
+  use Ecto.Migration
+
+  def up do
+    execute """
+    DROP TRIGGER protect_admin_group_membership ON user_group_membership;
+    """
+
+    execute """
+    DROP FUNCTION protect_admin_group_membership();
+    """
+
+    execute """
+    CREATE OR REPLACE FUNCTION protect_admin_group_membership()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+    AS $$
+    DECLARE
+      cog_admin_membership_count int;
+      cog_admin_group_id         uuid;
+    BEGIN
+      SELECT id INTO cog_admin_group_id
+      FROM groups
+      WHERE name = 'cog-admin';
+
+      SELECT count(*) INTO cog_admin_membership_count
+      FROM user_group_membership
+      WHERE group_id = cog_admin_group_id;
+
+      IF OLD.group_id = cog_admin_group_id AND cog_admin_membership_count = 0 THEN
+        RAISE EXCEPTION 'cannot remove last user from cog-admin group';
+      END IF;
+      RETURN NULL;
+    END;
+    $$;
+    """
+
+    execute """
+    CREATE CONSTRAINT TRIGGER protect_admin_group_membership
+    AFTER UPDATE OR DELETE
+    ON user_group_membership
+    FOR EACH ROW
+    EXECUTE PROCEDURE protect_admin_group_membership();
+    """
+  end
+
+  def down do
+    execute """
+    DROP TRIGGER protect_admin_group_membership ON user_group_membership;
+    """
+
+    execute """
+    DROP FUNCTION protect_admin_group_membership();
+    """
+
+    execute """
+    CREATE OR REPLACE FUNCTION protect_admin_group_membership()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+    AS $$
+    DECLARE
+      admin_member_id     uuid;
+      cog_admin_group_id  uuid;
+    BEGIN
+      SELECT id INTO admin_member_id
+      FROM users
+      WHERE username = 'admin';
+
+      SELECT id INTO cog_admin_group_id
+      FROM groups
+      WHERE name = 'cog-admin';
+
+      IF OLD.member_id = admin_member_id AND OLD.group_id = cog_admin_group_id THEN
+        RAISE EXCEPTION 'cannot remove admin user from cog-admin group';
+      END IF;
+      RETURN NULL;
+    END;
+    $$;
+    """
+
+    execute """
+    CREATE CONSTRAINT TRIGGER protect_admin_group_membership
+    AFTER UPDATE OR DELETE
+    ON user_group_membership
+    FOR EACH ROW
+    EXECUTE PROCEDURE protect_admin_group_membership();
+    """
+  end
+end

--- a/test/controllers/v1/group_membership_controller_test.exs
+++ b/test/controllers/v1/group_membership_controller_test.exs
@@ -287,4 +287,17 @@ defmodule Cog.V1.GroupMembershipController.Test do
                       "email_address" => bender.email_address}
 
   end
+
+  test "fails when removing the last user from the cog-admin group", %{authed: requestor} do
+    group = group("cog-admin")
+    user = user("admin")
+    Groupable.add_to(user, group)
+
+    conn = api_request(requestor, :post, "/v1/groups/#{group.id}/users",
+                       body: %{"users" => %{"remove" => [user.username]}})
+
+    assert json_response(conn, 422) == %{"errors" => "The cog-admin group must have at least one member"}
+
+    assert [user] == Repo.all(Ecto.assoc(group, :users))
+  end
 end

--- a/web/controllers/v1/group_membership_controller.ex
+++ b/web/controllers/v1/group_membership_controller.ex
@@ -30,10 +30,10 @@ defmodule Cog.V1.GroupMembershipController do
         conn
         |> put_status(:unprocessable_entity)
         |> json(%{"errors" => %{"not_found" => %{key => names}}})
-      {:error, :cannot_remove_admin_user} ->
+      {:error, :cannot_remove_last_admin_user} ->
         conn
         |> put_status(:unprocessable_entity)
-        |> json(%{errors: "The admin user cannot be removed from the cog-admin group"})
+        |> json(%{errors: "The cog-admin group must have at least one member"})
     end
   end
 


### PR DESCRIPTION
Now that the admin user can have any username, change our cog-admin
group protection trigger to prohibit removing the last member rather
than specifically checking for the "admin" username.