### PR TITLE
Threads

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -36,8 +36,7 @@ config :cog, :embedded_bundle_version, "0.18.0"
 # Chat Adapters
 # ========================================================================
 
-config :cog, Cog.Chat.Http.Provider,
-  foo: "blah"
+config :cog, Cog.Chat.Http.Provider, []
 
 config :cog, Cog.Chat.Adapter,
   providers: provider_list(),

--- a/config/slack.exs
+++ b/config/slack.exs
@@ -1,4 +1,6 @@
 use Mix.Config
+import Cog.Config.Helpers
 
 config :cog, Cog.Chat.Slack.Provider,
-  api_token: System.get_env("SLACK_API_TOKEN")
+  api_token: System.get_env("SLACK_API_TOKEN"),
+  enable_threaded_response: ensure_boolean(System.get_env("SLACK_ENABLE_THREADED_RESPONSES"))

--- a/lib/cog/chat/adapter.ex
+++ b/lib/cog/chat/adapter.ex
@@ -228,6 +228,13 @@ defmodule Cog.Chat.Adapter do
                                                     "message" => message,
                                                     "provider" => provider,
                                                     "metadata" => metadata}, state) do
+    metadata = case Cog.Chat.MessageMetadata.from_map(metadata) do
+      {:ok, metadata} ->
+        metadata
+      _error ->
+        %Cog.Chat.MessageMetadata{}
+    end
+
     case with_provider(provider, state, :send_message, [target, message, metadata]) do
       :ok ->
         :ok
@@ -236,6 +243,7 @@ defmodule Cog.Chat.Adapter do
       {:error, reason} ->
         Logger.error("Failed to send message to provider #{provider}: #{inspect reason, pretty: true}")
     end
+
     {:noreply, state}
   end
   def handle_cast(_conn, @incoming_topic, "event", event, state) do

--- a/lib/cog/chat/adapter.ex
+++ b/lib/cog/chat/adapter.ex
@@ -228,10 +228,15 @@ defmodule Cog.Chat.Adapter do
                                                     "message" => message,
                                                     "provider" => provider,
                                                     "metadata" => metadata}, state) do
-    metadata = case Cog.Chat.MessageMetadata.from_map(metadata) do
-      {:ok, metadata} ->
-        metadata
-      _error ->
+    metadata = case metadata do
+      map when is_map(map) ->
+        case Cog.Chat.MessageMetadata.from_map(metadata) do
+          {:ok, metadata} ->
+            metadata
+          _error ->
+          %Cog.Chat.MessageMetadata{}
+        end
+      _ ->
         %Cog.Chat.MessageMetadata{}
     end
 

--- a/lib/cog/chat/adapter.ex
+++ b/lib/cog/chat/adapter.ex
@@ -233,10 +233,12 @@ defmodule Cog.Chat.Adapter do
         case Cog.Chat.MessageMetadata.from_map(metadata) do
           {:ok, metadata} ->
             metadata
-          _error ->
-          %Cog.Chat.MessageMetadata{}
+          error ->
+            Logger.error("Failed to decode message metadata, continuing with an empty struct: #{inspect error}")
+            %Cog.Chat.MessageMetadata{}
         end
       _ ->
+        Logger.error("Expected message metadata to be a map, continuing with an empty struct.")
         %Cog.Chat.MessageMetadata{}
     end
 

--- a/lib/cog/chat/adapter.ex
+++ b/lib/cog/chat/adapter.ex
@@ -262,7 +262,7 @@ defmodule Cog.Chat.Adapter do
                   {true, text} ->
                     if message.edited == true do
                       mention_name = with_provider(message.provider, state, :mention_name, [message.user.handle])
-                      send(conn, message.provider, message.room, "#{mention_name} Executing edited command '#{text}'")
+                      send(conn, message.provider, message.room, "#{mention_name} Executing edited command '#{text}'", %Cog.Chat.MessageMetadata{})
                     end
                     request = %ProviderRequest{
                       text: text, sender: message.user, room: message.room,
@@ -285,7 +285,7 @@ defmodule Cog.Chat.Adapter do
               {:ok, message} ->
                 if message.edited == true do
                   mention_name = with_provider(message.provider, state, :mention_name, [message.user.handle])
-                  send(conn, message.provider, message.room, "#{mention_name} Executing edited command '#{message.text}'")
+                  send(conn, message.provider, message.room, "#{mention_name} Executing edited command '#{message.text}'", %Cog.Chat.MessageMetadata{})
                 end
                 request = %ProviderRequest{text: message.text, sender: message.user, room: message.room, reply: "", id: message.id,
                                            provider: message.provider, initial_context: message.initial_context || %{}}

--- a/lib/cog/chat/hipchat/connector.ex
+++ b/lib/cog/chat/hipchat/connector.ex
@@ -128,7 +128,7 @@ defmodule Cog.Chat.HipChat.Connector do
   def handle_call(:list_joined_rooms, _from, state) do
     {:reply, {:ok, Rooms.all(state.rooms)}, state}
   end
-  def handle_call({:send_message, target, message}, _from, state) do
+  def handle_call({:send_message, target, message, _metadata}, _from, state) do
     send_output(state, target, HipChatRenderer.render(message))
   end
 

--- a/lib/cog/chat/hipchat/provider.ex
+++ b/lib/cog/chat/hipchat/provider.ex
@@ -47,8 +47,8 @@ defmodule Cog.Chat.HipChat.Provider do
     GenServer.call(__MODULE__, {:call_connector, :list_joined_rooms}, :infinity)
   end
 
-  def send_message(target, message) do
-    GenServer.call(__MODULE__, {:call_connector, {:send_message, target, message}}, :infinity)
+  def send_message(target, message, metadata) do
+    GenServer.call(__MODULE__, {:call_connector, {:send_message, target, message, metadata}}, :infinity)
   end
 
   def start_link(config) do

--- a/lib/cog/chat/http/connector.ex
+++ b/lib/cog/chat/http/connector.ex
@@ -21,8 +21,8 @@ defmodule Cog.Chat.Http.Connector do
     end
   end
 
-  def finish_request(room, response),
-    do: GenServer.call(__MODULE__, {:finish_request, room, response})
+  def finish_request(room, response, metadata),
+    do: GenServer.call(__MODULE__, {:finish_request, room, response, metadata})
 
   ########################################################################
 
@@ -34,7 +34,7 @@ defmodule Cog.Chat.Http.Connector do
     GenServer.cast(Provider, {:pipeline, requestor, id, initial_context, pipeline})
     {:noreply, Map.put(state, id, from)}
   end
-  def handle_call({:finish_request, room_id, response}, _from, state) do
+  def handle_call({:finish_request, room_id, response, _metadata}, _from, state) do
     case Map.fetch(state, room_id) do
       {:ok, requestor} ->
         GenServer.reply(requestor, response)

--- a/lib/cog/chat/http/provider.ex
+++ b/lib/cog/chat/http/provider.ex
@@ -20,8 +20,8 @@ defmodule Cog.Chat.Http.Provider do
   ########################################################################
   # Provider Implementation
 
-  def send_message(room, response),
-    do: Connector.finish_request(room, response)
+  def send_message(room, response, metadata),
+    do: Connector.finish_request(room, response, metadata)
 
   def lookup_room(_room),
     do: {:error, :not_found}

--- a/lib/cog/chat/message.ex
+++ b/lib/cog/chat/message.ex
@@ -10,5 +10,6 @@ defmodule Cog.Chat.Message do
   field :edited, :bool, required: false
   field :initial_context, :map, required: false
   field :bot_name, :string, required: false
+  field :metadata, [object: Cog.Chat.MessageMetadata], required: false
 
 end

--- a/lib/cog/chat/message_metadata.ex
+++ b/lib/cog/chat/message_metadata.ex
@@ -1,3 +1,6 @@
+# Currently only used to render Slack threads, but is intended to be used to
+# store information about the original message used in rendering and sending
+# the response.
 defmodule Cog.Chat.MessageMetadata do
   use Conduit
 

--- a/lib/cog/chat/message_metadata.ex
+++ b/lib/cog/chat/message_metadata.ex
@@ -2,4 +2,5 @@ defmodule Cog.Chat.MessageMetadata do
   use Conduit
 
   field :thread_id, :string, required: false
+  field :originating_room_id, :string, required: false
 end

--- a/lib/cog/chat/message_metadata.ex
+++ b/lib/cog/chat/message_metadata.ex
@@ -1,0 +1,5 @@
+defmodule Cog.Chat.MessageMetadata do
+  use Conduit
+
+  field :thread_id, :string, required: false
+end

--- a/lib/cog/chat/provider.ex
+++ b/lib/cog/chat/provider.ex
@@ -21,7 +21,7 @@ defmodule Cog.Chat.Provider do
 
   @callback leave(room :: String.t) :: :ok | {:error, term}
 
-  @callback send_message(target :: String.t, message :: String.t | List.t, metadata :: Map.t) :: :ok | {:ok, sent_message ::String.t} | {:error, term}
+  @callback send_message(target :: String.t, message :: String.t | List.t, metadata :: Cog.Chat.MessageMetadata.t) :: :ok | {:ok, sent_message ::String.t} | {:error, term}
 
   @callback mention_name(handle :: String.t) :: String.t
 

--- a/lib/cog/chat/provider.ex
+++ b/lib/cog/chat/provider.ex
@@ -21,7 +21,7 @@ defmodule Cog.Chat.Provider do
 
   @callback leave(room :: String.t) :: :ok | {:error, term}
 
-  @callback send_message(target :: String.t, message :: String.t | List.t) :: :ok | {:ok, sent_message ::String.t} | {:error, term}
+  @callback send_message(target :: String.t, message :: String.t | List.t, metadata :: Map.t) :: :ok | {:ok, sent_message ::String.t} | {:error, term}
 
   @callback mention_name(handle :: String.t) :: String.t
 
@@ -39,7 +39,7 @@ defmodule Cog.Chat.Provider do
       def list_joined_rooms, do: {:error, :not_implemented}
       def join(_room), do: {:error, :not_implemented}
       def leave(_room), do: {:error, :not_implemented}
-      def send_message(_target, _message), do: {:error, :not_implemented}
+      def send_message(_target, _message, _metadata), do: {:error, :not_implemented}
 
       # TODO: Need to look into how useful this is... the new Slack
       # provider at least seems to not end up interpreting this as a
@@ -58,7 +58,7 @@ defmodule Cog.Chat.Provider do
                       list_joined_rooms: 0,
                       join: 1,
                       leave: 1,
-                      send_message: 2,
+                      send_message: 3,
                       mention_name: 1,
                       display_name: 0]
     end

--- a/lib/cog/chat/slack/connector.ex
+++ b/lib/cog/chat/slack/connector.ex
@@ -363,7 +363,8 @@ defmodule Cog.Chat.Slack.Connector do
     end
   end
 
-  def maybe_include_thread_attributes(message, %MessageMetadata{thread_id: thread_id}),
+  def maybe_include_thread_attributes(message, %MessageMetadata{thread_id: thread_id})
+      when is_binary(thread_id),
     do: Map.merge(message, %{thread_ts: thread_id, reply_broadcast: true})
   def maybe_include_thread_attributes(message, _metadata),
     do: message

--- a/lib/cog/chat/slack/connector.ex
+++ b/lib/cog/chat/slack/connector.ex
@@ -301,7 +301,7 @@ defmodule Cog.Chat.Slack.Connector do
         else
           {:chat_message, %Message{id: Cog.Events.Util.unique_id, room: room,
               user: user, text: text, provider: @provider_name,
-              metadata: %MessageMetadata{thread_id: ts},
+              metadata: %MessageMetadata{thread_id: ts, originating_room_id: room.id},
               bot_name: "@#{state.me.name}", edited: false}}
         end
     end

--- a/lib/cog/chat/slack/connector.ex
+++ b/lib/cog/chat/slack/connector.ex
@@ -2,7 +2,7 @@ defmodule Cog.Chat.Slack.Connector do
   require Logger
   use Slack
 
-  alias Cog.Chat.Message
+  alias Cog.Chat.{Message, MessageMetadata}
   alias Cog.Chat.Room
   alias Cog.Chat.Slack.Formatter
   alias Cog.Chat.Slack.Provider
@@ -85,11 +85,11 @@ defmodule Cog.Chat.Slack.Connector do
     send(sender, {ref, result})
     :ok
   end
-  def handle_info({{ref, sender}, {:send_message, %{token: token, target: target}=args}}, _state) do
-    message = %{token: token, as_user: true}
+  def handle_info({{ref, sender}, {:send_message, %{token: token, target: target, metadata: metadata}=args}}, _state) do
+    message = %{token: token, as_user: true, link_names: 1}
               |> prepare_text(args)
               |> prepare_attachments(args)
-              |> Map.put(:link_names, 1)
+              |> maybe_include_thread_attributes(metadata)
     # Avoids Slack throttling
     jitter()
     result = Slack.Web.Chat.post_message(target, message)
@@ -278,7 +278,7 @@ defmodule Cog.Chat.Slack.Connector do
   end
   defp annotate(_, _), do: :ignore
 
-  defp annotate_message(%{channel: channel, user: userid, text: text}, state) do
+  defp annotate_message(%{channel: channel, user: userid, text: text, ts: ts}, state) do
     text = Formatter.unescape(text, state)
 
     case lookup_user(userid, state.users, by: :id) do
@@ -299,8 +299,9 @@ defmodule Cog.Chat.Slack.Connector do
           Logger.info("Failed looking up channel '#{channel}'.")
           :ignore
         else
-          {:chat_message, %Message{id: Cog.Events.Util.unique_id,
-              room: room, user: user, text: text, provider: @provider_name,
+          {:chat_message, %Message{id: Cog.Events.Util.unique_id, room: room,
+              user: user, text: text, provider: @provider_name,
+              metadata: %MessageMetadata{thread_id: ts},
               bot_name: "@#{state.me.name}", edited: false}}
         end
     end
@@ -362,4 +363,8 @@ defmodule Cog.Chat.Slack.Connector do
     end
   end
 
+  def maybe_include_thread_attributes(message, %MessageMetadata{thread_id: thread_id}),
+    do: Map.merge(message, %{thread_ts: thread_id, reply_broadcast: true})
+  def maybe_include_thread_attributes(message, _metadata),
+    do: message
 end

--- a/lib/cog/chat/slack/provider.ex
+++ b/lib/cog/chat/slack/provider.ex
@@ -55,8 +55,8 @@ defmodule Cog.Chat.Slack.Provider do
     GenServer.call(__MODULE__, {:leave, room}, :infinity)
   end
 
-  def send_message(target, message) do
-    GenServer.call(__MODULE__, {:send_message, target, message}, :infinity)
+  def send_message(target, message, metadata) do
+    GenServer.call(__MODULE__, {:send_message, target, message, metadata}, :infinity)
   end
 
   def init([config]) do
@@ -114,8 +114,8 @@ defmodule Cog.Chat.Slack.Provider do
     end
   end
   # Old template processing
-  def handle_call({:send_message, target, message}, _from, %__MODULE__{connector: connector, token: token}=state) when is_binary(message) do
-    result = Connector.call(connector, token, :send_message, %{target: target, message: message})
+  def handle_call({:send_message, target, message, metadata}, _from, %__MODULE__{connector: connector, token: token}=state) when is_binary(message) do
+    result = Connector.call(connector, token, :send_message, %{target: target, message: message, metadata: metadata})
     case result["ok"] do
       true ->
         {:reply, :ok, state}
@@ -124,9 +124,9 @@ defmodule Cog.Chat.Slack.Provider do
     end
   end
   # New template processing
-  def handle_call({:send_message, target, message}, _from, %__MODULE__{connector: connector, token: token}=state) do
+  def handle_call({:send_message, target, message, metadata}, _from, %__MODULE__{connector: connector, token: token}=state) do
     {text, attachments} = SlackRenderer.render(message)
-    result = Connector.call(connector, token, :send_message, %{target: target, message: text, attachments: attachments})
+    result = Connector.call(connector, token, :send_message, %{target: target, message: text, metadata: metadata, attachments: attachments})
     case result["ok"] do
       true ->
         {:reply, :ok, state}

--- a/lib/cog/command/output.ex
+++ b/lib/cog/command/output.ex
@@ -25,7 +25,7 @@ defmodule Cog.Command.Output do
       message_data
     end
 
-    Adapter.send(connection, provider, room, payload)
+    Adapter.send(connection, provider, room, payload, %Cog.Chat.MessageMetadata{})
   end
 
   def format_error({:parse_error, msg}) when is_binary(msg),

--- a/lib/cog/messages.ex
+++ b/lib/cog/messages.ex
@@ -5,6 +5,7 @@ defmodule Cog.Messages.ProviderRequest do
   Input to the executor; all providers must generate one.
   """
   use Conduit
+  require Cog.Chat.MessageMetadata
 
   # Unique request ID
   field :id, :string, required: true
@@ -30,6 +31,8 @@ defmodule Cog.Messages.ProviderRequest do
   # Short name of provider, e.g. "slack"
   field :provider, :string, required: true
 
+  # Extra data related to the incoming message, like the thread_id
+  field :metadata, [object: Cog.Chat.MessageMetadata], required: false
 end
 
 defmodule Cog.Messages.Command do

--- a/lib/cog/pipeline/error_sink.ex
+++ b/lib/cog/pipeline/error_sink.ex
@@ -108,7 +108,7 @@ defmodule Cog.Pipeline.ErrorSink do
     context = prepare_error_context(signal, state)
     failure_event(signal.error, context["error_message"], state)
     output = output_for(type, signal, context)
-    Enum.each(targets, &ChatAdapter.send(state.conn, &1.provider, &1.room, output))
+    Enum.each(targets, &ChatAdapter.send(state.conn, &1.provider, &1.room, output, state.request.metadata))
   end
 
   defp send_to_owner(%__MODULE__{all_events: events, policy: policy, owner: owner}=state) when policy in [:owner, :adapter_owner] do

--- a/lib/cog/pipeline/output_sink.ex
+++ b/lib/cog/pipeline/output_sink.ex
@@ -150,7 +150,7 @@ defmodule Cog.Pipeline.OutputSink do
 
   defp send_to_adapter({type, targets}, signal, state) do
     output = output_for(type, signal, nil)
-    Enum.each(targets, &ChatAdapter.send(state.conn, &1.provider, &1.room, output))
+    Enum.each(targets, &ChatAdapter.send(state.conn, &1.provider, &1.room, output, state.request.metadata))
   end
 
   defp early_exit_response(%DoneSignal{}=signal, state) do
@@ -161,7 +161,8 @@ defmodule Cog.Pipeline.OutputSink do
     destinations = Destination.here(state.request)
     Enum.each(destinations, fn({type, destinations}) ->
       output = output_for(type, data_signal, "Terminated early")
-      Enum.each(destinations, &ChatAdapter.send(&1.provider, &1.room, output)) end)
+      Enum.each(destinations, &ChatAdapter.send(&1.provider, &1.room, output, state.request.metadata))
+    end)
   end
 
   defp output_for(:chat, %DataSignal{}=signal, _message) do

--- a/test/support/slack_client.ex
+++ b/test/support/slack_client.ex
@@ -229,12 +229,13 @@ defmodule Cog.Test.Support.SlackClient do
   end
 
   defp parse_message(%{attachments: [attachment|_], ts: ts}=message, state) do
-    make_message(attachment.text, ts, location(message, state))
+    make_message(attachment.text, ts, location(message, state), nil)
   end
   defp parse_message(%{text: text, ts: ts}=message, state) do
     make_message(resolve_references(text, state),
                  ts,
-                 location(message, state))
+                 location(message, state),
+                 message[:thread_ts])
   end
 
   # In a few places, we get Slack user IDs in our messages... it's
@@ -267,9 +268,9 @@ defmodule Cog.Test.Support.SlackClient do
   end
 
 
-  defp make_message(text, ts, locn) do
+  defp make_message(text, ts, locn, thread_ts) do
     [realtime, _] = String.split(ts, ".", parts: 2)
-    %{ts: ts, real_time: String.to_integer(realtime), text: text, location: locn}
+    %{ts: ts, real_time: String.to_integer(realtime), text: text, location: locn, thread_ts: thread_ts}
   end
 
   defp location(%{channel: %{is_im: true}}, _state) do


### PR DESCRIPTION
Probably not going to end up merging this, but figured I'd open a PR for some discussion.

This PR makes Cog respond to the message it was sent with a new thread response. All we need to do is set `thread_ts` with the value of `ts` from the original message. There are still some issues on Slack's end to work out, like attachments missing from responses and such. Also on our end we need to disable this when redirecting to another room since threads can only be created and responded to in a single room. Either way, this was a cool experiment and was really only a minimal amount of work.

<img width="574" alt="screen shot 2017-01-18 at 8 45 31 pm" src="https://cloud.githubusercontent.com/assets/228734/22090692/661fc38e-ddc1-11e6-9c4e-220541edcd79.png">
