### PR TITLE
Return relay errors as the error module expects

### DIFF
--- a/lib/cog/pipeline/relay_selector.ex
+++ b/lib/cog/pipeline/relay_selector.ex
@@ -21,13 +21,13 @@ defmodule Cog.Pipeline.RelaySelector do
       {:ok, relay} ->
         selector = %{selector | relay: relay}
         {:ok, selector}
-      error ->
-      # Query DB to clarify error before reporting to the user
-      if Cog.Repository.Bundles.assigned_to_group?(name) do
-        error
-      else
-        {:error, {:no_relay_group, name}}
-      end
+      {:error, error} ->
+        # Query DB to clarify error before reporting to the user
+        if Cog.Repository.Bundles.assigned_to_group?(name) do
+          {:error, error, name}
+        else
+          {:error, :no_relay_group, name}
+        end
     end
   end
   def select(%__MODULE__{bundle_name: name, bundle_version: version, relay: relay}=selector) do


### PR DESCRIPTION
Fixes #1314 

* Correctly outputs error when no relay groups are assigned a bundle
* Correctly outputs error when no relays are available to run a bundle