### PR TITLE
Added pipeline management commands

### DIFF
--- a/lib/cog/commands/history.ex
+++ b/lib/cog/commands/history.ex
@@ -1,0 +1,94 @@
+defmodule Cog.Commands.History do
+  use Cog.Command.GenCommand.Base,
+    bundle: Cog.Util.Misc.embedded_bundle,
+    name: "history"
+
+  alias Cog.Repository.PipelineHistory, as: HistoryRepo
+  alias Cog.Repository.Users, as: UserRepo
+
+  @description "View command history"
+  @default_limit 20
+
+  # Allow any user to run history
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:history allow"
+
+  option "limit", short: "l", type: "int", required: false,
+    description: "Show <limit> history entries"
+
+  def handle_message(%{options: opts, args: args}=req, state) do
+    limit = Map.get(opts, "limit", @default_limit)
+    with {:ok, {hist_start, hist_end}} <- parse_args(args)
+      do
+        case fetch_history(req, hist_start, hist_end, limit) |> format_entries do
+          [] ->
+            {:reply, req.reply_to, "Empty command history.", state}
+          entries ->
+            {:reply, req.reply_to, "history-list", entries, state}
+        end
+      else
+        {:error, reason} when is_binary(reason) ->
+          {:error, req.reply_to, reason, state}
+    end
+  end
+
+  defp fetch_history(req, hist_start, hist_end, limit) do
+    {:ok, app_user} = UserRepo.by_username(req.requestor.handle)
+    HistoryRepo.history_for_user(app_user.id, hist_start, hist_end, limit)
+  end
+
+  defp parse_args([]), do: {:ok, {nil, nil}}
+  defp parse_args([hist_start]) do
+    case String.split(hist_start, "-") do
+      [hist_start] ->
+        with {:ok, parsed} <- parse_int(hist_start),
+          do: {:ok, {parsed, nil}}
+      [hist_start, "-"] ->
+        with {:ok, parsed} <- parse_int(hist_start),
+          do: {:ok, parsed, nil}
+      ["-", hist_end] ->
+        with {:ok, parsed} <- parse_int(hist_end),
+          do: {:ok, nil, parsed}
+      [hist_start, "-", hist_end] ->
+        parse_args([hist_start, hist_end])
+    end
+  end
+  defp parse_args([hist_start, hist_end]) do
+    with {:ok, hist_start} <- parse_int(hist_start),
+         {:ok, hist_end} <- parse_int(hist_end),
+    do: {:ok, {hist_start, hist_end}}
+  end
+  defp parse_args([hist_start, "-"]) do
+    parse_args([hist_start])
+  end
+  defp parse_args([hist_start, "-", hist_end]) do
+    parse_args([hist_start, hist_end])
+  end
+  defp parse_args(["-", hist_end]) do
+    with {:ok, hist_end} <- parse_int(hist_end),
+      do: {:ok, {nil, hist_end}}
+  end
+
+  defp parse_int(i) do
+    case Integer.parse(i) do
+      {v, ""} ->
+        {:ok, v}
+      _ ->
+        {:error, "Invalid number: '#{i}"}
+    end
+  end
+
+  defp format_entries([]), do: []
+  defp format_entries([entry]), do: format_entry(entry, 2)
+  defp format_entries([[max_idx, _]|_]=entries) do
+    max_width = String.length(Integer.to_string(max_idx))
+    Enum.map(entries, &(format_entry(&1, max_width)))
+  end
+
+  defp format_entry([idx, text], max_width) do
+    idx = Integer.to_string(idx)
+    count = max_width - String.length(idx)
+    %{index: String.pad_leading(idx, count, [" "]),
+      text: String.replace(text, "|", "\\|")}
+  end
+
+end

--- a/lib/cog/commands/history/exec.ex
+++ b/lib/cog/commands/history/exec.ex
@@ -1,0 +1,43 @@
+defmodule Cog.Commands.HistoryExec do
+  use Cog.Command.GenCommand.Base,
+    bundle: Cog.Util.Misc.embedded_bundle,
+    name: "history-exec"
+
+  alias Cog.Chat.Message
+  alias Cog.Repository.PipelineHistory, as: HistoryRepo
+  alias Cog.Repository.Users, as: UserRepo
+
+  @description "Re-execute pipeline history entry"
+
+  @arguments "index"
+
+  # Allow any user to run history exec
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:history-exec allow"
+
+  def handle_message(%{args: [index]} = req, state) when is_integer(index) do
+    case fetch_entry(req, index) do
+      nil ->
+        {:error, req.reply_to, "Unknown history index: #{index}", state}
+      entry ->
+        replace_self(req, entry, state)
+    end
+  end
+  def handle_message(req, state) do
+    {:error, req.reply_to, "Invalid or missing pipeline history index.", state}
+  end
+
+  defp fetch_entry(req, index) do
+    {:ok, app_user} = UserRepo.by_username(req.requestor.handle)
+    HistoryRepo.history_entry(app_user.id, index)
+  end
+
+  defp replace_self(req, entry, state) do
+    message = %Message{id: String.replace(UUID.uuid4(), "-", ""),
+                       room: req.room,
+                       user: req.requestor,
+                       text: entry.text,
+                       provider: entry.provider}
+    {:replace_invocation, message, state}
+  end
+
+end

--- a/lib/cog/commands/pipeline/info.ex
+++ b/lib/cog/commands/pipeline/info.ex
@@ -1,0 +1,33 @@
+defmodule Cog.Commands.Pipeline.Info do
+
+  use Cog.Command.GenCommand.Base,
+    bundle: Cog.Util.Misc.embedded_bundle,
+    name: "pipeline-info"
+
+  alias Cog.Commands.Pipeline.Util
+  alias Cog.Repository.PipelineHistory, as: HistoryRepo
+
+  @description "Display command pipeline details"
+
+  @arguments "id ..."
+
+  # Allow any user to run info
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:pipeline-info allow"
+
+  def handle_message(%{args: ids} = req, state) do
+    infos = ids
+            |> Enum.reduce([], &pipeline_info/2)
+            |> Enum.map(&Util.entry_to_map/1)
+    {:reply, req.reply_to, "pipeline-info", infos, state}
+  end
+
+  defp pipeline_info(id, accum) do
+    case HistoryRepo.by_short_id(id) do
+      nil ->
+        accum
+      entry ->
+        [entry|accum]
+    end
+  end
+
+end

--- a/lib/cog/commands/pipeline/kill.ex
+++ b/lib/cog/commands/pipeline/kill.ex
@@ -15,12 +15,15 @@ defmodule Cog.Commands.Pipeline.Kill do
   rule "when command is #{Cog.Util.Misc.embedded_bundle}:pipeline-kill allow"
 
   def handle_message(%{args: ids} = req, state) do
-    killed = Enum.reduce(ids, [], &kill_pipeline/2) |> Enum.join(",")
-    results = if killed == "" do
-      %{"killed" => "none"}
-    else
-      %{"killed" => killed}
-    end
+    killed = Enum.reduce(ids, [], &kill_pipeline/2)
+    killed_text = case killed do
+                    [] ->
+                      "none"
+                    _ ->
+                      Enum.join(killed, ",")
+                  end
+    results = %{killed: killed,
+                killed_text: killed_text}
     {:reply, req.reply_to, "pipeline-kill", results, state}
   end
 

--- a/lib/cog/commands/pipeline/kill.ex
+++ b/lib/cog/commands/pipeline/kill.ex
@@ -1,0 +1,36 @@
+defmodule Cog.Commands.Pipeline.Kill do
+  use Cog.Command.GenCommand.Base,
+    bundle: Cog.Util.Misc.embedded_bundle,
+    name: "pipeline-kill"
+
+  alias Cog.Pipeline
+  alias Cog.Pipeline.Tracker
+
+  @description "Abort a running pipeline"
+
+  @arguments "id ..."
+
+  # Allow any user to run ps
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:pipeline-kill allow"
+
+  def handle_message(%{args: ids} = req, state) do
+    killed = Enum.reduce(ids, [], &kill_pipeline/2) |> Enum.join(",")
+    results = if killed == "" do
+      %{"killed" => "none"}
+    else
+      %{"killed" => killed}
+    end
+    {:reply, req.reply_to, "pipeline-kill", results, state}
+  end
+
+  defp kill_pipeline(id, killed) do
+    case Tracker.pipeline_pid(id) do
+      nil ->
+        killed
+      pid ->
+        Pipeline.teardown(pid)
+        [id|killed]
+    end
+  end
+
+end

--- a/lib/cog/commands/pipeline/list.ex
+++ b/lib/cog/commands/pipeline/list.ex
@@ -1,0 +1,83 @@
+defmodule Cog.Commands.Pipeline.List do
+  use Cog.Command.GenCommand.Base,
+    bundle: Cog.Util.Misc.embedded_bundle,
+    name: "pipeline-list"
+
+  alias Cog.Pipeline.Tracker
+
+  @description "Display command pipeline statistics"
+
+  # Allow any user to run ps
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:pipeline-list allow"
+
+  option "user", short: "u", type: "string", required: false,
+    description: "View pipelines for specified user"
+
+  option "last", short: "l", type: "int", required: false,
+    description: "View <last> pipelines"
+
+  option "expr", short: "e", type: "string", required: false,
+    description: "Display only pipelines with command text matching regular expression <expr>"
+
+  option "invert", short: "v", type: "bool", required: false,
+    description: "Invert regular expression matching"
+
+  option "runtime", short: "r", type: "int", required: false,
+    description: "Display pipelines with a run time of at least <runtime> milliseconds"
+
+  def handle_message(%{options: opts, pipeline_id: pipeline_id} = req, state) do
+    results = case Map.get(opts, "user") do
+                nil ->
+                  Tracker.pipelines_by(user: req.requestor.handle)
+                "all" ->
+                  Tracker.all_pipelines()
+                user ->
+                  Tracker.pipelines_by(user: user)
+              end
+    {regex_error, text_regex} = parse_regex(opts)
+    if regex_error do
+      {:error, req.reply_to, {:error, "Bad regular expression"}, state}
+    else
+      updated = results
+              |> Enum.filter(&(String.starts_with?(pipeline_id, &1.id) == false))
+              |> Enum.filter(&text_matches?(&1, text_regex, Map.get(opts, "invert")))
+              |> Enum.filter(&runtime_in_bounds?(&1, Map.get(opts, "runtime")))
+              |> limit(Map.get(opts, "last"))
+      {:reply, req.reply_to, "pipeline-list", updated, state}
+    end
+  end
+
+  defp limit(results, nil), do: results
+  defp limit(results, count) do
+    Enum.slice(results, 0, count)
+  end
+
+  defp text_matches?(_, nil, _), do: true
+  defp text_matches?(entry, regex, invert) do
+    if invert do
+      not(Regex.match?(regex, entry.text))
+    else
+      Regex.match?(regex, entry.text)
+    end
+  end
+
+  defp runtime_in_bounds?(_, nil), do: true
+  defp runtime_in_bounds?(entry, min_rt) do
+    entry.elapsed >= min_rt
+  end
+
+  defp parse_regex(opts) do
+    case Map.get(opts, "expr") do
+      nil ->
+        {false, nil}
+      expr ->
+        case Regex.compile(expr) do
+          {:ok, cexpr} ->
+            {false, cexpr}
+          {:error, _} ->
+            {true, nil}
+        end
+    end
+  end
+
+end

--- a/lib/cog/commands/pipeline/list.ex
+++ b/lib/cog/commands/pipeline/list.ex
@@ -54,7 +54,8 @@ defmodule Cog.Commands.Pipeline.List do
                                        room_matches?(&1, room) and
                                        state_matches?(&1, state_name))
                       |> Enum.map(&(format_entry(Util.entry_to_map(&1))))
-           {:reply, req.reply_to, "pipeline-list", updated, state}
+           results = %{pipeline_count: length(updated), pipelines: updated}
+           {:reply, req.reply_to, "pipeline-list", results, state}
           else
             {:error, req.reply_to, "Valid state names are: #{Enum.join(@valid_state_names, ", ")}", state}
           end

--- a/lib/cog/commands/pipeline/util.ex
+++ b/lib/cog/commands/pipeline/util.ex
@@ -7,7 +7,7 @@ defmodule Cog.Commands.Pipeline.Util do
   def entry_to_map(entry) do
     %{id: short_id(entry.id),
       user: entry.user.username,
-      room: entry.room,
+      room: entry.room_name,
       text: entry.text,
       processed: entry.count,
       state: entry.state,

--- a/lib/cog/commands/pipeline/util.ex
+++ b/lib/cog/commands/pipeline/util.ex
@@ -7,16 +7,21 @@ defmodule Cog.Commands.Pipeline.Util do
   def entry_to_map(entry) do
     %{id: short_id(entry.id),
       user: entry.user.username,
+      room: entry.room,
       text: entry.text,
       processed: entry.count,
       state: entry.state,
       started: format_timestamp(entry.started_at),
-      elapsed: PipelineHistory.elapsed(entry)}
+      time: PipelineHistory.elapsed(entry)}
   end
 
   def short_id(id) do
     String.slice(id, 0, @short_id_length)
   end
+
+  def short_state("waiting"), do: "W"
+  def short_state("running"), do: "R"
+  def short_state("finished"), do: "F"
 
   def format_timestamp(ts) do
     {:ok, ts} = DateTime.from_unix(ts, :milliseconds)

--- a/lib/cog/commands/pipeline/util.ex
+++ b/lib/cog/commands/pipeline/util.ex
@@ -1,0 +1,28 @@
+defmodule Cog.Commands.Pipeline.Util do
+
+  alias Cog.Models.PipelineHistory
+
+  @short_id_length 15
+
+  def entry_to_map(entry) do
+    %{id: short_id(entry.id),
+      user: entry.user.username,
+      text: entry.text,
+      processed: entry.count,
+      state: entry.state,
+      started: format_timestamp(entry.started_at),
+      elapsed: PipelineHistory.elapsed(entry)}
+  end
+
+  def short_id(id) do
+    String.slice(id, 0, @short_id_length)
+  end
+
+  def format_timestamp(ts) do
+    {:ok, ts} = DateTime.from_unix(ts, :milliseconds)
+    ts
+    |> DateTime.to_iso8601
+    |> String.replace(~r/\.[0-9]+Z$/, "Z")
+  end
+
+end

--- a/lib/cog/messages.ex
+++ b/lib/cog/messages.ex
@@ -41,6 +41,9 @@ defmodule Cog.Messages.Command do
   alias Cog.ServiceEndpoint
   use Conduit
 
+  # Unique identifier for the entire command pipeline
+  field :pipeline_id, :string, required: true
+
   # Unique identifier for the individual command invocation
   field :invocation_id, :string, required: true
 
@@ -88,12 +91,13 @@ defmodule Cog.Messages.Command do
   field :user, :map, required: true
 
   @doc "Creates a new Command from an invocation, options, and args"
-  defmacro create(invocation, options, args) do
-    quote bind_quoted: [invocation: invocation, options: options, args: args] do
+  defmacro create(pipeline_id, invocation, options, args) do
+    quote bind_quoted: [pipeline_id: pipeline_id, invocation: invocation, options: options, args: args] do
       %Cog.Messages.Command{command: invocation.meta.full_command_name,
                             options: options,
                             args: args,
                             invocation_id: invocation.id,
+                            pipeline_id: pipeline_id,
                             services_root: ServiceEndpoint.url()}
     end
   end

--- a/lib/cog/models/pipeline_history.ex
+++ b/lib/cog/models/pipeline_history.ex
@@ -13,7 +13,9 @@ defmodule Cog.Models.PipelineHistory do
     field :idx, :integer, read_after_writes: true
     field :pid, ProcessId
     field :text, :string
-    field :room, :string
+    field :room_name, :string
+    field :room_id, :string
+    field :provider, :string
     field :count, :integer
     field :state, :string
     field :started_at, :integer
@@ -24,7 +26,7 @@ defmodule Cog.Models.PipelineHistory do
     timestamps
   end
 
-  @required_fields ~w(id text room count state user_id started_at)
+  @required_fields ~w(id text room_name room_id provider count state user_id started_at)
   @optional_fields ~w(pid finished_at)
 
   def changeset(model, params \\ :empty) do

--- a/lib/cog/models/pipeline_history.ex
+++ b/lib/cog/models/pipeline_history.ex
@@ -13,6 +13,7 @@ defmodule Cog.Models.PipelineHistory do
     field :idx, :integer, read_after_writes: true
     field :pid, ProcessId
     field :text, :string
+    field :room, :string
     field :count, :integer
     field :state, :string
     field :started_at, :integer
@@ -23,7 +24,7 @@ defmodule Cog.Models.PipelineHistory do
     timestamps
   end
 
-  @required_fields ~w(id text count state user_id started_at)
+  @required_fields ~w(id text room count state user_id started_at)
   @optional_fields ~w(pid finished_at)
 
   def changeset(model, params \\ :empty) do

--- a/lib/cog/models/pipeline_history.ex
+++ b/lib/cog/models/pipeline_history.ex
@@ -1,0 +1,52 @@
+defmodule Cog.Models.PipelineHistory do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Cog.Models.User
+  alias Cog.Models.Types.ProcessId
+
+  @primary_key {:id, :string, autogenerate: false}
+  @foreign_key_type Ecto.UUID
+
+  schema "pipeline_history" do
+    field :idx, :integer, read_after_writes: true
+    field :pid, ProcessId
+    field :text, :string
+    field :count, :integer
+    field :state, :string
+    field :started_at, :integer
+    field :finished_at, :integer
+
+    belongs_to :user, User
+
+    timestamps
+  end
+
+  @required_fields ~w(id text count state user_id started_at)
+  @optional_fields ~w(pid finished_at)
+
+  def changeset(model, params \\ :empty) do
+    model
+    |> cast(params, @required_fields, @optional_fields)
+    |> assoc_constraint(:user)
+    |> ensure_sane_state
+  end
+
+  def elapsed(%__MODULE__{started_at: started_at, finished_at: nil}) do
+    DateTime.to_unix(DateTime.utc_now(), :milliseconds) - started_at
+  end
+  def elapsed(%__MODULE__{started_at: started_at, finished_at: finished_at}) do
+    finished_at - started_at
+  end
+
+  defp ensure_sane_state(changeset) do
+    case get_change(changeset, :state) do
+      "finished" ->
+        put_change(changeset, :pid, nil)
+      _ ->
+        changeset
+    end
+  end
+
+end

--- a/lib/cog/models/types/process_id.ex
+++ b/lib/cog/models/types/process_id.ex
@@ -1,0 +1,30 @@
+defmodule Cog.Models.Types.ProcessId do
+
+  @behaviour Ecto.Type
+
+  def type, do: :string
+
+  def cast(value) when is_pid(value) do
+    try do
+      {:ok, pid_to_string(value)}
+    rescue
+      _e in ErlangError ->
+        :error
+    end
+  end
+  def cast(_), do: :error
+
+  def load(value) when is_binary(value), do: {:ok, string_to_pid(value)}
+
+  def dump(value) when is_binary(value), do: {:ok, value}
+  def dump(_), do: :error
+
+  defp pid_to_string(p) do
+    String.Chars.to_string(:erlang.pid_to_list(p))
+  end
+
+  defp string_to_pid(p) do
+    :erlang.list_to_pid(String.to_charlist(p))
+  end
+
+end

--- a/lib/cog/pipeline.ex
+++ b/lib/cog/pipeline.ex
@@ -223,7 +223,9 @@ defmodule Cog.Pipeline do
                           count: 0,
                           state: "running",
                           text: state.request.text,
-                          room: room_name(state.request.room)})
+                          provider: state.request.provider,
+                          room_name: room_name(state.request.room),
+                          room_id: room_id(state.request)})
         InitialContext.unlock(initial_context)
         {:reply, :ok, %{state | stages: stages}}
       rescue
@@ -351,6 +353,14 @@ defmodule Cog.Pipeline do
       "DM"
     else
       room.name
+    end
+  end
+
+  defp room_id(req) do
+    if req.room.is_dm do
+      req.sender.id
+    else
+      req.room.id
     end
   end
 

--- a/lib/cog/pipeline.ex
+++ b/lib/cog/pipeline.ex
@@ -222,7 +222,8 @@ defmodule Cog.Pipeline do
                           user_id: user.id,
                           count: 0,
                           state: "running",
-                          text: state.request.text})
+                          text: state.request.text,
+                          room: room_name(state.request.room)})
         InitialContext.unlock(initial_context)
         {:reply, :ok, %{state | stages: stages}}
       rescue
@@ -343,6 +344,14 @@ defmodule Cog.Pipeline do
   defp initialization_event(user, state) do
     PipelineEvent.initialized(state.request.id, state.started, state.request.text,
       state.request.provider, user.username, state.request.sender.handle) |> Probe.notify
+  end
+
+  defp room_name(room) do
+    if room.is_dm do
+      "DM"
+    else
+      room.name
+    end
   end
 
 end

--- a/lib/cog/pipeline/tracker.ex
+++ b/lib/cog/pipeline/tracker.ex
@@ -1,0 +1,141 @@
+defmodule Cog.Pipeline.Tracker do
+
+  @pipelines :cog_pipelines
+  @max_records 500
+  @short_id_length 15
+
+  alias Cog.Events.Util
+
+  require Record
+
+  Record.defrecordp :pipeline, [id: nil, pid: nil, user: nil, text: nil, count: 0, state: :running, started: nil, finished: nil]
+
+  @doc "Configures ETS tables"
+  def init() do
+    :ets.new(@pipelines, [:set, :public, :named_table, {:keypos, 2}])
+  end
+
+  def start_pipeline(id, pid, text, user, started) do
+    pline = pipeline(id: id, pid: pid, user: user, text: text, started: started)
+    :ets.insert_new(@pipelines, pline)
+  end
+
+  def finish_pipeline(id, finished) do
+    case :ets.lookup(@pipelines, id) do
+      [] ->
+        :ok
+      [pline] ->
+        updated = pline
+                  |> pipeline(finished: finished)
+                  |> pipeline(state: :finished)
+        :ets.insert(@pipelines, updated)
+    end
+    prune_old_records(@max_records)
+  end
+
+  def update_pipeline(id, opts) do
+    case :ets.lookup(@pipelines, id) do
+      [] ->
+        false
+      [pline] ->
+        updated = update_record(pline, opts)
+        :ets.insert(@pipelines, updated)
+    end
+  end
+
+  def all_pipelines() do
+    :ets.tab2list(@pipelines)
+    |> Enum.map(&pipeline_to_map/1)
+    |> Enum.sort(&by_started/2)
+  end
+
+  def pipeline_pid(id) do
+    results = if String.length(id) == @short_id_length do
+      pipelines_by(short_id: id)
+    else
+      pipelines_by(id: id)
+    end
+    case results do
+      [] ->
+        nil
+      [pline] ->
+        if pipeline(pline, :state) == :finished do
+          nil
+        else
+          pipeline(pline, :pid)
+        end
+    end
+  end
+
+  def pipelines_by(user: user) do
+    :ets.select(@pipelines, [{{:pipeline, :_, :_, user, :_, :_, :_, :_, :_}, [], [:"$_"]}])
+    |> Enum.map(&pipeline_to_map/1)
+    |> Enum.sort(&by_started/2)
+  end
+  def pipelines_by(state: state) do
+    :ets.select(@pipelines, [{{:pipeline, :_, :_, :_, :_, :_, state, :_, :_}, [], [:"$_"]}])
+    |> Enum.map(&pipeline_to_map/1)
+    |> Enum.sort(&by_started/2)
+  end
+  def pipelines_by(id: id) do
+    :ets.lookup(@pipelines, id)
+  end
+  def pipelines_by(short_id: sid) do
+    :ets.select(@pipelines, [{{:pipeline, :"$1", :_, :_, :_, :_, :_, :_, :_}, [], [:"$1"]}])
+    |> Enum.filter(&(String.starts_with?(&1, sid)))
+    |> Enum.flat_map(&(pipelines_by(id: &1)))
+  end
+
+  def prune_old_records(max) do
+    count = :ets.info(@pipelines, :size)
+    if count > max do
+      prune_old_records(pipelines_by(state: :finished), count - max)
+    end
+  end
+
+  defp prune_old_records([], _), do: :ok
+  defp prune_old_records(_, 0), do: :ok
+  defp prune_old_records([%{id: id}|rest], count) do
+    :ets.delete(@pipelines, id)
+    prune_old_records(rest, count - 1)
+  end
+
+  defp update_record(pline, []), do: pline
+  defp update_record(pline, [{:count, v}|rest]) do
+    updated = pipeline(pline, :count) + v
+    update_record(pipeline(pline, count: updated), rest)
+  end
+  defp update_record(pline, [{:state, v}|rest]) do
+    update_record(pipeline(pline, state: v), rest)
+  end
+
+  defp pipeline_to_map(pline) do
+    entry = %{id: short_id(pipeline(pline, :id)),
+              user: pipeline(pline, :user),
+              text: pipeline(pline, :text),
+              processed: pipeline(pline, :count),
+              state: pipeline(pline, :state),
+              started: pipeline(pline, :started)}
+    elapsed = case pipeline(pline, :finished) do
+                nil ->
+                  Util.elapsed(entry.started, DateTime.utc_now(), :milliseconds)
+                finished ->
+                  Util.elapsed(entry.started, finished, :milliseconds)
+              end
+    Map.put(entry, :elapsed, elapsed)
+    |> Map.put(:started, format_timestamp(entry.started))
+  end
+
+  defp short_id(id) do
+    String.slice(id, 0, @short_id_length)
+  end
+
+  defp by_started(p1, p2) do
+    p1.started >= p2.started
+  end
+
+  defp format_timestamp(ts) do
+    DateTime.to_iso8601(ts) |> String.replace(~r/\.[0-9]+Z$/, "Z")
+  end
+
+end

--- a/lib/cog/pipeline_core_sup.ex
+++ b/lib/cog/pipeline_core_sup.ex
@@ -1,6 +1,7 @@
 defmodule Cog.PipelineCoreSup do
 
   use Supervisor
+  alias Cog.Pipeline.Tracker
 
   def start_link() do
     Supervisor.start_link(__MODULE__, [], name: __MODULE__)
@@ -14,6 +15,7 @@ defmodule Cog.PipelineCoreSup do
                 supervisor(Cog.PipelineSup, []),
                 worker(Cog.Pipeline.PermissionsCache, []),
                 worker(Cog.Pipeline.Initializer, [])]
+    Tracker.init()
     {:ok, {%{strategy: :one_for_one, intensity: 10, period: 60}, children}}
   end
 

--- a/lib/cog/repository/pipeline_history.ex
+++ b/lib/cog/repository/pipeline_history.ex
@@ -42,10 +42,10 @@ defmodule Cog.Repository.PipelineHistory do
     end
   end
 
-  def all_history(limit \\20) do
+  def all_history(limit \\ 20) do
     query = from ph in PipelineHistory,
             order_by: [desc: :started_at],
-            limit: ^limit,
+            limit: ^(limit + 1),
             preload: [:user]
     Repo.all(query)
   end
@@ -54,7 +54,7 @@ defmodule Cog.Repository.PipelineHistory do
     query = from ph in PipelineHistory,
             where: ph.user_id == ^user_id,
             order_by: [desc: :idx],
-            limit: ^limit,
+            limit: ^(limit + 1),
             preload: [:user]
     Repo.all(query)
   end

--- a/lib/cog/repository/pipeline_history.ex
+++ b/lib/cog/repository/pipeline_history.ex
@@ -1,0 +1,79 @@
+defmodule Cog.Repository.PipelineHistory do
+  @moduledoc """
+  Behavioral API for interacting with pipeline history
+  records.
+  """
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Cog.Repo
+  alias Cog.Models.PipelineHistory
+
+  @allowed_states ["running", "waiting", "finished"]
+
+  def new(attr) do
+    attr = Map.put(attr, :started_at, now_timestamp_ms())
+    cs = PipelineHistory.changeset(%PipelineHistory{}, attr)
+    Repo.insert!(cs)
+  end
+
+  def increment_count(id, incr) do
+    case Repo.get_by(PipelineHistory, id: id) do
+      nil ->
+        :ok
+      ph ->
+        cs = PipelineHistory.changeset(ph, %{count: ph.count + incr})
+        Repo.update!(cs)
+    end
+  end
+
+  def update_state(id, state) when state in @allowed_states do
+    case Repo.get_by(PipelineHistory, id: id) do
+      nil ->
+        :ok
+      ph ->
+        args = if state == "finished" do
+            %{state: state, finished_at: now_timestamp_ms()}
+          else
+            %{state: state}
+          end
+        cs = PipelineHistory.changeset(ph, args)
+        Repo.update!(cs)
+    end
+  end
+
+  def all_history(limit \\20) do
+    query = from ph in PipelineHistory,
+            order_by: [desc: :started_at],
+            limit: ^limit,
+            preload: [:user]
+    Repo.all(query)
+  end
+
+  def history_for_user(user_id, limit \\ 20) do
+    query = from ph in PipelineHistory,
+            where: ph.user_id == ^user_id,
+            order_by: [desc: :idx],
+            limit: ^limit,
+            preload: [:user]
+    Repo.all(query)
+  end
+
+  def by_short_id(short_id, except_state \\ nil) when is_binary(short_id) do
+    query = if except_state != nil do
+      from ph in PipelineHistory,
+      where: ph.state != ^except_state and like(ph.id, ^"#{short_id}%"),
+      preload: [:user]
+    else
+      from ph in PipelineHistory,
+      where: like(ph.id, ^"#{short_id}%"),
+      preload: [:user]
+    end
+    Repo.one(query)
+  end
+
+  defp now_timestamp_ms() do
+    DateTime.to_unix(DateTime.utc_now(), :milliseconds)
+  end
+
+end

--- a/lib/cog/repository/pipeline_history.ex
+++ b/lib/cog/repository/pipeline_history.ex
@@ -44,6 +44,7 @@ defmodule Cog.Repository.PipelineHistory do
 
   def all_pipelines(limit \\ 20) do
     query = from ph in PipelineHistory,
+            where: ph.state != "finished",
             order_by: [desc: :started_at],
             limit: ^(limit + 1),
             preload: [:user]
@@ -52,7 +53,7 @@ defmodule Cog.Repository.PipelineHistory do
 
   def pipelines_for_user(user_id, limit \\ 20) do
     query = from ph in PipelineHistory,
-            where: ph.user_id == ^user_id,
+            where: ph.user_id == ^user_id and ph.state != "finished",
             order_by: [desc: :idx],
             limit: ^(limit + 1),
             preload: [:user]

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Cog.Mixfile do
   def project do
     [app: :cog,
      version: "0.18.0",
-     elixir: "~> 1.3.1",
+     elixir: "~> 1.3.2",
      erlc_paths: ["emqttd_plugins"],
      erlc_options: [:debug_info, :warnings_as_errors],
      elixirc_options: [warnings_as_errors: System.get_env("ALLOW_WARNINGS") == nil,

--- a/priv/repo/migrations/20170120141008_add_pipeline_history.exs
+++ b/priv/repo/migrations/20170120141008_add_pipeline_history.exs
@@ -39,6 +39,7 @@ defmodule Cog.Repo.Migrations.AddPipelineHistory do
       add :text, :text, null: false
       add :count, :integer, null: false
       add :state, :text, null: false
+      add :room, :text, null: false
       add :started_at, :bigint, null: false
       add :finished_at, :bigint, null: true
 

--- a/priv/repo/migrations/20170120141008_add_pipeline_history.exs
+++ b/priv/repo/migrations/20170120141008_add_pipeline_history.exs
@@ -39,7 +39,9 @@ defmodule Cog.Repo.Migrations.AddPipelineHistory do
       add :text, :text, null: false
       add :count, :integer, null: false
       add :state, :text, null: false
-      add :room, :text, null: false
+      add :room_name, :text, null: false
+      add :room_id, :text, null: false
+      add :provider, :text, null: false
       add :started_at, :bigint, null: false
       add :finished_at, :bigint, null: true
 

--- a/priv/repo/migrations/20170120141008_add_pipeline_history.exs
+++ b/priv/repo/migrations/20170120141008_add_pipeline_history.exs
@@ -1,0 +1,90 @@
+defmodule Cog.Repo.Migrations.AddPipelineHistory do
+  use Ecto.Migration
+
+  def up do
+    create table(:user_history_counters, primary_key: false) do
+      add :id, references(:users, type: :uuid, on_delete: :delete_all), null: false
+      add :value, :integer, null: false
+    end
+    create unique_index(:user_history_counters, [:id])
+
+    # Populate user_history_counters from newly inserted user
+    # table rows
+    execute """
+    create function create_user_history_counter() returns trigger as $proc$
+    begin
+      insert into user_history_counters values (new.id, 0);
+      return new;
+    end;
+    $proc$ language plpgsql;
+    """
+
+    # Connect create_user_history_counter to users table
+    execute """
+    create trigger user_history_counter after insert on users
+    for each row
+    execute procedure create_user_history_counter();
+    """
+
+    # Create user_history_counters records for existing users
+    execute """
+    insert into user_history_counters (select id, 0 from users);
+    """
+
+    create table(:pipeline_history, primary_key: false) do
+      add :id, :text, primary_key: true
+      add :user_id, references(:users, type: :uuid, on_delete: :delete_all), null: false
+      add :idx, :integer, null: true
+      add :pid, :text, null: true
+      add :text, :text, null: false
+      add :count, :integer, null: false
+      add :state, :text, null: false
+      add :started_at, :bigint, null: false
+      add :finished_at, :bigint, null: true
+
+      timestamps
+    end
+    create index(:pipeline_history, [:user_id])
+    create index(:pipeline_history, [:user_id, :idx])
+
+    # Add per-user history index to new pipeine history records
+    execute """
+    create function add_history_index() returns trigger as $proc$
+    begin
+      update user_history_counters
+        set value = value + 1 where id = NEW.user_id
+        returning value into NEW.idx;
+      return NEW;
+    end
+    $proc$ language plpgsql;
+    """
+
+    # Connect add_history_index to pipeline_history table
+    execute """
+    create trigger history_index before insert on pipeline_history
+    for each row
+    execute procedure add_history_index();
+    """
+  end
+
+  def down do
+    execute """
+    drop trigger user_history_counter on users;
+    """
+    execute """
+    drop function create_user_history_counter();
+    """
+
+    execute """
+    drop trigger history_index on pipeline_history;
+    """
+
+    execute """
+    drop function add_history_index();
+    """
+
+    drop table :pipeline_history
+    drop table :user_history_counters
+  end
+
+end

--- a/priv/templates/embedded/history-list.greenbar
+++ b/priv/templates/embedded/history-list.greenbar
@@ -1,0 +1,5 @@
+|Index|Pipeline|
+|---|---|
+~each var=$results~
+|~$item.index~|~$item.text~|
+~end~

--- a/priv/templates/embedded/pipeline-info.greenbar
+++ b/priv/templates/embedded/pipeline-info.greenbar
@@ -2,10 +2,11 @@
 ~attachment color="operableblue"~
 **Id:** ~$item.id~
 **Text:** `~$item.text~`
-**Count:** ~$item.processed~
-**Run:** ~$item.elapsed~ ms
+**Time:** ~$item.time~ ms
+**User:** ~$item.user~
+**Room:** ~$item.room~
 **State:** ~$item.state~
 **Started:** ~$item.started~
-**User:** ~$item.user~
+**Processed:** ~$item.processed~
 ~end~
 ~end~

--- a/priv/templates/embedded/pipeline-info.greenbar
+++ b/priv/templates/embedded/pipeline-info.greenbar
@@ -1,0 +1,11 @@
+~each var=$results~
+~attachment color="operableblue"~
+**Id:** ~$item.id~
+**Text:** `~$item.text~`
+**Count:** ~$item.processed~
+**Run:** ~$item.elapsed~ ms
+**State:** ~$item.state~
+**Started:** ~$item.started~
+**User:** ~$item.user~
+~end~
+~end~

--- a/priv/templates/embedded/pipeline-kill.greenbar
+++ b/priv/templates/embedded/pipeline-kill.greenbar
@@ -1,0 +1,1 @@
+Pipelines killed: ~$results[0].killed~

--- a/priv/templates/embedded/pipeline-kill.greenbar
+++ b/priv/templates/embedded/pipeline-kill.greenbar
@@ -1,1 +1,1 @@
-Pipelines killed: ~$results[0].killed~
+Pipelines killed: ~$results[0].killed_text~

--- a/priv/templates/embedded/pipeline-list.greenbar
+++ b/priv/templates/embedded/pipeline-list.greenbar
@@ -1,5 +1,10 @@
+~if cond=$results[0].pipeline_count == 0~
+No pipelines found.
+~end~
+~if cond=$results[0].pipeline_count > 0~
 |Id|Text|User|Room|State|Processed|Started|Time|
 |---|---|---|---|---|---|---|---|
-~each var=$results~
+~each var=$results[0].pipelines~
 |~$item.id~|~$item.text~|~$item.user~|~$item.room~|~$item.state~|~$item.processed~|~$item.started~|~$item.time~|
+~end~
 ~end~

--- a/priv/templates/embedded/pipeline-list.greenbar
+++ b/priv/templates/embedded/pipeline-list.greenbar
@@ -1,5 +1,5 @@
-|Id|User|Text|State|Cnt|Started|Run|
-|---|---|---|---|---|---|---|
+|Id|Text|User|Room|State|Processed|Started|Time|
+|---|---|---|---|---|---|---|---|
 ~each var=$results~
-|~$item.id~|~$item.user~|~$item.text~|~$item.state~|~$item.processed~|~$item.started~|~$item.elapsed~|
+|~$item.id~|~$item.text~|~$item.user~|~$item.room~|~$item.state~|~$item.processed~|~$item.started~|~$item.time~|
 ~end~

--- a/priv/templates/embedded/pipeline-list.greenbar
+++ b/priv/templates/embedded/pipeline-list.greenbar
@@ -1,0 +1,5 @@
+|Id|User|Text|State|Cnt|Started|Run|
+|---|---|---|---|---|---|---|
+~each var=$results~
+|~$item.id~|~$item.user~|~$item.text~|~$item.state~|~$item.processed~|~$item.started~|~$item.elapsed~|
+~end~

--- a/test/cog/chat/hipchat/templates/embedded/history_list_test.exs
+++ b/test/cog/chat/hipchat/templates/embedded/history_list_test.exs
@@ -1,0 +1,26 @@
+defmodule Cog.Chat.Hipchat.Templates.Embedded.HistoryListTest do
+
+  use Cog.TemplateCase
+
+  test "history-list template" do
+
+    data = %{"results" => [
+              %{"index" => 1,
+                "text" => "echo foo"},
+              %{"index" => 2,
+                "text" => "echo bar"}
+            ]}
+
+    expected = """
+    <pre>+-------+----------+
+    | Index | Pipeline |
+    +-------+----------+
+    | 1     | echo foo |
+    | 2     | echo bar |
+    +-------+----------+
+    </pre>
+    """ |> String.strip()
+
+    assert_rendered_template(:hipchat, :embedded, "history-list", data, expected)
+  end
+end

--- a/test/cog/chat/hipchat/templates/embedded/pipeline_info_test.exs
+++ b/test/cog/chat/hipchat/templates/embedded/pipeline_info_test.exs
@@ -1,0 +1,32 @@
+defmodule Cog.Chat.Hipchat.Templates.Embedded.PipelineInfoTest do
+
+  use Cog.TemplateCase
+
+  test "pipeline-info template" do
+
+    data = %{"results" => [
+              %{"id" => "beefbeefbeefbeef",
+                "text" => "echo foo",
+                "time" => "123",
+                "user" => "chris",
+                "room" => "dev",
+                "state" => "running",
+                "started" => "Noon",
+                "processed" => 1
+               }
+            ]}
+
+    expected = """
+    <strong>Id:</strong> beefbeefbeefbeef<br/>
+    <strong>Text:</strong> <code>echo foo</code><br/>
+    <strong>Time:</strong> 123 ms<br/>
+    <strong>User:</strong> chris<br/>
+    <strong>Room:</strong> dev<br/>
+    <strong>State:</strong> running<br/>
+    <strong>Started:</strong> Noon<br/>
+    <strong>Processed:</strong> 1
+    """ |> String.replace("\n", "")
+
+    assert_rendered_template(:hipchat, :embedded, "pipeline-info", data, expected)
+  end
+end

--- a/test/cog/chat/hipchat/templates/embedded/pipeline_kill_test.exs
+++ b/test/cog/chat/hipchat/templates/embedded/pipeline_kill_test.exs
@@ -1,0 +1,15 @@
+defmodule Cog.Chat.Hipchat.Templates.Embedded.PipelineKillTest do
+
+  use Cog.TemplateCase
+
+  test "pipeline-kill template" do
+
+    data = %{"results" => [
+              %{"killed_text" => "echo 'Dead, Jim!'"}
+            ]}
+
+    expected = "Pipelines killed: echo 'Dead, Jim!'"
+
+    assert_rendered_template(:hipchat, :embedded, "pipeline-kill", data, expected)
+  end
+end

--- a/test/cog/chat/hipchat/templates/embedded/pipeline_list_test.exs
+++ b/test/cog/chat/hipchat/templates/embedded/pipeline_list_test.exs
@@ -1,0 +1,49 @@
+defmodule Cog.Chat.Hipchat.Templates.Embedded.PipelineListTest do
+
+  use Cog.TemplateCase
+
+  test "pipeline-list template with no pipelines" do
+
+    data = %{"results" => [
+              %{"pipeline_count" => 0}
+            ]}
+
+    expected = "No pipelines found."
+
+    assert_rendered_template(:hipchat, :embedded, "pipeline-list", data, expected)
+  end
+
+  test "pipeline-list template with pipelines" do
+    data = %{"results" => [
+              %{"pipeline_count" => 2,
+                "pipelines" => [
+                  %{"id" => "beefbeefbeefbeef",
+                    "text" => "echo foo",
+                    "time" => "123",
+                    "user" => "chris",
+                    "room" => "dev",
+                    "state" => "running",
+                    "started" => "Noon",
+                    "processed" => "1"},
+                  %{"id" => "beefbeefbeefbeef",
+                    "text" => "echo foo",
+                    "time" => "123",
+                    "user" => "chris",
+                    "room" => "dev",
+                    "state" => "running",
+                    "started" => "Noon",
+                    "processed" => "1"}]}]}
+
+    expected = """
+    <pre>+------------------+----------+-------+------+---------+-----------+---------+------+
+    | Id               | Text     | User  | Room | State   | Processed | Started | Time |
+    +------------------+----------+-------+------+---------+-----------+---------+------+
+    | beefbeefbeefbeef | echo foo | chris | dev  | running | 1         | Noon    | 123  |
+    | beefbeefbeefbeef | echo foo | chris | dev  | running | 1         | Noon    | 123  |
+    +------------------+----------+-------+------+---------+-----------+---------+------+
+    </pre>
+    """ |> String.strip
+
+    assert_rendered_template(:hipchat, :embedded, "pipeline-list", data, expected)
+  end
+end

--- a/test/cog/chat/slack/templates/embedded/history_list_test.exs
+++ b/test/cog/chat/slack/templates/embedded/history_list_test.exs
@@ -1,0 +1,26 @@
+defmodule Cog.Chat.Slack.Templates.Embedded.HistoryListTest do
+
+  use Cog.TemplateCase
+
+  test "history-list template" do
+
+    data = %{"results" => [
+              %{"index" => 1,
+                "text" => "echo foo"},
+              %{"index" => 2,
+                "text" => "echo bar"}
+            ]}
+
+    expected = """
+    ```+-------+----------+
+    | Index | Pipeline |
+    +-------+----------+
+    | 1     | echo foo |
+    | 2     | echo bar |
+    +-------+----------+
+    ```
+    """ |> String.strip()
+
+    assert_rendered_template(:slack, :embedded, "history-list", data, expected)
+  end
+end

--- a/test/cog/chat/slack/templates/embedded/pipeline_info_test.exs
+++ b/test/cog/chat/slack/templates/embedded/pipeline_info_test.exs
@@ -1,0 +1,34 @@
+defmodule Cog.Chat.Slack.Templates.Embedded.PipelineInfoTest do
+
+  use Cog.TemplateCase
+
+  test "pipeline-info template" do
+
+    data = %{"results" => [
+              %{"id" => "beefbeefbeefbeef",
+                "text" => "echo foo",
+                "time" => "123",
+                "user" => "chris",
+                "room" => "dev",
+                "state" => "running",
+                "started" => "Noon",
+                "processed" => "1"
+               }
+            ]}
+
+    attachments = [
+    """
+    *Id:* beefbeefbeefbeef
+    *Text:* `echo foo`
+    *Time:* 123 ms
+    *User:* chris
+    *Room:* dev
+    *State:* running
+    *Started:* Noon
+    *Processed:* 1
+    """ |> String.strip
+    ]
+
+    assert_rendered_template(:slack, :embedded, "pipeline-info", data, {"", attachments})
+  end
+end

--- a/test/cog/chat/slack/templates/embedded/pipeline_kill_test.exs
+++ b/test/cog/chat/slack/templates/embedded/pipeline_kill_test.exs
@@ -1,0 +1,15 @@
+defmodule Cog.Chat.Slack.Templates.Embedded.PipelineKillTest do
+
+  use Cog.TemplateCase
+
+  test "pipeline-kill template" do
+
+    data = %{"results" => [
+              %{"killed_text" => "echo 'Dead, Jim!'"}
+            ]}
+
+    expected = "Pipelines killed: echo 'Dead, Jim!'"
+
+    assert_rendered_template(:slack, :embedded, "pipeline-kill", data, expected)
+  end
+end

--- a/test/cog/chat/slack/templates/embedded/pipeline_list_test.exs
+++ b/test/cog/chat/slack/templates/embedded/pipeline_list_test.exs
@@ -1,0 +1,49 @@
+defmodule Cog.Chat.Slack.Templates.Embedded.PipelineListTest do
+
+  use Cog.TemplateCase
+
+  test "pipeline-list template with no pipelines" do
+
+    data = %{"results" => [
+              %{"pipeline_count" => 0}
+            ]}
+
+    expected = "No pipelines found."
+
+    assert_rendered_template(:slack, :embedded, "pipeline-list", data, expected)
+  end
+
+  test "pipeline-list template with pipelines" do
+    data = %{"results" => [
+              %{"pipeline_count" => 2,
+                "pipelines" => [
+                  %{"id" => "beefbeefbeefbeef",
+                    "text" => "echo foo",
+                    "time" => "123",
+                    "user" => "chris",
+                    "room" => "dev",
+                    "state" => "running",
+                    "started" => "Noon",
+                    "processed" => "1"},
+                  %{"id" => "beefbeefbeefbeef",
+                    "text" => "echo foo",
+                    "time" => "123",
+                    "user" => "chris",
+                    "room" => "dev",
+                    "state" => "running",
+                    "started" => "Noon",
+                    "processed" => "1"}]}]}
+
+    expected = """
+    ```+------------------+----------+-------+------+---------+-----------+---------+------+
+    | Id               | Text     | User  | Room | State   | Processed | Started | Time |
+    +------------------+----------+-------+------+---------+-----------+---------+------+
+    | beefbeefbeefbeef | echo foo | chris | dev  | running | 1         | Noon    | 123  |
+    | beefbeefbeefbeef | echo foo | chris | dev  | running | 1         | Noon    | 123  |
+    +------------------+----------+-------+------+---------+-----------+---------+------+
+    ```
+    """ |> String.strip
+
+    assert_rendered_template(:slack, :embedded, "pipeline-list", data, expected)
+  end
+end


### PR DESCRIPTION
This PR adds several commands aimed at helping users manage pipeline execution and their command history a la standard Unix shell behaviors. The commands are:

* `pipeline list` - `ps`-style command for viewing pipeline status
* `pipeline info` - Displays detailed information about a specific pipeline
* `pipeline kill` - Aborts an executing pipeline
* `history` - Lists user's command history
* `history exec` - Re-executes a previous command history entry

Pipeline information is stored in the DB and retained essentially forever. Commands which list data, like `pipeline list` and `history`, limit the number of entries to 20 unless the user specifies otherwise. Pipeline process information is also stored in the DB, which is a little odd, but avoids having to keep two data stores in sync (DB table and ETS in-memory table).

There are a couple of TODOs left which need to be addressed. I'm not going to have time before I travel so I'll explain them here and trust either someone else will handle them or I'll tackle the work once I've got internet access again.

In rough priority order:

- [x] Template tests - Builds are currently failing because the new commands' templates are lacking tests. Should be pretty easy, if a little tedious, to address.
- [x] `pipeline kill` should return a list of killed pipeline IDs in its response so as to play nicely with pipelines.
- [x] `pipeline list`'s output should include only pipelines in `running` or `waiting` states. `finished` pipelines can be viewed with `history`.
- [ ] Some of the queries in `Cog.Repository.PipelineHistory` could use some refactoring to reduce duplication via query composition.
- [ ] Revisit permissions - Currently any user can view the pipeline history for any other user. LIkewise any user can kill any other user's executing pipelines. I'm not sure this is the desired behavior. I can make convincing arguments for both sides.

`pipeline exec`'s output isn't currently spliced into the parent pipeline. In other words, pipelines initiated by `pipeline exec` execute in parallel and independently of the pipeline managing the call to `pipeline exec`. This is a known limitation of Cog's current design and will require internal refactors to address. imo, this work should be considered out of scope for this PR and can be tackled separately.