### PR TITLE
group many-to-many associations

### DIFF
--- a/lib/cog/models/group.ex
+++ b/lib/cog/models/group.ex
@@ -75,8 +75,7 @@ defimpl Poison.Encoder, for: Cog.Models.Group do
   def encode(struct, options) do
     map = struct
     |> Map.from_struct
-    |> Map.take([:id, :name, :roles])
-    |> Map.put(:members, struct.users)
+    |> Map.take([:id, :name, :roles, :users])
 
     Poison.Encoder.Map.encode(map, options)
   end

--- a/lib/cog/repository/groups.ex
+++ b/lib/cog/repository/groups.ex
@@ -19,7 +19,7 @@ defmodule Cog.Repository.Groups do
   alias Cog.Models.Role
   import Ecto.Query, only: [from: 2]
 
-  @preloads [:direct_user_members, :roles]
+  @preloads [:users, :roles]
 
   @doc """
   Creates a new user group given a map of attributes

--- a/test/commands/group/member/remove_test.exs
+++ b/test/commands/group/member/remove_test.exs
@@ -29,7 +29,7 @@ defmodule Cog.Test.Commands.Group.Member.RemoveTest do
     do: [group: group("elves")]
 
   defp is_group_user?(%Cog.Models.Group{}=group, username) do
-    Enum.map(group.user_membership, &(&1.member.username))
+    Enum.map(group.users, &(&1.username))
     |> Enum.member?(username)
   end
   defp is_group_user?(%{members: members}, username) do

--- a/test/controllers/v1/group_membership_controller_test.exs
+++ b/test/controllers/v1/group_membership_controller_test.exs
@@ -34,7 +34,7 @@ defmodule Cog.V1.GroupMembershipController.Test do
     assert conn.halted
     assert conn.status == 403
 
-    assert [] == Repo.preload(group, :direct_user_members).direct_user_members
+    assert [] == Repo.preload(group, :users).users
   end
 
   test "fails if group doesn't exist", %{authed: requestor} do
@@ -54,7 +54,7 @@ defmodule Cog.V1.GroupMembershipController.Test do
 
     # user's got nothing yet!
     assert [] == Repo.preload(user, :direct_group_memberships).direct_group_memberships
-    assert [] == Repo.preload(group, :direct_user_members).direct_user_members
+    assert [] == Repo.preload(group, :users).users
 
     conn = api_request(requestor, :post, "/v1/groups/#{group.id}/users",
                        body: %{"users" => %{"add" => [user.username]}})
@@ -68,7 +68,7 @@ defmodule Cog.V1.GroupMembershipController.Test do
                                                        "email_address" => user.email_address}],
                                          "roles" => []}}} == json_response(conn, 200)
 
-    assert [user] == Repo.preload(group, :direct_user_members).direct_user_members
+    assert [user] == Repo.preload(group, :users).users
     assert [group] == Repo.preload(user, :direct_group_memberships).direct_group_memberships
   end
 
@@ -79,7 +79,7 @@ defmodule Cog.V1.GroupMembershipController.Test do
     [hal, data, robbie] = users = Enum.map(usernames, &user(&1))
 
     # group's got nothing yet!
-    assert [] == Repo.preload(group, :direct_user_members).direct_user_members
+    assert [] == Repo.preload(group, :users).users
 
     # Grant the permissions
     conn = api_request(requestor, :post, "/v1/groups/#{group.id}/users",
@@ -150,7 +150,7 @@ defmodule Cog.V1.GroupMembershipController.Test do
                                                       "i_dont_exist"]}})
     assert json_response(conn, 422) == %{"errors" => %{"not_found" => %{"users" => ["i_dont_exist"]}}}
 
-    assert [] == Repo.preload(group, :direct_user_members).direct_user_members
+    assert [] == Repo.preload(group, :users).users
   end
 
   test "adding a user works even when the user is already a member", %{authed: requestor} do
@@ -186,7 +186,7 @@ defmodule Cog.V1.GroupMembershipController.Test do
                           "members" => %{"users" => [],
                                          "roles" => []}}} == json_response(conn, 200)
 
-    assert [] == Repo.preload(group, :direct_user_members).direct_user_members
+    assert [] == Repo.preload(group, :users).users
   end
 
   test "remove multiple users at once", %{authed: requestor} do
@@ -245,7 +245,7 @@ defmodule Cog.V1.GroupMembershipController.Test do
 
     assert json_response(conn, 422) == %{"errors" => %{"not_found" => %{"users" => ["i_dont_exist"]}}}
 
-    assert [user] == Repo.preload(group, :direct_user_members).direct_user_members
+    assert [user] == Repo.preload(group, :users).users
   end
 
   test "removing a user works even when the user wasn't a member in the first place", %{authed: requestor} do

--- a/test/support/database_assertions.ex
+++ b/test/support/database_assertions.ex
@@ -95,8 +95,8 @@ defmodule DatabaseAssertions do
   end
 
   def assert_group_member_was_added(group, %Cog.Models.User{}=member) do
-    loaded = Repo.preload(group, :direct_user_members)
-    assert member in loaded.direct_user_members
+    loaded = Repo.preload(group, :users)
+    assert member in loaded.users
   end
   def assert_group_member_was_added(group, %Cog.Models.Group{}=member) do
     loaded = Repo.preload(group, :direct_group_members)

--- a/web/views/groups_view.ex
+++ b/web/views/groups_view.ex
@@ -5,7 +5,7 @@ defmodule Cog.V1.GroupView do
     %{id: group.id,
       name: group.name,
       members: %{roles: render_roles(group.roles),
-                 users: render_users(group.direct_user_members)}
+                 users: render_users(group.users)}
     }
   end
 
@@ -21,7 +21,7 @@ defmodule Cog.V1.GroupView do
     %{id: group.id,
       name: group.name,
       roles: render_roles(group.roles),
-      members: render_users(group.direct_user_members)}
+      members: render_users(group.users)}
   end
 
   defp render_roles(roles) when is_list(roles) do


### PR DESCRIPTION
This just changes the user and role associations to many-to-many, which reduces some of the extra unnecessary bits on the model.