### PR TITLE
Restrict deletion on group and relay group relations

### DIFF
--- a/lib/cog/models/group.ex
+++ b/lib/cog/models/group.ex
@@ -49,6 +49,8 @@ defmodule Cog.Models.Group do
     model
     |> cast(params, @required_fields, @optional_fields)
     |> protect_admin_group
+    |> group_roles_constraint
+    |> user_group_membership_constraint
     |> unique_constraint(:name, name: :groups_name_index)
   end
 
@@ -61,6 +63,19 @@ defmodule Cog.Models.Group do
     end
   end
 
+  defp group_roles_constraint(changeset) do
+    foreign_key_constraint(changeset,
+                           :id,
+                           name: :group_roles_group_id_fkey,
+                           message: "cannot delete group that has been granted roles")
+  end
+
+  defp user_group_membership_constraint(changeset) do
+    foreign_key_constraint(changeset,
+                           :id,
+                           name: :user_group_membership_group_id_fkey,
+                           message: "cannot delete group that has user members")
+  end
 end
 
 defimpl Permittable, for: Cog.Models.Group do

--- a/lib/cog/models/group_role.ex
+++ b/lib/cog/models/group_role.ex
@@ -14,6 +14,6 @@ defmodule Cog.Models.GroupRole do
   def changeset(model, params) do
     model
     |> cast(params, @required_fields)
-    |> unique_constraint(:role_grant , name: "group_roles_group_id_role_id_index")
+    |> unique_constraint(:role_grant, name: "group_roles_group_id_role_id_index")
   end
 end

--- a/lib/cog/models/permission.ex
+++ b/lib/cog/models/permission.ex
@@ -2,7 +2,6 @@ defmodule Cog.Models.Permission do
   use Cog.Model
 
   alias Cog.Models.Bundle
-  alias Ecto.Changeset
 
   schema "permissions" do
     belongs_to :bundle, Bundle
@@ -47,8 +46,9 @@ defmodule Cog.Models.Permission do
 
   def changeset(model, params) do
     model
-    |> Changeset.cast(params, @required_fields, @optional_fields)
-    |> Changeset.unique_constraint(:name, name: "permissions_bundle_id_name_index")
+    |> cast(params, @required_fields, @optional_fields)
+    |> role_permissions_constraint
+    |> unique_constraint(:name, name: "permissions_bundle_id_name_index")
   end
 
   @doc """
@@ -70,4 +70,10 @@ defmodule Cog.Models.Permission do
     {bundle, name}
   end
 
+  defp role_permissions_constraint(changeset) do
+    foreign_key_constraint(changeset,
+                           :id,
+                           name: :role_permissions_permission_id_fkey,
+                           message: "cannot delete permission that has been granted to a role")
+  end
 end

--- a/lib/cog/models/relay_group.ex
+++ b/lib/cog/models/relay_group.ex
@@ -25,9 +25,24 @@ defmodule Cog.Models.RelayGroup do
     model
     |> Repo.preload([:bundles, :relays])
     |> cast(params, @required_fields, @optional_fields)
+    |> relay_group_assignment_constraint
+    |> relay_group_membership_constraint
     |> unique_constraint(:name)
   end
 
+  defp relay_group_assignment_constraint(changeset) do
+    foreign_key_constraint(changeset,
+                           :id,
+                           name: :relay_group_assignments_group_id_fkey,
+                           message: "cannot delete relay group that has bundles assigned")
+  end
+
+  defp relay_group_membership_constraint(changeset) do
+    foreign_key_constraint(changeset,
+                           :id,
+                           name: :relay_group_memberships_group_id_fkey,
+                           message: "cannot delete relay group that has relay members")
+  end
 end
 
 defimpl Groupable, for: Cog.Models.RelayGroups do

--- a/lib/cog/models/role.ex
+++ b/lib/cog/models/role.ex
@@ -46,6 +46,8 @@ defmodule Cog.Models.Role do
     model
     |> cast(params, @required_fields, @optional_fields)
     |> protect_admin_role
+    |> group_roles_constraint
+    |> role_permissions_constraint
     |> unique_constraint(:name)
   end
 
@@ -58,6 +60,19 @@ defmodule Cog.Models.Role do
     end
   end
 
+  defp group_roles_constraint(changeset) do
+    foreign_key_constraint(changeset,
+                           :id,
+                           name: :group_roles_role_id_fkey,
+                           message: "cannot delete role that has been granted to a group")
+  end
+
+  defp role_permissions_constraint(changeset) do
+    foreign_key_constraint(changeset,
+                           :id,
+                           name: :role_permissions_role_id_fkey,
+                           message: "cannot delete role that has been granted permissions")
+  end
 end
 
 defimpl Permittable, for: Cog.Models.Role do

--- a/lib/cog/models/user.ex
+++ b/lib/cog/models/user.ex
@@ -80,6 +80,7 @@ defmodule Cog.Models.User do
     |> cast(params, @required_fields, @optional_fields)
     |> validate_presence_on_insert(:password)
     |> encode_password
+    |> user_group_membership_constraint
     |> unique_constraint(:username)
   end
 
@@ -110,6 +111,12 @@ defmodule Cog.Models.User do
     end
   end
 
+  defp user_group_membership_constraint(changeset) do
+    foreign_key_constraint(changeset,
+                           :id,
+                           name: :user_group_membership_member_id_fkey,
+                           message: "cannot delete user that is a member of a group")
+  end
 end
 
 defimpl Permittable, for: Cog.Models.User do

--- a/lib/cog/repository/relays.ex
+++ b/lib/cog/repository/relays.ex
@@ -74,7 +74,8 @@ defmodule Cog.Repository.Relays do
   def delete(id) do
     try do
       with {:ok, relay} <- by_id(id),
-           {:ok, deleted_relay} <- Repo.delete(relay),
+           changeset <- Relay.changeset(relay, %{}),
+           {:ok, deleted_relay} <- Repo.delete(changeset),
            :ok <- Relays.drop_relay(relay),
              do: {:ok, deleted_relay}
     rescue

--- a/priv/repo/migrations/20170123141709_convert_cascade_references_to_restrict.exs
+++ b/priv/repo/migrations/20170123141709_convert_cascade_references_to_restrict.exs
@@ -1,0 +1,61 @@
+defmodule Cog.Repo.Migrations.ConvertCascadeReferencesToRestrict do
+  use Ecto.Migration
+
+  def up do
+    execute "ALTER TABLE group_roles DROP CONSTRAINT group_roles_group_id_fkey"
+    execute "ALTER TABLE group_roles ADD CONSTRAINT group_roles_group_id_fkey FOREIGN KEY (group_id) REFERENCES groups(id) ON UPDATE CASCADE ON DELETE RESTRICT"
+
+    execute "ALTER TABLE group_roles DROP CONSTRAINT group_roles_role_id_fkey"
+    execute "ALTER TABLE ONLY group_roles ADD CONSTRAINT group_roles_role_id_fkey FOREIGN KEY (role_id) REFERENCES roles(id) ON UPDATE CASCADE ON DELETE RESTRICT"
+
+    execute "ALTER TABLE relay_group_assignments DROP CONSTRAINT relay_group_assignments_group_id_fkey"
+    execute "ALTER TABLE ONLY relay_group_assignments ADD CONSTRAINT relay_group_assignments_group_id_fkey FOREIGN KEY (group_id) REFERENCES relay_groups(id) ON UPDATE CASCADE ON DELETE RESTRICT"
+
+    execute "ALTER TABLE relay_group_memberships DROP CONSTRAINT relay_group_memberships_group_id_fkey"
+    execute "ALTER TABLE ONLY relay_group_memberships ADD CONSTRAINT relay_group_memberships_group_id_fkey FOREIGN KEY (group_id) REFERENCES relay_groups(id) ON UPDATE CASCADE ON DELETE RESTRICT"
+
+    execute "ALTER TABLE relay_group_memberships DROP CONSTRAINT relay_group_memberships_relay_id_fkey"
+    execute "ALTER TABLE ONLY relay_group_memberships ADD CONSTRAINT relay_group_memberships_relay_id_fkey FOREIGN KEY (relay_id) REFERENCES relays(id) ON UPDATE CASCADE ON DELETE RESTRICT"
+
+    execute "ALTER TABLE role_permissions DROP CONSTRAINT role_permissions_permission_id_fkey"
+    execute "ALTER TABLE ONLY role_permissions ADD CONSTRAINT role_permissions_permission_id_fkey FOREIGN KEY (permission_id) REFERENCES permissions(id) ON UPDATE CASCADE ON DELETE RESTRICT"
+
+    execute "ALTER TABLE role_permissions DROP CONSTRAINT role_permissions_role_id_fkey"
+    execute "ALTER TABLE ONLY role_permissions ADD CONSTRAINT role_permissions_role_id_fkey FOREIGN KEY (role_id) REFERENCES roles(id) ON UPDATE CASCADE ON DELETE RESTRICT"
+
+    execute "ALTER TABLE user_group_membership DROP CONSTRAINT user_group_membership_group_id_fkey"
+    execute "ALTER TABLE ONLY user_group_membership ADD CONSTRAINT user_group_membership_group_id_fkey FOREIGN KEY (group_id) REFERENCES groups(id) ON UPDATE CASCADE ON DELETE RESTRICT"
+
+    execute "ALTER TABLE user_group_membership DROP CONSTRAINT user_group_membership_member_id_fkey"
+    execute "ALTER TABLE ONLY user_group_membership ADD CONSTRAINT user_group_membership_member_id_fkey FOREIGN KEY (member_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE RESTRICT"
+  end
+
+  def down do
+    execute "ALTER TABLE group_roles DROP CONSTRAINT group_roles_group_id_fkey"
+    execute "ALTER TABLE group_roles ADD CONSTRAINT group_roles_group_id_fkey FOREIGN KEY (group_id) REFERENCES groups(id) ON DELETE CASCADE"
+
+    execute "ALTER TABLE group_roles DROP CONSTRAINT group_roles_role_id_fkey"
+    execute "ALTER TABLE ONLY group_roles ADD CONSTRAINT group_roles_role_id_fkey FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE"
+
+    execute "ALTER TABLE relay_group_assignments DROP CONSTRAINT relay_group_assignments_group_id_fkey"
+    execute "ALTER TABLE ONLY relay_group_assignments ADD CONSTRAINT relay_group_assignments_group_id_fkey FOREIGN KEY (group_id) REFERENCES relay_groups(id) ON DELETE CASCADE"
+
+    execute "ALTER TABLE relay_group_memberships DROP CONSTRAINT relay_group_memberships_group_id_fkey"
+    execute "ALTER TABLE ONLY relay_group_memberships ADD CONSTRAINT relay_group_memberships_group_id_fkey FOREIGN KEY (group_id) REFERENCES relay_groups(id) ON DELETE CASCADE"
+
+    execute "ALTER TABLE relay_group_memberships DROP CONSTRAINT relay_group_memberships_relay_id_fkey"
+    execute "ALTER TABLE ONLY relay_group_memberships ADD CONSTRAINT relay_group_memberships_relay_id_fkey FOREIGN KEY (relay_id) REFERENCES relays(id) ON DELETE CASCADE"
+
+    execute "ALTER TABLE role_permissions DROP CONSTRAINT role_permissions_permission_id_fkey"
+    execute "ALTER TABLE ONLY role_permissions ADD CONSTRAINT role_permissions_permission_id_fkey FOREIGN KEY (permission_id) REFERENCES permissions(id) ON DELETE CASCADE"
+
+    execute "ALTER TABLE role_permissions DROP CONSTRAINT role_permissions_role_id_fkey"
+    execute "ALTER TABLE ONLY role_permissions ADD CONSTRAINT role_permissions_role_id_fkey FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE"
+
+    execute "ALTER TABLE user_group_membership DROP CONSTRAINT user_group_membership_group_id_fkey"
+    execute "ALTER TABLE ONLY user_group_membership ADD CONSTRAINT user_group_membership_group_id_fkey FOREIGN KEY (group_id) REFERENCES groups(id) ON DELETE CASCADE"
+
+    execute "ALTER TABLE user_group_membership DROP CONSTRAINT user_group_membership_member_id_fkey"
+    execute "ALTER TABLE ONLY user_group_membership ADD CONSTRAINT user_group_membership_member_id_fkey FOREIGN KEY (member_id) REFERENCES users(id) ON DELETE CASCADE"
+  end
+end

--- a/test/cog/bootstrap_test.exs
+++ b/test/cog/bootstrap_test.exs
@@ -100,7 +100,8 @@ defmodule Cog.Bootstrap.Test do
 
   test "the embedded bundle cannot be deleted" do
     try do
-      Cog.Models.Bundle |> Cog.Repo.delete_all
+      embedded = Repo.get_by!(Bundle, name: Cog.Util.Misc.embedded_bundle)
+      Cog.Repository.Bundles.delete(embedded)
     rescue
       exception ->
         assert exception.postgres.message == "cannot modify embedded bundle"

--- a/test/cog/bootstrap_test.exs
+++ b/test/cog/bootstrap_test.exs
@@ -1,10 +1,6 @@
 defmodule Cog.Bootstrap.Test do
   use Cog.ModelCase
-
-  alias Cog.Models.Bundle
-  alias Cog.Models.BundleVersion
-  alias Cog.Models.Group
-  alias Cog.Models.Role
+  alias Cog.Models.{Bundle, BundleVersion, Group, Role}
 
   @admin_user %{
     "username" => "test-admin",
@@ -18,8 +14,8 @@ defmodule Cog.Bootstrap.Test do
       {:ok, bootstrapped: false}
     else
       {:ok, admin_user} = Cog.Bootstrap.bootstrap(@admin_user)
-      admin_role = Cog.Repo.get_by!(Role, name: Cog.Util.Misc.admin_role)
-      admin_group = Cog.Repo.get_by!(Group, name: Cog.Util.Misc.admin_group)
+      admin_role = Repo.get_by!(Role, name: Cog.Util.Misc.admin_role)
+      admin_group = Repo.get_by!(Group, name: Cog.Util.Misc.admin_group)
       {:ok, admin: admin_user, admin_role: admin_role, admin_group: admin_group, bootstrapped: true}
     end
   end
@@ -78,25 +74,27 @@ defmodule Cog.Bootstrap.Test do
     refute Cog.Bootstrap.is_bootstrapped?
 
     Cog.Bootstrap.bootstrap(@admin_user)
-    assert Cog.Models.Group |> Cog.Repo.one! |> Map.get(:name) == Cog.Util.Misc.admin_group
+    assert Group |> Repo.one! |> Map.get(:name) == Cog.Util.Misc.admin_group
     assert Cog.Bootstrap.is_bootstrapped?
   end
 
   test "the admin group cannot be deleted" do
     try do
-      Cog.Models.Group |> Cog.Repo.delete_all
+      admin_group = Repo.get_by!(Group, name: Cog.Util.Misc.admin_group)
+      Repo.delete(admin_group)
     rescue
       exception ->
-        assert exception.postgres.message == "cannot modify admin group"
+        assert %Ecto.ConstraintError{constraint: "group_roles_group_id_fkey"} = exception
     end
   end
 
   test "the admin role cannot be deleted" do
     try do
-      Cog.Models.Role |> Cog.Repo.delete_all
+      admin_role = Repo.get_by!(Role, name: Cog.Util.Misc.admin_group)
+      Repo.delete(admin_role)
     rescue
       exception ->
-        assert exception.postgres.message == "cannot modify admin role"
+        assert %Ecto.ConstraintError{constraint: "group_roles_role_id_fkey"} = exception
     end
   end
 

--- a/test/cog/group_test.exs
+++ b/test/cog/group_test.exs
@@ -1,5 +1,6 @@
 defmodule GroupTest do
   use Cog.ModelCase
+  alias Cog.Models.Group
 
   setup do
     {:ok, [user: user("cog"),
@@ -38,4 +39,17 @@ defmodule GroupTest do
     assert(:ok = Permittable.grant_to(group, role))
   end
 
+  test "deleting a group with roles granted", %{group: group, role: role} do
+    :ok = Permittable.grant_to(group, role)
+    changeset = Group.changeset(group, %{})
+    assert {:error, changeset} = Repo.delete(changeset)
+    assert [id: {"cannot delete group that has been granted roles", []}] = changeset.errors
+  end
+
+  test "deleting a group with members", %{group: group, user: user} do
+    :ok = Groupable.add_to(user, group)
+    changeset = Group.changeset(group, %{})
+    assert {:error, changeset} = Repo.delete(changeset)
+    assert [id: {"cannot delete group that has user members", []}] = changeset.errors
+  end
 end

--- a/test/cog/models/permission_test.exs
+++ b/test/cog/models/permission_test.exs
@@ -1,4 +1,18 @@
 defmodule Cog.Models.Permission.Test do
-  use ExUnit.Case
-  doctest Cog.Models.Permission
+  use Cog.ModelCase
+  alias Cog.Models.Permission
+
+  doctest Permission
+
+  setup do
+    {:ok, [role: role("admin"),
+           permission: permission("test:do_stuff")]}
+  end
+
+  test "deleting a permission granted to a role", %{role: role, permission: permission} do :ok = Permittable.grant_to(role, permission)
+    :ok = Permittable.grant_to(role, permission)
+    changeset = Permission.changeset(permission, %{})
+    assert {:error, changeset} = Repo.delete(changeset)
+    assert [id: {"cannot delete permission that has been granted to a role", []}] = changeset.errors
+  end
 end

--- a/test/cog/models/relay_group_test.exs
+++ b/test/cog/models/relay_group_test.exs
@@ -1,0 +1,24 @@
+defmodule Cog.Models.RelayGroup.Test do
+  use Cog.ModelCase
+  alias Cog.Models.RelayGroup
+
+  setup do
+    {:ok, [relay: relay("test_relay", "sekret"),
+           relay_group: relay_group("test_relay_group"),
+           bundle: bundle_version("test_bundle").bundle]}
+  end
+
+  test "deleting a relay group with a relay member", %{relay: relay, relay_group: relay_group} do
+    :ok = Groupable.add_to(relay, relay_group)
+    changeset = RelayGroup.changeset(relay_group, %{})
+    assert {:error, changeset} = Repo.delete(changeset)
+    assert [id: {"cannot delete relay group that has relay members", []}] = changeset.errors
+  end
+
+  test "deleting a relay group with a bundle assigned", %{bundle: bundle, relay_group: relay_group} do
+    :ok = Groupable.add_to(bundle, relay_group)
+    changeset = RelayGroup.changeset(relay_group, %{})
+    assert {:error, changeset} = Repo.delete(changeset)
+    assert [id: {"cannot delete relay group that has bundles assigned", []}] = changeset.errors
+  end
+end

--- a/test/cog/models/relay_test.exs
+++ b/test/cog/models/relay_test.exs
@@ -1,0 +1,16 @@
+defmodule Cog.Models.Relay.Test do
+  use Cog.ModelCase
+  alias Cog.Models.Relay
+
+  setup do
+    {:ok, [relay: relay("test_relay", "sekret"),
+           relay_group: relay_group("test_relay_group")]}
+  end
+
+  test "deleting a relay that is a member of a relay group", %{relay: relay, relay_group: relay_group} do
+    :ok = Groupable.add_to(relay, relay_group)
+    changeset = Relay.changeset(relay, %{})
+    assert {:error, changeset} = Repo.delete(changeset)
+    assert [id: {"cannot delete relay that is a member of a relay group", []}] = changeset.errors
+  end
+end

--- a/test/cog/role_test.exs
+++ b/test/cog/role_test.exs
@@ -1,9 +1,11 @@
 defmodule RoleTest do
   use Cog.ModelCase
+  alias Cog.Models.Role
 
   setup do
     {:ok, [role: role("admin"),
-           permission: permission("test:do_stuff")]}
+           permission: permission("test:do_stuff"),
+           group: group("test_group")]}
   end
 
   test "permissions may be granted to roles", %{role: role, permission: permission} do
@@ -12,8 +14,21 @@ defmodule RoleTest do
   end
 
   test "adding a permission to a role is idempotent", %{role: role, permission: permission} do
-    Permittable.grant_to(role, permission)
+    :ok = Permittable.grant_to(role, permission)
     assert(:ok = Permittable.grant_to(role, permission))
   end
 
+  test "deleting a role granted to a group", %{role: role, group: group} do
+    :ok = Permittable.grant_to(group, role)
+    changeset = Role.changeset(role, %{})
+    assert {:error, changeset} = Repo.delete(changeset)
+    assert [id: {"cannot delete role that has been granted to a group", []}] = changeset.errors
+  end
+
+  test "deleting a role with granted permissions", %{role: role, permission: permission} do
+    :ok = Permittable.grant_to(role, permission)
+    changeset = Role.changeset(role, %{})
+    assert {:error, changeset} = Repo.delete(changeset)
+    assert [id: {"cannot delete role that has been granted permissions", []}] = changeset.errors
+  end
 end

--- a/test/cog/user_test.exs
+++ b/test/cog/user_test.exs
@@ -8,7 +8,8 @@ defmodule UserTest do
     user = user("cog")
     {:ok, [user: user,
            role: role("create"),
-           permission: permission("test:creation")]}
+           permission: permission("test:creation"),
+           group: group("test_group")]}
   end
 
   test "permissions may be granted directly to users", %{user: user, permission: permission} do
@@ -107,6 +108,13 @@ defmodule UserTest do
 
     assert old_digest != updated.password_digest
     assert String.starts_with?(updated.password_digest, "$2")
+  end
+
+  test "deleting a user belonging to a group", %{user: user, group: group} do
+    :ok = Groupable.add_to(user, group)
+    changeset = User.changeset(user, %{})
+    assert {:error, changeset} = Repo.delete(changeset)
+    assert [id: {"cannot delete user that is a member of a group", []}] = changeset.errors
   end
 
   @doc """

--- a/test/controllers/v1/relay_controller_test.exs
+++ b/test/controllers/v1/relay_controller_test.exs
@@ -101,7 +101,7 @@ defmodule Cog.V1.RelayControllerTest do
   test "deleted relays are removed from the tracker", %{authed: requestor} do
     # We create a relay and add a bundle to it so we can query for it in
     # 'Cog.Relay.Relays'
-    {relay, bundle_version, _relay_group} = create_relay_bundle_and_group("deleted-relay", relay_opts: [enabled: true])
+    {relay, bundle_version, relay_group} = create_relay_bundle_and_group("deleted-relay", relay_opts: [enabled: true])
 
     # We shouldn't see any relays running our bundle yet, because the relay
     # has not yet announced it's presence.
@@ -117,6 +117,7 @@ defmodule Cog.V1.RelayControllerTest do
     assert Relays.relays_running(bundle_version.bundle.name, bundle_version.version) == [relay.id]
 
     # This should delete the relay
+    api_request(requestor, :post, "/v1/relay_groups/#{relay_group.id}/relays", body: %{"relays" => %{"remove" => [relay.id]}})
     conn = api_request(requestor, :delete, "/v1/relays/#{relay.id}")
 
     # Confirm that the api thinks the relay has been deleted

--- a/web/controllers/v1/relay_controller.ex
+++ b/web/controllers/v1/relay_controller.ex
@@ -55,6 +55,10 @@ defmodule Cog.V1.RelayController do
         conn
         |> put_status(:bad_request)
         |> json(%{errors: "Bad ID format"})
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(Cog.ChangesetView, "error.json", changeset: changeset)
     end
   end
 


### PR DESCRIPTION
Instead of restricting on delete for all foreign key relations, it made sense to only restrict relations that can be manually modified via the api. The main exception is the tree of bundle relations, so when a bundle is deleted we still cascade and delete all associated child records. To cleanly delete bundles, permissions are unlinked from any roles they had been granted to first. All exceptions raised are returned as errors on the id attribute since there's no other key that would really make sense to hang it off of.

Closes https://github.com/operable/cog/issues/794