### PR TITLE
fix group chat command

### DIFF
--- a/lib/cog/models/group.ex
+++ b/lib/cog/models/group.ex
@@ -91,11 +91,10 @@ end
 # Currently we have one scheme for the chat command and another for the api.
 defimpl Poison.Encoder, for: Cog.Models.Group do
   def encode(struct, options) do
-    map = struct
+    struct
     |> Map.from_struct
     |> Map.take([:id, :name, :roles])
     |> Map.put(:members, struct.users)
-
-    Poison.Encoder.Map.encode(map, options)
+    |> Poison.Encoder.Map.encode(options)
   end
 end

--- a/lib/cog/models/group.ex
+++ b/lib/cog/models/group.ex
@@ -86,11 +86,15 @@ defimpl Permittable, for: Cog.Models.Group do
 
 end
 
+# As far as I can tell this is only being used with the group chat command
+# TODO: We need to consolidate how we present group data to the end user.
+# Currently we have one scheme for the chat command and another for the api.
 defimpl Poison.Encoder, for: Cog.Models.Group do
   def encode(struct, options) do
     map = struct
     |> Map.from_struct
-    |> Map.take([:id, :name, :roles, :users])
+    |> Map.take([:id, :name, :roles])
+    |> Map.put(:members, struct.users)
 
     Poison.Encoder.Map.encode(map, options)
   end

--- a/test/commands/group/info_test.exs
+++ b/test/commands/group/info_test.exs
@@ -11,6 +11,8 @@ defmodule Cog.Test.Commands.Group.InfoTest do
       new_req(args: ["info_group"])
       |> send_req(Info)
 
-    assert(%{name: "info_group"} = response)
+    assert(%{name: "info_group",
+             roles: [],
+             members: []} = response)
   end
 end

--- a/test/commands/group/info_test.exs
+++ b/test/commands/group/info_test.exs
@@ -2,7 +2,10 @@ defmodule Cog.Test.Commands.Group.InfoTest do
   use Cog.CommandCase, command_module: Cog.Commands.Group
 
   alias Cog.Commands.Group.Info
-  import Cog.Support.ModelUtilities, only: [group: 1]
+  import Cog.Support.ModelUtilities, only: [group: 1,
+                                            user: 1,
+                                            role: 1,
+                                            add_to_group: 2]
 
   test "can get info" do
     group("info_group")
@@ -14,5 +17,23 @@ defmodule Cog.Test.Commands.Group.InfoTest do
     assert(%{name: "info_group",
              roles: [],
              members: []} = response)
+  end
+
+  test "can get info with members and roles" do
+    group("info_group")
+    |> add_to_group(role("role1"))
+    |> add_to_group(role("role2"))
+    |> add_to_group(user("user1"))
+    |> add_to_group(user("user2"))
+
+    {:ok, response} =
+      new_req(args: ["info_group"])
+      |> send_req(Info)
+
+    assert(%{name: "info_group",
+             roles: [%{name: "role1"},
+                     %{name: "role2"}],
+             members: [%{username: "user1"},
+                       %{username: "user2"}]} = response)
   end
 end


### PR DESCRIPTION
Replaces the users key with a members key when encoding a group to json. Fixes the bug with group info not returning associated members.

resolves #1332 