### PR TITLE
Support command aborts

### DIFF
--- a/lib/cog.ex
+++ b/lib/cog.ex
@@ -18,7 +18,7 @@ defmodule Cog do
     maybe_display_unenforcing_warning()
     children = [worker(Cog.BusDriver, [], shutdown: 1000),
                 supervisor(Carrier.Messaging.ConnectionSup, []),
-                worker(Cog.Repo, []),
+                supervisor(Cog.DBSup, []),
                 supervisor(Cog.CoreSup, [])]
 
     opts = [strategy: :one_for_one, name: Cog.Supervisor]

--- a/lib/cog/command/gen_command.ex
+++ b/lib/cog/command/gen_command.ex
@@ -203,6 +203,10 @@ defmodule Cog.Command.GenCommand do
           new_state = %{state | cb_state: cb_state}
           send_error_reply(error_message, reply_to, new_state)
           {:noreply, new_state}
+        {:abort, reply_to, message, cb_state} ->
+          new_state = %{state | cb_state: cb_state}
+          send_abort_reply(message, reply_to, new_state)
+          {:noreply, new_state}
         {:noreply, cb_state} ->
           new_state = %{state | cb_state: cb_state}
           {:noreply, new_state}
@@ -213,6 +217,14 @@ defmodule Cog.Command.GenCommand do
         send_error_reply(message, req.reply_to, state)
         {:noreply, state}
     end
+  end
+
+  ########################################################################
+
+  defp send_abort_reply(message, reply_to, state) do
+    resp = %Cog.Messages.CommandResponse{status: "abort",
+                                         status_message: message}
+    Carrier.Messaging.Connection.publish(state.mq_conn, resp, routed_by: reply_to)
   end
 
   ########################################################################

--- a/lib/cog/commands/abort_when.ex
+++ b/lib/cog/commands/abort_when.ex
@@ -1,0 +1,31 @@
+defmodule Cog.Commands.AbortWhen do
+  use Cog.Command.GenCommand.Base,
+    bundle: Cog.Util.Misc.embedded_bundle,
+    name: "abort-when"
+
+  @description "Aborts pipeline when argument evaluates to truthy"
+
+  @arguments "value"
+
+  @default_message "Pipeline aborted"
+
+  option "message", short: "m", type: "string", required: false,
+    description: "Message sent when pipeline is aborted"
+
+  # Allow any user to run
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:abort-when allow"
+
+  def handle_message(req, state) do
+    case eval_args(req.args) do
+      true ->
+        {:abort, req.reply_to, Map.get(req.options, "message", @default_message), state}
+      false ->
+        {:reply, req.reply_to, req.cog_env, state}
+    end
+  end
+
+  defp eval_args([n|_]) when n > 0, do: true
+  defp eval_args([true|_]), do: true
+  defp eval_args(_), do: false
+
+end

--- a/lib/cog/db_sup.ex
+++ b/lib/cog/db_sup.ex
@@ -1,0 +1,29 @@
+defmodule Cog.DBSup do
+
+  require Logger
+  use Supervisor
+
+  alias Cog.Repository.PipelineHistory
+
+  def start_link() do
+    case Supervisor.start_link(__MODULE__, []) do
+      {:ok, pid} ->
+        # Update orphaned pipeline statuses after Cog.Repo has been started.
+        # This ensures we have a (relatively) consistent view
+        # of pipelines and their status after we start up.
+        count = PipelineHistory.update_orphans()
+        if count > 0 do
+          Logger.warn("Updated #{count} orphaned pipeline records.")
+        end
+        {:ok, pid}
+      error ->
+        error
+    end
+  end
+
+  def init(_) do
+    children = [worker(Cog.Repo, [])]
+    {:ok, {%{strategy: :one_for_one, intensity: 10, period: 60}, children}}
+  end
+
+end

--- a/lib/cog/pipeline/output_sink.ex
+++ b/lib/cog/pipeline/output_sink.ex
@@ -99,6 +99,7 @@ defmodule Cog.Pipeline.OutputSink do
   defp want_signal?(%DoneSignal{}=done) do
     DoneSignal.error?(done) == false
   end
+  defp want_signal?(_), do: false
 
   def process_output(%__MODULE__{all_events: []}=state, _) do
     state

--- a/lib/cog/pipeline/signals.ex
+++ b/lib/cog/pipeline/signals.ex
@@ -10,7 +10,6 @@ defmodule Cog.Pipeline.DoneSignal do
 
 end
 
-
 defmodule Cog.Pipeline.DataSignal do
   defstruct [invocation: nil,
              template: nil,
@@ -26,5 +25,20 @@ defmodule Cog.Pipeline.DataSignal do
   def wrap(data, bundle_version_id, template) when is_map(data) do
     %__MODULE__{data: data, bundle_version_id: bundle_version_id, template: template}
   end
+
+end
+
+defmodule Cog.Pipeline.AbortSignal do
+  defstruct [message: nil,
+             cog_env: nil,
+             invocation: nil,
+             template: "abort"]
+
+  def wrap(invocation, cog_env, message) do
+    %__MODULE__{invocation: invocation, cog_env: cog_env, message: message}
+  end
+
+  def abort?(%__MODULE__{}), do: true
+  def abort?(_), do: false
 
 end

--- a/priv/templates/common/abort.greenbar
+++ b/priv/templates/common/abort.greenbar
@@ -1,0 +1,7 @@
+~attachment title=$message color="yellow"~
+
+**Command:** `~$invocation~`
+**Calling Environment:** `~$cog_env_text~`
+**Pipeline Id:** ~$pipeline_id~
+
+~end~

--- a/test/integration/abort_test.exs
+++ b/test/integration/abort_test.exs
@@ -1,0 +1,34 @@
+defmodule Integration.AbortTest do
+
+  use Cog.AdapterCase, provider: "test"
+
+  @moduletag integration: :general
+  @moduletag :command
+  @moduletag :abort
+
+  setup do
+    user = user("vanstee", first_name: "Patrick", last_name: "Van Stee")
+    |> with_chat_handle_for("test")
+
+    {:ok, %{user: user}}
+  end
+
+  test "abort-when aborts a pipeline", %{user: user} do
+    response = send_message(user, "@bot: operable:seed '[{\"foo\": 1}]' | operable:abort-when $foo")
+    assert String.starts_with?(response, "Command: operable:abort-when $foo\nCalling Environment: {\n  \"foo\": 1\n}\n")
+    [response] = send_message(user, "@bot: operable:seed '[{\"foo\": 0}]' | operable:abort-when $foo")
+    assert response == %{foo: 0}
+  end
+
+  test "abort-when uses custom abort message", %{user: user} do
+    response = send_message(user, "@bot: operable:seed '[{\"foo\": 1}]' | operable:abort-when -m \"PIPELINE ABORT\" $foo")
+    assert String.starts_with?(response, "Command: operable:abort-when -m \"PIPELINE ABORT\" $foo\nCalling Environment: {\n  \"foo\": 1\n}\n")
+  end
+
+  test "abort-when works in middle of pipeline", %{user: user} do
+    json = Poison.encode!([%{foo: 0}, %{foo: 0}, %{foo: 1}, %{foo: 0}])
+    response = send_message(user, "@bot: operable:seed '#{json}' | operable:abort-when $foo | operable:echo foo is $foo")
+    assert String.starts_with?(response, "Command: operable:abort-when $foo\nCalling Environment: {\n  \"foo\": 1\n}\n")
+  end
+
+end

--- a/test/support/snoop.ex
+++ b/test/support/snoop.ex
@@ -145,6 +145,8 @@ defmodule Cog.Snoop do
     do: text
   defp render_directive(%{"name" => "fixed_width_block", "text" => text}),
     do: text
+  defp render_directive(%{"name" => "bold", "text" => text}),
+    do: text
   # We can also get plain text (e.g., from `echo` output)
   defp render_directive(%{"name" => "text", "text" => text}),
     do: text


### PR DESCRIPTION
Support for command aborts were omitted in initial `Executor` re-work. I suspect our lack of test coverage for aborts had a lot to do with why this happened. This PR restores abort support and adds test coverage.

Fixes #1340 