### PR TITLE
Catch constraint errors on role delete

### DIFF
--- a/lib/cog/models/role.ex
+++ b/lib/cog/models/role.ex
@@ -25,7 +25,7 @@ defmodule Cog.Models.Role do
   If no params are provided, an invalid changeset is returned
   with no validation performed.
   """
-  def changeset(model), do: changeset(model, :empty)
+  def changeset(model, params \\ %{})
 
   @doc """
   Creates a changeset based on the `model` to validate a delete
@@ -34,7 +34,8 @@ defmodule Cog.Models.Role do
   def changeset(model, :delete) do
     %{Changeset.change(model) | action: :delete}
     |> protect_admin_role
-
+    |> group_roles_constraint
+    |> role_permissions_constraint
   end
 
   @doc """

--- a/lib/cog/repository/roles.ex
+++ b/lib/cog/repository/roles.ex
@@ -21,7 +21,7 @@ defmodule Cog.Repository.Roles do
   def delete(%Role{name: unquote(Cog.Util.Misc.admin_role)=name}),
     do: {:error, {:protected_role, name}}
   def delete(%Role{}=role),
-    do: Repo.delete(role)
+    do: role |> Role.changeset(:delete) |> Repo.delete
 
   def all,
     do: Repo.all(Role) |> preload

--- a/test/controllers/v1/role_controller_test.exs
+++ b/test/controllers/v1/role_controller_test.exs
@@ -138,6 +138,15 @@ defmodule Cog.V1.RoleController.Test do
     assert %Ecto.NoResultsError{} = error
   end
 
+  test "delete fails when role still granted permissions", %{authed: user} do
+    role = role("admin")
+    permission = permission("site:world")
+    Permittable.grant_to(role, permission)
+    conn = api_request(user, :delete, "/v1/roles/#{role.id}")
+    body = json_response(conn, 422)
+    assert %{"id" => ["cannot delete role that has been granted permissions"]} = body["errors"]
+  end
+
   test "cannot list roles without permission", %{unauthed: user} do
     conn = api_request(user, :get, "/v1/roles")
     assert conn.halted

--- a/web/controllers/v1/role_controller.ex
+++ b/web/controllers/v1/role_controller.ex
@@ -48,7 +48,7 @@ defmodule Cog.V1.RoleController do
   end
 
   def delete(conn, %{"id" => id}) do
-    case Roles.by_id!(id) |> Roles.delete() do
+    case id |> Roles.by_id! |> Roles.delete do
       {:ok, _} ->
         send_resp(conn, :no_content, "")
       {:error, changed} ->


### PR DESCRIPTION
If trying to delete a role via the API, the server will response with a `422` and the body: `{"errors":{"id":["cannot delete role that has been granted permissions"]}}` instead of throwing an exception.

Fixes https://github.com/operable/cog/issues/1336