### PR TITLE
Replace escaped double quotes with double quotes

### DIFF
--- a/lib/cog/commands/seed.ex
+++ b/lib/cog/commands/seed.ex
@@ -30,6 +30,7 @@ defmodule Cog.Command.Seed do
   def handle_message(%Command{args: [input]}=req, state) when not(is_binary(input)),
     do: {:error, req.reply_to, "Argument must be a string", state}
   def handle_message(%Command{args: [input]}=req, state) do
+    input = String.replace(input, ~r/\\\"/, "\"")
     case Poison.decode(input) do
       {:ok, value} when is_map(value) ->
         {:reply, req.reply_to, value, state}
@@ -41,7 +42,8 @@ defmodule Cog.Command.Seed do
         end
       {:ok, _} ->
         {:error, req.reply_to, "JSON must be a map or a list of maps", state}
-      {:error, _} ->
+      {:error, reason} ->
+        Logger.error("#{inspect reason}")
         {:error, req.reply_to, "Bad input! Please supply valid JSON", state}
     end
   end

--- a/test/integration/command_test.exs
+++ b/test/integration/command_test.exs
@@ -193,4 +193,10 @@ defmodule Integration.CommandTest do
 
     assert response.body == ["do-something-dangerous --option= bar"]
   end
+
+  test "seed handles escaped double quotes", %{user: user} do
+    response = send_message(user, "@bot: seed \"[{\\\"key\\\": \\\"foo\\\"}, {\\\"foo\\\": 123}]\"")
+    assert response == [%{key: "foo"}, %{foo: 123}]
+  end
+
 end


### PR DESCRIPTION
Fixes `Cog.Command.Seed` crash triggered when given a string containing escaped double quotes.

Fixes #1323