### PR TITLE
Disable dependent cogctl build

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -86,36 +86,3 @@ cat <<EOF
     label: ":docker: Build Real Image"
 
 EOF
-
-########################################################################
-# Triggered Builds
-
-# We'd like to ensure that cogctl can still work with cog, so we'll
-# trigger a build using the cog image we just built.
-#
-# However, we won't do this if it's a scheduled nightly build. cogctl
-# has its own nightly build, and there's no reason to build it twice.
-if [ "${BUILDKITE_SOURCE}" != "schedule" ]
-then
-    # If there's a branch in cogctl with the same name as the branch we're
-    # building here in Cog, use that branch. Otherwise, build on master.
-    if git ls-remote --exit-code --heads https://github.com/operable/cogctl refs/heads/${BUILDKITE_BRANCH} > /dev/null 2>&1
-    then
-        TRIGGER_BRANCH=${BUILDKITE_BRANCH}
-    else
-        TRIGGER_BRANCH='master'
-    fi
-
-    cat <<EOF
-  - wait
-
-  - trigger: "cogctl"
-    label: ":cogops: Triggered cogctl build"
-    async: true
-    build:
-      branch: "${TRIGGER_BRANCH}"
-      commit: "HEAD"
-      env:
-        COG_IMAGE: ${COG_IMAGE}
-EOF
-fi


### PR DESCRIPTION
Until we level-up the new Python-based cogctl tests to hit a live Cog
server, dependent builds aren't going to do anything for us but eat up
build agents.