### PR TITLE
Refactor the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY . /home/operable/cog/
 RUN chown -R operable /home/operable
 
 RUN apk update -U && \
-    apk add expat-dev gcc g++ libstdc++ make && \
+    apk add expat-dev gcc g++ libstdc++ && \
     mix clean && mix deps.get && mix compile && \
     apk del gcc g++ && \
     rm -f /var/cache/apk/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,8 @@ FROM operable/elixir:1.3.4-r0
 
 ENV MIX_ENV prod
 
-# Setup Operable user. UID/GID default to 60000 but can be overriden.
-ARG OPERABLE_UID
-ENV OPERABLE_UID ${OPERABLE_UID:-60000}
-
-ARG OPERABLE_GID
-ENV OPERABLE_GID ${OPERABLE_UID:-60000}
-
-RUN addgroup -g $OPERABLE_GID operable && \
-    adduser -h /home/operable -D -u $OPERABLE_UID -G operable -s /bin/ash operable
+RUN addgroup -g 60000 operable && \
+    adduser -h /home/operable -D -u 60000 -G operable -s /bin/ash operable
 
 # Create directories and upload cog source
 WORKDIR /home/operable/cog

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,9 @@ WORKDIR /home/operable/cog
 COPY . /home/operable/cog/
 RUN chown -R operable /home/operable
 
-RUN apk update -U && \
-    apk add expat-dev gcc g++ libstdc++ && \
-    mix clean && mix deps.get && mix compile && \
-    apk del gcc g++ && \
-    rm -f /var/cache/apk/*
+RUN apk --no-cache add expat-dev gcc g++ libstdc++ && \
+    mix deps.get && mix compile && \
+    apk del gcc g++
 
 # This should be in place in the build environment already
 COPY cogctl-for-docker-build /usr/local/bin/cogctl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM operable/elixir:1.3.4-r0
 
-# Select mix environment to use. We declare the MIX_ENV at build time
-ARG MIX_ENV
-ENV MIX_ENV ${MIX_ENV:-dev}
+ENV MIX_ENV prod
 
 # Setup Operable user. UID/GID default to 60000 but can be overriden.
 ARG OPERABLE_UID

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,11 @@ RUN addgroup -g 60000 operable && \
 
 # Create directories and upload cog source
 WORKDIR /home/operable/cog
+# Really, we only need the cog directory to be owned by operable,
+# because (by default) that's where we write log files. None of the
+# actual scripts or library files need to be owned by operable.
+RUN chown -R operable /home/operable/cog
 COPY . /home/operable/cog/
-RUN chown -R operable /home/operable
 
 RUN apk --no-cache add expat-dev gcc g++ libstdc++ && \
     mix deps.get && mix compile && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,6 @@ FROM operable/elixir:1.3.4-r0
 ARG MIX_ENV
 ENV MIX_ENV ${MIX_ENV:-dev}
 
-# Install runtime dependencies & nice-to-have packages
-RUN apk update -U && apk add curl postgresql-client
-
 # Setup Operable user. UID/GID default to 60000 but can be overriden.
 ARG OPERABLE_UID
 ENV OPERABLE_UID ${OPERABLE_UID:-60000}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN chown -R operable /home/operable/cog
 
 COPY mix.exs mix.lock /home/operable/cog/
 COPY config/ /home/operable/cog/config/
-RUN mix deps.get
+RUN mix deps.get --only=prod --no-archives-check
 
 # Compile all the dependencies. The additional packages installed here
 # are for Greenbar to build and run.
@@ -33,7 +33,7 @@ COPY priv/ /home/operable/cog/priv/
 COPY web/ /home/operable/cog/web/
 COPY lib/ /home/operable/cog/lib/
 
-RUN mix compile
+RUN mix compile --no-deps-check --no-archives-check
 
 COPY scripts/ /home/operable/cog/scripts/
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ reset-db:
 docker:
 	scripts/get_cogctl.sh
 	docker build \
-		   --build-arg MIX_ENV=prod \
 		   -t $(DOCKER_IMAGE) .
 
 .PHONY: docker

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,7 @@ reset-db:
 
 docker:
 	scripts/get_cogctl.sh
-	docker build \
-		   -t $(DOCKER_IMAGE) .
+	docker build  -t $(DOCKER_IMAGE) .
 
 .PHONY: docker
 


### PR DESCRIPTION
Streamline the Dockerfile, getting rid of things we never used, removing some unnecessary and costly operations, and leverage the Docker cache for quicker builds.

It's also smaller!