### PR TITLE
Check assigning a chat handle to more than one user

### DIFF
--- a/lib/cog/models/chat_handle.ex
+++ b/lib/cog/models/chat_handle.ex
@@ -25,6 +25,9 @@ defmodule Cog.Models.ChatHandle do
 
     model
     |> cast(params, @required_fields, @optional_fields)
+    |> unique_constraint(:handle,
+                         name: :chat_handles_provider_id_handle_index,
+                         message: "Another user has claimed this chat handle")
   end
 
   # Normally we would use an `update_change` call for something like this. But,

--- a/test/cog/models/chat_handle_repo_test.exs
+++ b/test/cog/models/chat_handle_repo_test.exs
@@ -1,0 +1,29 @@
+defmodule Cog.Models.ChatHandleRepoTest do
+  @moduledoc """
+  Test side-effecting ChatHandle model code
+  """
+  use Cog.ModelCase, async: false
+  alias Cog.Models.ChatHandle
+
+  test "chat handles are unique for a provider" do
+    first = user("first_user")
+    second = user("second_user")
+
+
+    attrs = %{"handle" => "test_handle",
+              "provider_id" => 1,
+              "chat_provider_user_id" => "my_slack_id"}
+
+
+    assert %ChatHandle{} = %ChatHandle{}
+    |> ChatHandle.changeset(Map.merge(attrs, %{"user_id" => first.id}))
+    |> Repo.insert!
+
+    {:error, changeset} = %ChatHandle{}
+    |> ChatHandle.changeset(Map.merge(attrs, %{"user_id" => second.id}))
+    |> Repo.insert
+
+    assert {:handle, {"Another user has claimed this chat handle", []}} in changeset.errors
+  end
+
+end


### PR DESCRIPTION
If another user has already claimed a given chat handle, deal with the
error gracefully, instead of crashing the web controller.