### PR TITLE
Change Cog-Book URLs in README to unsecure

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Cog brings the power of the command line to the place you collaborate with your 
 
 Powerful access control means you can collaborate around even the most sensitive tasks with confidence. A focus on extensibility and adaptability means that you can respond quickly to the unexpected, without your team losing visibility.
 
-* [Installation Guide](https://cog-book.operable.io/#_installation_guide) - You want Cog, now go here to start installing it.
+* [Installation Guide](http://cog-book.operable.io/#_installation_guide) - You want Cog, now go here to start installing it.
 * [Development Guide](https://github.com/operable/cog/blob/master/DEVELOP.md)
-* [Cog Book](https://cog-book.operable.io) - This is Cog's Documentation! Our new book that includes the above mentioned Installation Guide and a chapter on Command Bundle Writing.
+* [Cog Book](http://cog-book.operable.io) - This is Cog's Documentation! Our new book that includes the above mentioned Installation Guide and a chapter on Command Bundle Writing.
 * [Bundle Warehouse](https://bundles.operable.io/) - Install one of these bundles on Cog and/or create your own command bundle and upload it here.
 
 ## Status


### PR DESCRIPTION
This prevents the security warning, and fixes #1386 until a certificate solution is implemented.