### PR TITLE
Rpi dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,4 +58,8 @@ COPY scripts/ /home/operable/cog/scripts/
 COPY cogctl-for-docker-build /usr/local/bin/cogctl
 
 USER operable
+# TODO: For some reason, Hex needs to be present in the operable
+# user's home directory for Cog to run (specifically, for it to apply
+# the database migrations at startup). It complains of not being able
+# to build gen_stage, *even though it's already been built!*
 RUN mix local.hex --force

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,9 @@
 FROM armhf/alpine
 MAINTAINER Pablo Carranza <pcarranza@gmail.com>
 
-RUN apk --no-cache add \
-	erlang \
-        erlang-ssl \
-	erlang-crypto \
-	erlang-syntax-tools \
-	git \
-        elixir
-
 ENV MIX_ENV prod
 
-# RUN groupadd --gid 60000 operable
-# RUN useradd -d /home/operable -u 60000 -g operable -s /bin/ash operable
-
+# Add operable user and group
 RUN addgroup -g 60000 operable && \
     adduser -h /home/operable -D -u 60000 -G operable -s /bin/ash operable
 
@@ -28,8 +18,6 @@ RUN chown -R operable /home/operable/cog
 COPY mix.exs mix.lock /home/operable/cog/
 COPY config/ /home/operable/cog/config/
 
-RUN mix local.hex --force && mix local.rebar --force && mix deps.get --only=prod --no-archives-check
-
 # Compile all the dependencies. The additional packages installed here
 # are for Greenbar to build and run.
 RUN apk --no-cache add \
@@ -39,14 +27,20 @@ RUN apk --no-cache add \
     apk --no-cache add \
         expat-dev \
         libstdc++ \
-	openssl-dev
+        openssl-dev \
+        erlang \
+        erlang-dev \
+        erlang-ssl \
+        erlang-crypto \
+        erlang-syntax-tools \
+        erlang-parsetools \
+        make \
+        git \
+        elixir
 
-RUN apk --no-cache add \
-	make \
-	erlang-dev \
-	erlang-parsetools
-
-ENV DEBUG 1
+RUN mix local.hex --force && \
+        mix local.rebar --force && \
+        mix deps.get --only=prod --no-archives-check
 
 RUN mix deps.compile && \
     apk del .build_deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN mix compile --no-deps-check --no-archives-check
 COPY scripts/ /home/operable/cog/scripts/
 
 # This should be in place in the build environment already
-# COPY cogctl-for-docker-build /usr/local/bin/cogctl
+COPY cogctl-for-docker-build /usr/local/bin/cogctl
 
 USER operable
 RUN mix local.hex --force


### PR DESCRIPTION
This has been quite a trip but I finally got it to build.

This is being sent as a RFC to discuss how to add this dockerfile because I don't think we want to replace the base one with this, but this simplifies comparing both files.

## Preparation

To build cogctl binary I had to patch [PyInstaller](https://github.com/pyinstaller/pyinstaller) on tag v3.2.1 with:

```sh
$ git diff
diff --git a/bootloader/wscript b/bootloader/wscript
index 3c24644..598c732 100644
--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -287,8 +287,8 @@ def set_arch_flags(ctx):
         if ctx.env.CC_NAME == 'gcc':
             if ctx.env.PYI_ARCH == '32bit':
                 ctx.check_cc(ccflags='-milp32', msg='Checking for flags -milp32')
-                ctx.env.append_value('CFLAGS', '-milp32')
-                ctx.env.append_value('LINKFLAGS', '-milp32')
+                # ctx.env.append_value('CFLAGS', '-milp32')
+                # ctx.env.append_value('LINKFLAGS', '-milp32')
             else:
                 ctx.check_cc(ccflags='-mlp64', msg='Checking for flags -mlp64')
                 ctx.env.append_value('CFLAGS', '-mlp64')
```

otherwise compilation fails because of the wrong arguments used for compilation. Additionally I needed to install `zlib1g-dev` for compilation to succeed (installation into the environment was done with `sudo /home/USER/.virtualenvs/cogctl/bin/python3 setup.py install`. 

Refer to https://github.com/pyinstaller/pyinstaller/issues/1619 for more details.

Once this requirement was installed I managed to build the `cogctl` binary for arm architecture and copy it over renaming it with `mv ../../cogctl cogctl-for-docker-build` and was ready to build.

## Building

Just ran `docker build -t pcarranza/cog:latest-arm .` and I'm pushing the image right now.

## Caveat

I haven't tested the image yet, I just managed to build it.