### PR TITLE
Disable HipChat integration tests for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ services:
 env:
   - TEST=unit
   - TEST=slack
-  - TEST=hipchat
+  # Temporarily disabling HipChat integration tests while we track
+  # down some connection issues.
+  # - TEST=hipchat
 
 script:
   - docker-compose -f docker-compose.ci.yml run test ./scripts/wait-for-it.sh postgres:5432 -s -t 30 -- make test-$TEST


### PR DESCRIPTION
Unit and Slack integration tests work, but some timeout issues need to
be tracked down on the HipChat side of things. See #1395 for more.

We can disable the HipChat tests for now, so we can benefit from Travis
CI builds on other PRs.
