### PR TITLE
Add operable:count command

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -30,7 +30,7 @@ end
 # NOTE: Do not change this value unless you know what you're doing.
 # ========================================================================
 
-config :cog, :embedded_bundle_version, "0.18.1"
+config :cog, :embedded_bundle_version, "0.18.2"
 
 # ========================================================================
 # Chat Adapters

--- a/lib/cog/commands/count.ex
+++ b/lib/cog/commands/count.ex
@@ -1,0 +1,72 @@
+defmodule Cog.Commands.Count do
+  use Cog.Command.GenCommand.Base,
+    bundle: Cog.Util.Misc.embedded_bundle
+
+  alias Cog.Command.Service.MemoryClient
+
+  @description "Return the count of the values in the input list"
+
+  @arguments "[path]"
+
+  @examples """
+  seed '[{"a": 2}, {"a": -1}, {"b": 3}]' | count
+  > 3
+
+  seed '[{"a": 2}, {"a": -1}, {"b": 3}]' | count a
+  > 2
+
+  seed '[{"a": {"b": 2}}, {"b": {"b": -1}}, {"a": {"c": 3}}]' | count a.b
+  > 1
+  """
+
+  rule "when command is #{Cog.Util.Misc.embedded_bundle}:count allow"
+
+  def handle_message(req, state) do
+    root  = req.services_root
+    token = req.service_token
+    key   = req.invocation_id
+    step  = req.invocation_step
+    value = req.cog_env
+    args  = req.args
+
+    MemoryClient.accum(root, token, key, value)
+
+    case step do
+      step when step in ["first", "", nil] ->
+        {:reply, req.reply_to, nil, state}
+      "last" ->
+        accumulated_value = MemoryClient.fetch(root, token, key)
+        {:ok, value} = count_by(accumulated_value, args)
+        MemoryClient.delete(root, token, key)
+        {:reply, req.reply_to, value, state}
+    end
+  end
+
+  defp count_by([%{}], []),
+    do: {:ok, 0}
+  defp count_by(items, []),
+    do: {:ok, Enum.count(items)}
+  defp count_by(items, [path]) do
+    path_list = path_to_list(path)
+
+    case bad_path(items, path_list) do
+      true ->
+        {:ok, 0}
+      false ->
+        count = Enum.count(items, &get_in(&1, path_list))
+        {:ok, count}
+    end
+  end
+
+  defp bad_path(items, path_list) do
+    Enum.all?(items, fn item ->
+      item
+      |> get_in(path_list)
+      |> is_nil
+    end)
+  end
+
+  defp path_to_list(path) do
+    String.split(path, ".")
+  end
+end

--- a/test/commands/count_test.exs
+++ b/test/commands/count_test.exs
@@ -1,0 +1,61 @@
+defmodule Cog.Test.Commands.CountTest do
+  use Cog.CommandCase, command_module: Cog.Commands.Count
+
+  test "basic count" do
+    inv_id = "basic_count"
+    memory_accum(inv_id, %{"a" => 1})
+    memory_accum(inv_id, %{"b" => 3})
+
+    response = new_req(invocation_id: inv_id, cog_env: %{"a" => 2})
+               |> send_req()
+               |> unwrap()
+
+    assert(response == 3)
+  end
+
+  test "count by simple key" do
+    inv_id = "simple_key_count"
+    memory_accum(inv_id, %{"a" => 1})
+    memory_accum(inv_id, %{"b" => 3})
+
+    response = new_req(invocation_id: inv_id, cog_env: %{"a" => 2}, args: ["a"])
+               |> send_req()
+               |> unwrap()
+
+    assert(response == 2)
+  end
+
+  test "count by complex key" do
+    inv_id = "complex_key_count"
+    memory_accum(inv_id, %{"a" => %{"b" => 1}})
+    memory_accum(inv_id, %{"a" => %{"b" => 3}})
+
+    response = new_req(invocation_id: inv_id, cog_env: %{"a" => %{"c" => 2}}, args: ["a.b"])
+               |> send_req()
+               |> unwrap()
+
+    assert(response == 2)
+  end
+
+  test "count by incorrect key" do
+    inv_id = "complex_incorrect"
+    memory_accum(inv_id, %{"a" => %{"b" => 1}})
+    memory_accum(inv_id, %{"a" => %{"b" => 3}})
+
+    response = new_req(invocation_id: inv_id, cog_env: %{"a" => %{"c" => 2}}, args: ["c.d"])
+               |> send_req()
+               |> unwrap()
+
+    assert(response == 0)
+  end
+
+  test "count of nothing" do
+    inv_id = "complex_nothing"
+
+    response = new_req(invocation_id: inv_id, cog_env: %{}, args: [])
+               |> send_req()
+               |> unwrap()
+
+    assert(response == 0)
+  end
+end


### PR DESCRIPTION
First attempt at a count command.
Mostly just took what was already in mix/max and changed it slightly.

Not sure if I'm totally on board with the current state.
If you pass in something like:
```seed '[{}]' | count```
It will return 0, due to how Cog passes in the `cog_env` param (otherwise, just running `count` would result in a 1).

At the moment there are no error cases.

Thoughts/suggestions appreciated.

This would potentially handle https://github.com/operable/cog/issues/772