### PR TITLE
Allow COG_PIPELINE_TIMEOUT to set the timeout at runtime

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -68,7 +68,7 @@ config :cog, Cog.Bundle.BundleSup,
   bundle_root: Path.join([File.cwd!, "bundles"])
 
 config :cog, Cog.Command.Pipeline,
-  interactive_timeout: {60, :sec},
+  interactive_timeout: {String.to_integer(System.get_env("COG_PIPELINE_TIMEOUT") || "60"), :sec},
   trigger_timeout: {300, :sec}
 
 config :cog, Cog.Command.Service,


### PR DESCRIPTION
Simple change to at least allow a flexible global pipeline command timeout at runtime.

This is a minor part of https://github.com/operable/cog/issues/1283 but that ticket will need to be revisited with a full planning of how to implement the real feature.