### PR TITLE
Temporarily point warehouse to static site

### DIFF
--- a/lib/cog/bundle/warehouse.ex
+++ b/lib/cog/bundle/warehouse.ex
@@ -1,9 +1,9 @@
 defmodule Cog.Bundle.Warehouse do
-  @registry_url "https://warehouse.operable.io"
+  @registry_url "https://warehouse.cog.bot"
 
   def get_config(bundle, version) do
     headers = ["Accepts": "application/json"]
-    response = HTTPotion.get(@registry_url <> "/api/bundles/#{bundle}/#{version}", headers: headers)
+    response = HTTPotion.get(@registry_url <> "/api/bundles/#{bundle}/#{version}.json", headers: headers)
 
     case response do
       %HTTPotion.Response{status_code: 200, body: body} ->


### PR DESCRIPTION
This will allow us to temporarily point the warehouse at this gh-pages static site until we can figure out what to do with the warehouse.