### PR TITLE
Allow overriding the reply_broadcast value when using threading in slack

### DIFF
--- a/config/slack.exs
+++ b/config/slack.exs
@@ -3,4 +3,5 @@ import Cog.Config.Helpers
 
 config :cog, Cog.Chat.Slack.Provider,
   api_token: System.get_env("SLACK_API_TOKEN"),
-  enable_threaded_response: ensure_boolean(System.get_env("SLACK_ENABLE_THREADED_RESPONSES"))
+  enable_threaded_response: ensure_boolean(System.get_env("SLACK_ENABLE_THREADED_RESPONSES")),
+  enable_thread_broadcast: ensure_boolean(System.get_env("SLACK_ENABLE_THREAD_BROADCAST"))

--- a/lib/cog/chat/message_metadata.ex
+++ b/lib/cog/chat/message_metadata.ex
@@ -6,4 +6,5 @@ defmodule Cog.Chat.MessageMetadata do
 
   field :thread_id, :string, required: false
   field :originating_room_id, :string, required: false
+  field :reply_broadcast, :bool, required: false
 end

--- a/lib/cog/chat/slack/connector.ex
+++ b/lib/cog/chat/slack/connector.ex
@@ -301,7 +301,7 @@ defmodule Cog.Chat.Slack.Connector do
         else
           {:chat_message, %Message{id: Cog.Events.Util.unique_id, room: room,
               user: user, text: text, provider: @provider_name,
-              metadata: %MessageMetadata{thread_id: ts, originating_room_id: room.id},
+              metadata: %MessageMetadata{thread_id: ts, originating_room_id: room.id, reply_broadcast: true},
               bot_name: "@#{state.me.name}", edited: false}}
         end
     end
@@ -363,9 +363,9 @@ defmodule Cog.Chat.Slack.Connector do
     end
   end
 
-  def maybe_include_thread_attributes(message, %MessageMetadata{thread_id: thread_id})
+  def maybe_include_thread_attributes(message, %MessageMetadata{thread_id: thread_id, reply_broadcast: broadcast})
       when is_binary(thread_id),
-    do: Map.merge(message, %{thread_ts: thread_id, reply_broadcast: true})
+    do: Map.merge(message, %{thread_ts: thread_id, reply_broadcast: broadcast})
   def maybe_include_thread_attributes(message, _metadata),
     do: message
 end

--- a/lib/cog/chat/slack/provider.ex
+++ b/lib/cog/chat/slack/provider.ex
@@ -10,7 +10,7 @@ defmodule Cog.Chat.Slack.Provider do
   alias Cog.Chat.Slack.Connector
   alias Greenbar.Renderers.SlackRenderer
 
-  defstruct [:token, :incoming, :connector, :mbus, :enable_threaded_response]
+  defstruct [:token, :incoming, :connector, :mbus, :enable_threaded_response, :enable_thread_broadcast]
 
   def display_name, do: "Slack"
 
@@ -71,9 +71,15 @@ defmodule Cog.Chat.Slack.Provider do
     else
       incoming = Keyword.fetch!(config, :incoming_topic)
       enable_threaded_response = Keyword.get(config, :enable_threaded_response)
+      enable_thread_broadcast = Keyword.get(config, :enable_thread_broadcast, false)
       with {:ok, mbus} <- ConnectionSup.connect(),
            {:ok, pid} <- Connector.start_link(token) do
-        {:ok, %__MODULE__{token: token, incoming: incoming, connector: pid, mbus: mbus, enable_threaded_response: enable_threaded_response}}
+        {:ok, %__MODULE__{token: token,
+                          incoming: incoming,
+                          connector: pid,
+                          mbus: mbus,
+                          enable_threaded_response: enable_threaded_response,
+                          enable_thread_broadcast: enable_thread_broadcast}}
       else
         {:error, reason}=error when is_binary(reason) ->
           Logger.error("Slack connection initialization failed: #{reason}")
@@ -116,7 +122,7 @@ defmodule Cog.Chat.Slack.Provider do
   end
   # Old template processing
   def handle_call({:send_message, target, message, metadata}, _from, %__MODULE__{connector: connector, token: token}=state) when is_binary(message) do
-    metadata = maybe_remove_thread_id(metadata, state.enable_threaded_response, target)
+    metadata = maybe_remove_thread_id(metadata, state.enable_threaded_response, state.enable_thread_broadcast, target)
     result = Connector.call(connector, token, :send_message, %{target: target, message: message, metadata: metadata})
     case result["ok"] do
       true ->
@@ -128,7 +134,7 @@ defmodule Cog.Chat.Slack.Provider do
   # New template processing
   def handle_call({:send_message, target, message, metadata}, _from, %__MODULE__{connector: connector, token: token}=state) do
     {text, attachments} = SlackRenderer.render(message)
-    metadata = maybe_remove_thread_id(metadata, state.enable_threaded_response, target)
+    metadata = maybe_remove_thread_id(metadata, state.enable_threaded_response, state.enable_thread_broadcast, target)
     result = Connector.call(connector, token, :send_message, %{target: target, message: text, metadata: metadata, attachments: attachments})
     case result["ok"] do
       true ->
@@ -147,8 +153,8 @@ defmodule Cog.Chat.Slack.Provider do
     {:noreply, state}
   end
 
-  defp maybe_remove_thread_id(%Cog.Chat.MessageMetadata{originating_room_id: target_room_id} = metadata, true, target_room_id),
-    do: metadata
-  defp maybe_remove_thread_id(metadata, _disabled, _taget_room_id),
+  defp maybe_remove_thread_id(%Cog.Chat.MessageMetadata{originating_room_id: target_room_id} = metadata, true, broadcast, target_room_id),
+    do: %{metadata | reply_broadcast: broadcast}
+  defp maybe_remove_thread_id(metadata, _disabled, _broadcast, _target_room_id),
     do: %{metadata | thread_id: nil}
 end


### PR DESCRIPTION
This allows you to turn reply broadcasting off if you'd prefer when using threading.
This means that messages will only go to the thread and not also to the channel.

It defaults to broadcasting ON, since that's what it was previously doing.