### PR TITLE
Chat service POC

### DIFF
--- a/lib/cog/command/service/chat.ex
+++ b/lib/cog/command/service/chat.ex
@@ -15,7 +15,7 @@ defmodule Cog.Command.Service.Chat do
     end
   end
 
-  defp build_target(provider, "chat://@" <> handle) do
+  defp build_target(provider, "@" <> handle) do
     case Adapter.lookup_user(provider, handle) do
       {:ok, %{id: user_id}} -> 
         {:ok, %{provider: provider, id: user_id, name: handle, is_dm: true}}
@@ -23,7 +23,7 @@ defmodule Cog.Command.Service.Chat do
         {:error, :unknown_handle}
     end
   end
-  defp build_target(provider, "chat://#" <> room) do
+  defp build_target(provider, "#" <> room) do
     case Adapter.lookup_room(provider, name: "##{room}") do
       {:ok, %{id: room_id}} -> 
         {:ok, %{provider: provider, id: room_id, name: room, is_dm: false}}

--- a/lib/cog/command/service/chat.ex
+++ b/lib/cog/command/service/chat.ex
@@ -1,6 +1,6 @@
 defmodule Cog.Command.Service.Chat do
   require Logger
-  
+
   alias Cog.Chat.Adapter
 
   def send_message(destination, message) do
@@ -8,7 +8,7 @@ defmodule Cog.Command.Service.Chat do
 
     case build_target(provider, destination) do
       {:ok, target} ->
-        Cog.Chat.Adapter.send("slack", target, message, %{originating_room_id: target.id})
+        Cog.Chat.Adapter.send(provider, target, message, %{originating_room_id: target.id})
       {:error, reason} ->
         Logger.debug("Invalid message destination: #{inspect destination}")
         {:error, reason}
@@ -17,7 +17,7 @@ defmodule Cog.Command.Service.Chat do
 
   defp build_target(provider, "@" <> handle) do
     case Adapter.lookup_user(provider, handle) do
-      {:ok, %{id: user_id}} -> 
+      {:ok, %{id: user_id}} ->
         {:ok, %{provider: provider, id: user_id, name: handle, is_dm: true}}
       _ ->
         {:error, :unknown_handle}
@@ -25,11 +25,11 @@ defmodule Cog.Command.Service.Chat do
   end
   defp build_target(provider, "#" <> room) do
     case Adapter.lookup_room(provider, name: "##{room}") do
-      {:ok, %{id: room_id}} -> 
+      {:ok, %{id: room_id}} ->
         {:ok, %{provider: provider, id: room_id, name: room, is_dm: false}}
       _ ->
         {:error, :unknown_room}
-    end    
+    end
   end
   defp build_target(_provider, _destination) do
     {:error, :invalid_destination}

--- a/lib/cog/command/service/chat.ex
+++ b/lib/cog/command/service/chat.ex
@@ -1,0 +1,38 @@
+defmodule Cog.Command.Service.Chat do
+  require Logger
+  
+  alias Cog.Chat.Adapter
+
+  def send_message(destination, message) do
+    {:ok, provider} = Cog.Util.Misc.chat_provider_module
+
+    case build_target(provider, destination) do
+      {:ok, target} ->
+        Cog.Chat.Adapter.send("slack", target, message, %{originating_room_id: target.id})
+      {:error, reason} ->
+        Logger.debug("Invalid message destination: #{inspect destination}")
+        {:error, reason}
+    end
+  end
+
+  defp build_target(provider, "chat://@" <> handle) do
+    case Adapter.lookup_user(provider, handle) do
+      {:ok, %{id: user_id}} -> 
+        {:ok, %{provider: provider, id: user_id, name: handle, is_dm: true}}
+      _ ->
+        {:error, :unknown_handle}
+    end
+  end
+  defp build_target(provider, "chat://#" <> room) do
+    case Adapter.lookup_room(provider, name: "##{room}") do
+      {:ok, %{id: room_id}} -> 
+        {:ok, %{provider: provider, id: room_id, name: room, is_dm: false}}
+      _ ->
+        {:error, :unknown_room}
+    end    
+  end
+  defp build_target(_provider, _destination) do
+    {:error, :invalid_destination}
+  end
+
+end

--- a/lib/cog/repository/services.ex
+++ b/lib/cog/repository/services.ex
@@ -12,8 +12,10 @@ defmodule Cog.Repository.Services do
     # TODO: Eventually, we'll want to introspect the system for this
     # information. For now, though, this will be effectively duplicating
     # information contained in the service router.
-    [%{name: "memory",
-       version: "1.0.0"}]
+    [
+      %{name: "memory", version: "1.0.0"},
+      %{name: "chat", version: "1.0.0"}
+    ]
   end
 
   def deployed(name),

--- a/test/controllers/v1/chat_service_controller_test.exs
+++ b/test/controllers/v1/chat_service_controller_test.exs
@@ -1,0 +1,50 @@
+defmodule Cog.V1.ChatServiceControllerTest do
+  use Cog.ConnCase
+
+  @moduletag :services
+  @endpoint Cog.ServiceEndpoint
+
+  @path "/v1/services/chat/1.0.0"
+
+  alias Cog.Command.Service.Tokens
+
+  setup do
+    # This makes the test process look like a pipeline executor,
+    # because the token will be registered to it.
+    token = Tokens.new
+    conn = tokened_connection(token)
+    {:ok, [conn: conn]}
+  end
+
+  defp tokened_connection(token) do
+    build_conn()
+    |> Plug.Conn.put_req_header("content-type", "application/json")
+    |> Plug.Conn.put_req_header("authorization", "pipeline #{token}")
+  end
+
+  test "requests without a token are denied" do
+    conn = post(build_conn(), @path <> "/send_message")
+    assert response(conn, 401)
+  end
+
+  test "sending message to an unknown user is an error", %{conn: conn} do
+    conn = post(conn, @path <> "/send_message", Poison.encode!(%{destination: "@fake_user", message: "taco"}))
+    assert %{"error" => "Unable to find chat user for @fake_user"} == json_response(conn, 404)
+  end
+
+  test "sending message to an unknown room is an error", %{conn: conn} do
+    conn = post(conn, @path <> "/send_message", Poison.encode!(%{destination: "#fake_room", message: "taco"}))
+    assert %{"error" => "Unable to find chat room for #fake_room"} == json_response(conn, 404)
+  end
+
+  test "sending message to an invalid destination is an error", %{conn: conn} do
+    conn = post(conn, @path <> "/send_message", Poison.encode!(%{destination: "definitely_fake", message: "taco"}))
+    assert %{"error" => "Invalid chat destination URI definitely_fake"} == json_response(conn, 404)
+  end
+
+  test "sending message to a good message results in a success", %{conn: conn} do
+    conn = post(conn, @path <> "/send_message", Poison.encode!(%{destination: "#ci_bot_testing", message: "taco"}))
+    assert %{"status" => "sent"} == json_response(conn, 200)
+  end
+
+end

--- a/test/support/test_provider.ex
+++ b/test/support/test_provider.ex
@@ -28,6 +28,7 @@ defmodule Cog.Chat.Test.Provider do
                    provider: @provider_name,
                    email: handle}
   end
+  def lookup_user("fake_user"), do: {:error, :unknown_user}
   def lookup_user(handle) do
     %Cog.Chat.User{id: handle,
                    first_name: handle,
@@ -49,6 +50,7 @@ defmodule Cog.Chat.Test.Provider do
                    provider: @provider_name,
                    is_dm: false}
   end
+  def lookup_room({:name, "#fake_room"}), do: {:error, :unknown_room}
   def lookup_room({:name, name}) do
     %Cog.Chat.Room{id: name,
                    name: name,

--- a/web/controllers/v1/chat_service_controller.ex
+++ b/web/controllers/v1/chat_service_controller.ex
@@ -1,0 +1,32 @@
+defmodule Cog.V1.ChatServiceController do
+  use Cog.Web, :controller
+  require Logger
+
+  plug Cog.Plug.ServiceAuthentication
+
+  alias Cog.Command.Service.Chat
+
+  def send_message(conn, %{"destination" => destination, "message" => message}) do
+    case Chat.send_message(destination, message) do
+      {:error, reason} when reason == :unknown_handle or reason == :unknown_room or reason == :invalid_destination ->
+        conn
+        |> put_status(:not_found)
+        |> json(%{"error" => destination_error(destination, reason)})
+      _ ->
+        conn
+        |> put_status(:ok)
+        |> json(%{"status": "sent"})
+    end
+  end
+
+  defp destination_error(destination, :unknown_handle) do
+    "Unable to find chat user for #{destination}"
+  end
+  defp destination_error(destination, :unknown_room) do
+    "Unable to find chat room for #{destination}"
+  end
+  defp destination_error(destination, _reason) do
+    "Invalid chat destination URI #{destination}"
+  end
+
+end

--- a/web/service_router.ex
+++ b/web/service_router.ex
@@ -17,5 +17,6 @@ defmodule Cog.ServiceRouter do
     put "/memory/1.0.0/:key", V1.MemoryServiceController, :update
     post "/memory/1.0.0/:key", V1.MemoryServiceController, :change
 
+    post "/chat/1.0.0/send_message", V1.ChatServiceController, :send_message
   end
 end


### PR DESCRIPTION
I've taken what Mark started and just added some tests for it.
This adds a chat service endpoint so you can post message back to the user/channel (or a specific user/channel if desired).

Will add docs on its usage, but it's just a POST to /v1/services/chat/1.0.0/send_message  with a destination channel/user and a message. 

Right now if the user wants to respond back directly they'd need to find out if the COG_ROOM was "direct", if so set the destination as @${COG_CHAT_HANDLE}, otherwise use #${COG_ROOM}. In the future i'd like to update the relay to set a COG_INITIATOR or something which decides this for you.