### PR TITLE
Allow redirection to private groups again

### DIFF
--- a/lib/cog/chat/slack/formatter.ex
+++ b/lib/cog/chat/slack/formatter.ex
@@ -1,5 +1,5 @@
 defmodule Cog.Chat.Slack.Formatter do
-  @channel ~r/<\#(C.*)(\|(.*))?>/U
+  @channel ~r/<\#([CG].*)(\|(.*))?>/U
   @user    ~r/<\@(U.*)(\|(.*))?>/U
   @command ~r/<\!(.*)(\|(.*))?>/U
   @link    ~r/<(.*)(\|(.*))?>/U


### PR DESCRIPTION
Slack is now using the group id rather than the channel id when passing the name in a chat message (ie, `!echo "test" > #private_room`) results in G12345 instead of C12345. This allows us to catch this case and pass it through.