### PR TITLE
Fix broken links to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Cog brings the power of the command line to the place you collaborate with your 
 
 Powerful access control means you can collaborate around even the most sensitive tasks with confidence. A focus on extensibility and adaptability means that you can respond quickly to the unexpected, without your team losing visibility.
 
-* [Installation Guide](http://book.cog.bot/sections/installation_guide.html) - You want Cog, now go here to start installing it.
+* [Installation Guide](https://operable.github.io/cog-book/sections/installation_guide.html) - You want Cog, now go here to start installing it.
 * [Development Guide](https://github.com/operable/cog/blob/master/DEVELOP.md)
-* [Cog Book](http://book.cog.bot) - This is Cog's Documentation! Our new book that includes the above mentioned Installation Guide and a chapter on Command Bundle Writing.
+* [Cog Book](https://operable.github.io/cog-book/) - This is Cog's Documentation! Our new book that includes the above mentioned Installation Guide and a chapter on Command Bundle Writing.
 * [Bundle Warehouse](https://bundles.operable.io/) - Install one of these bundles on Cog and/or create your own command bundle and upload it here.
 
 ## Status


### PR DESCRIPTION
The `book.cog.bot` domain is no longer working and the book is now hosted on github pages. This PR changes links to the docs to github pages.